### PR TITLE
fix: restore frontend dev runtime and favicon

### DIFF
--- a/docs/dev-logs/2026-04-09-frontend-dev-runtime-favicon.md
+++ b/docs/dev-logs/2026-04-09-frontend-dev-runtime-favicon.md
@@ -1,0 +1,21 @@
+# 2026-04-09 프론트 dev 런타임 및 파비콘 정리
+
+## 변경 이유
+- 로컬에서 `npm run dev:frontend` 실행 후 `500 Internal Server Error`, `_jsxDEV is not a function`, `favicon` 응답 오류가 함께 발생했다.
+- 프론트 UX 작업을 이어가기 전에 개발 서버를 안정적으로 띄울 수 있는 상태로 먼저 복구할 필요가 있었다.
+
+## 변경 내용
+- `shims/react-cjs-loader.mjs`가 개발 서버에서도 React dev runtime을 직접 읽도록 조정했다.
+- `frontend/index.html`의 파비콘 참조를 정리하고, `frontend/public/` 아래에 `favicon.svg`, `favicon.ico`를 추가했다.
+- 의존성 실행 파일이 누락된 상태를 해소하기 위해 루트에서 `npm install`을 다시 수행했고, 그 결과 `package-lock.json`을 갱신했다.
+
+## 영향 범위
+- 프론트 개발 서버 실행 경로
+- 프론트 정적 자산 로딩 경로
+- 루트 의존성 잠금 파일
+
+## 검증
+- `npm run build:frontend` 통과
+- `http://127.0.0.1:5173/` 응답 `200` 확인
+- `http://127.0.0.1:5173/favicon.svg` 응답 `200` 확인
+- `http://127.0.0.1:5173/favicon.ico` 응답 `200` 확인

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>내맘대로클래스 | MyWayClass</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/remixicon@4.3.0/fonts/remixicon.css"

--- a/frontend/public/favicon.ico
+++ b/frontend/public/favicon.ico
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#4f46e5" />
+  <path d="M10 9.5 22 16 10 22.5Z" fill="#fff" />
+</svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#4f46e5" />
+  <path d="M10 9.5 22 16 10 22.5Z" fill="#fff" />
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "mywayclass",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "workspaces": [
         "frontend",
         "backend",

--- a/shims/react-cjs-loader.mjs
+++ b/shims/react-cjs-loader.mjs
@@ -1,11 +1,11 @@
-import reactProdUrl from '../node_modules/react/cjs/react.production.js?url';
-import jsxDevRuntimeProdUrl from '../node_modules/react/cjs/react-jsx-dev-runtime.production.js?url';
-import jsxRuntimeProdUrl from '../node_modules/react/cjs/react-jsx-runtime.production.js?url';
-import schedulerProdUrl from '../node_modules/scheduler/cjs/scheduler.production.js?url';
-import reactDomProdUrl from '../node_modules/react-dom/cjs/react-dom.production.js?url';
-import reactDomClientProdUrl from '../node_modules/react-dom/cjs/react-dom-client.production.js?url';
+import reactDevUrl from '../node_modules/react/cjs/react.development.js?url';
+import jsxDevRuntimeDevUrl from '../node_modules/react/cjs/react-jsx-dev-runtime.development.js?url';
+import jsxRuntimeDevUrl from '../node_modules/react/cjs/react-jsx-runtime.development.js?url';
+import schedulerDevUrl from '../node_modules/scheduler/cjs/scheduler.development.js?url';
+import reactDomDevUrl from '../node_modules/react-dom/cjs/react-dom.development.js?url';
+import reactDomClientDevUrl from '../node_modules/react-dom/cjs/react-dom-client.development.js?url';
 
-const processShim = { env: { NODE_ENV: 'production' } };
+const processShim = { env: { NODE_ENV: 'development' } };
 
 const [
   reactSource,
@@ -15,12 +15,12 @@ const [
   reactDomSource,
   reactDomClientSource,
 ] = await Promise.all([
-  reactProdUrl,
-  jsxDevRuntimeProdUrl,
-  jsxRuntimeProdUrl,
-  schedulerProdUrl,
-  reactDomProdUrl,
-  reactDomClientProdUrl,
+  reactDevUrl,
+  jsxDevRuntimeDevUrl,
+  jsxRuntimeDevUrl,
+  schedulerDevUrl,
+  reactDomDevUrl,
+  reactDomClientDevUrl,
 ].map(async (url) => {
   const response = await fetch(url);
   if (!response.ok) {


### PR DESCRIPTION
# 변경 요약
프론트 개발 서버가 500, _jsxDEV is not a function, avicon 오류 없이 다시 뜨도록 dev runtime 로더와 정적 자산 경로를 정리했습니다.

## 배경
로컬에서 
pm run dev:frontend를 실행했을 때 프론트가 정상적으로 열리지 않아, UX 작업을 이어가기 전에 개발 환경 자체를 먼저 복구할 필요가 있었습니다.

## 변경 내용
- shims/react-cjs-loader.mjs가 React dev runtime을 직접 읽도록 조정했습니다.
- rontend/index.html의 파비콘 참조를 정리했습니다.
- rontend/public/favicon.svg, rontend/public/favicon.ico를 추가했습니다.
- 누락된 실행 파일 복구를 위해 의존성을 다시 설치하면서 package-lock.json을 갱신했습니다.
- 변경 이유와 검증 결과를 docs/dev-logs/2026-04-09-frontend-dev-runtime-favicon.md에 남겼습니다.

## 연결 이슈
- Closes #52
- Fixes #52

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 rontend/ 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 ackend/ 담당자 확인이 필요하다
- [x] 문서 변경이면 docs/ 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 packages/shared/ 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트
- dev 서버에서 React runtime 오류가 재발하지 않는지
- avicon.svg, avicon.ico가 로컬과 빌드 결과 모두에서 정상 응답하는지
- 이번 수정이 프론트 UX 작업 브랜치와 충돌하지 않는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] docs/dev-logs/에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다