### PR TITLE
[Feature] AI provider 계층과 fallback 전략 정리

### DIFF
--- a/backend/src/lib/ai-provider.ts
+++ b/backend/src/lib/ai-provider.ts
@@ -1,0 +1,44 @@
+import { getAIProviderCatalog, getAIProviderPlan, type AIProviderCapability, type AIProviderName } from '@myway/shared';
+
+export type AIProviderSelection = {
+  feature: AIProviderCapability;
+  current_provider: AIProviderName;
+  recommended_chain: AIProviderName[];
+  fallback_chain: AIProviderName[];
+};
+
+const DEFAULT_FALLBACK_ORDER: Record<AIProviderCapability, AIProviderName[]> = {
+  intent: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  search: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  answer: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  summary: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  quiz: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  smart: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  insights: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  recommendations: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  stt: ['cloudflare', 'gemini', 'demo'],
+  embedding: ['cloudflare', 'ollama', 'demo'],
+};
+
+function uniqueProviders(chain: AIProviderName[]): AIProviderName[] {
+  return Array.from(new Set(chain));
+}
+
+export function getAIProviderSelection(feature: AIProviderCapability, preferredProvider?: AIProviderName): AIProviderSelection {
+  const plan = getAIProviderPlan(feature);
+  const fallback_chain = uniqueProviders([
+    ...(preferredProvider ? [preferredProvider] : []),
+    ...DEFAULT_FALLBACK_ORDER[feature],
+  ]);
+
+  return {
+    feature: plan.feature,
+    current_provider: preferredProvider ?? plan.current_provider,
+    recommended_chain: plan.recommended_chain,
+    fallback_chain,
+  };
+}
+
+export function getAIProviderOverview() {
+  return getAIProviderCatalog();
+}

--- a/backend/src/routes/ai-providers.ts
+++ b/backend/src/routes/ai-providers.ts
@@ -1,0 +1,23 @@
+import { Hono } from 'hono';
+import { getAIProviderOverview } from '../lib/ai-provider';
+import { getAuthenticatedUser } from '../lib/auth';
+import { jsonFailure, jsonSuccess } from '../lib/http';
+
+const aiProviders = new Hono();
+
+aiProviders.get('/', (c) => {
+  const user = getAuthenticatedUser(c.req.raw);
+  if (!user) {
+    return jsonFailure('UNAUTHENTICATED', '로그인이 필요합니다.', 401);
+  }
+
+  return jsonSuccess(
+    {
+      ...getAIProviderOverview(),
+      requested_by: user.role,
+    },
+    'AI provider 구성을 조회했습니다.',
+  );
+});
+
+export default aiProviders;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import auth from './auth';
 import customCourses from './custom-courses';
 import aiInsights from './ai-insights';
 import aiRecommendations from './ai-recommendations';
+import aiProviders from './ai-providers';
 import ai from './ai';
 import courses from './courses';
 import dashboard from './dashboard';
@@ -18,6 +19,7 @@ export function registerRoutes(app: Hono): void {
   app.route('/api/v1/auth', auth);
   app.route('/api/v1/ai/insights', aiInsights);
   app.route('/api/v1/ai', aiRecommendations);
+  app.route('/api/v1/ai/providers', aiProviders);
   app.route('/api/v1/ai', ai);
   app.route('/api/v1/custom-courses', customCourses);
   app.route('/api/v1/dashboard', dashboard);

--- a/docs/dev-logs/2026-04-09-ai-provider-strategy.md
+++ b/docs/dev-logs/2026-04-09-ai-provider-strategy.md
@@ -1,0 +1,16 @@
+# AI Provider Strategy
+
+## 배경
+- 이슈 #42에서는 AI 기능을 실제 엔진에 붙이기 전에 provider 계층과 fallback 전략을 먼저 정리했다.
+- 현재 구현은 demo 기반이지만, 향후 Ollama, Gemini, Cloudflare AI를 섞어 쓸 수 있어야 한다.
+
+## 변경 내용
+- `packages/shared/src/ai-provider.ts`를 추가해 provider 이름, 기능 범위, fallback 순서를 공통 타입으로 정리했다.
+- `backend/src/lib/ai-provider.ts`와 `backend/src/routes/ai-providers.ts`를 추가해 provider 카탈로그를 API로 조회할 수 있게 했다.
+- `frontend/src/lib/api.ts`, `frontend/src/lib/app-state.ts`, `frontend/src/components/LmsDashboard.tsx`, `frontend/src/features/lms/pages/AdminAutomationPage.tsx`를 연결해 운영자 화면에서 provider 계층을 볼 수 있게 했다.
+- `docs/project/14-ai-layer.md`, `docs/project/15-api-map.md`에 provider 계층과 `GET /api/v1/ai/providers`를 반영했다.
+
+## 검증 포인트
+- provider 계층은 `Ollama -> Gemini -> Cloudflare AI -> demo`를 기본 fallback으로 둔다.
+- `STT`와 `embedding`은 Cloudflare AI 우선, 텍스트 생성 계열은 Ollama 우선으로 정리했다.
+- 운영자 자동화 화면에서 provider 우선순위와 fallback 순서를 확인할 수 있다.

--- a/docs/project/14-ai-layer.md
+++ b/docs/project/14-ai-layer.md
@@ -75,6 +75,12 @@
 - 각 AI 기능의 책임이 겹치지 않는다.
 - 실패 시 fallback 경로가 문서로 설명된다.
 
+## Provider 계층
+- 현재 구현은 `demo` 엔진을 기본 동작으로 유지한다.
+- 향후 운영 경로는 `Ollama -> Gemini -> Cloudflare AI -> demo` 순의 fallback 계층을 기본으로 둔다.
+- `STT`와 `embedding`은 `Cloudflare AI`를 우선 고려하고, 텍스트 생성 계열은 `Ollama`를 우선 고려한다.
+- provider 선택과 fallback 순서는 `GET /api/v1/ai/providers`로 조회할 수 있다.
+
 ## 현재 구현
 - `POST /api/v1/ai/intent`로 사용자 메시지의 의도를 분류한다.
 - `POST /api/v1/ai/search`로 강의 본문, 트랜스크립트, 요약 노트에서 근거를 찾는다.
@@ -82,5 +88,6 @@
 - `POST /api/v1/ai/summary`로 강의 요약을 생성한다.
 - `POST /api/v1/ai/quiz`로 강의 기반 퀴즈를 생성한다.
 - `GET /api/v1/ai/insights`로 AI 사용량과 역할별 인사이트를 조회한다.
+- `GET /api/v1/ai/providers`로 provider 계층과 fallback 순서를 조회한다.
 - `POST /api/v1/smart/chat`로 의도 분류와 응답 라우팅을 한 번에 처리한다.
 - 공통 로직은 `packages/shared/src/ai.ts`에서 관리한다.

--- a/docs/project/15-api-map.md
+++ b/docs/project/15-api-map.md
@@ -142,6 +142,8 @@
   - 강의 기반 퀴즈 생성
 - `GET /api/v1/ai/insights`
   - AI 사용량과 역할별 인사이트
+- `GET /api/v1/ai/providers`
+  - AI provider 계층과 fallback 순서
 - `POST /api/v1/smart/chat`
   - 스마트 AI 통합 채팅
 - `GET /api/v1/enrollments`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import {
   canManageCourses,
   demoUsers,
   type AIInsights,
+  type AIProviderCatalog,
   type AIRecommendationOverview,
   type AIUserSettings,
   type CourseCard,
@@ -37,6 +38,7 @@ export default function App() {
   const [session, setSession] = useState<LoginResponse | null>(null);
   const [dashboard, setDashboard] = useState<Dashboard | null>(null);
   const [insights, setInsights] = useState<AIInsights | null>(null);
+  const [providers, setProviders] = useState<AIProviderCatalog | null>(null);
   const [recommendations, setRecommendations] = useState<AIRecommendationOverview | null>(null);
   const [settings, setSettings] = useState<AIUserSettings | null>(null);
   const [courseCards, setCourseCards] = useState<CourseCard[]>([]);
@@ -61,6 +63,7 @@ export default function App() {
     setSelectedCourseId,
     setDashboard,
     setInsights,
+    setProviders,
     setRecommendations,
     setSettings,
     setNotice,
@@ -258,6 +261,7 @@ export default function App() {
       loading={loading}
       notice={notice}
       insights={insights}
+      providers={providers}
       recommendations={recommendations}
       settings={settings}
       onCompleteLecture={(lectureId) => void completeLectureFlow(flowDeps, lectureId)}

--- a/frontend/src/components/LmsDashboard.tsx
+++ b/frontend/src/components/LmsDashboard.tsx
@@ -33,6 +33,7 @@ export function LmsDashboard(props: LmsDashboardProps) {
         recommendations={props.recommendations}
         courseCards={props.courseCards}
         insights={props.insights}
+        providers={props.providers}
         onSelectCourse={props.onSelectCourse}
         demoUsers={props.demoUsers}
       />

--- a/frontend/src/features/lms/pages/AdminAutomationPage.tsx
+++ b/frontend/src/features/lms/pages/AdminAutomationPage.tsx
@@ -1,3 +1,5 @@
+import type { AIProviderCatalog } from '@myway/shared';
+
 type AutomationTool = {
   icon: string;
   iconClass: string;
@@ -64,7 +66,13 @@ const rules: AutomationRule[] = [
   },
 ];
 
-export function AdminAutomationPage() {
+type AdminAutomationPageProps = {
+  providerCatalog: AIProviderCatalog | null;
+};
+
+export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProps) {
+  const providerPlans = providerCatalog?.plans.slice(0, 4) ?? [];
+
   return (
     <div className="space-y-5">
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -106,6 +114,58 @@ export function AdminAutomationPage() {
                 {rule.active ? '활성' : '비활성'}
               </span>
             </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+        <h3 className="flex items-center gap-2 text-[15px] font-bold tracking-[-0.02em] text-slate-900">
+          <i className="ri-database-2-line text-indigo-600" />
+          AI provider 계층
+        </h3>
+        <p className="mt-2 text-[12px] leading-6 text-slate-500">
+          현재는 demo 엔진으로 기본 동작을 유지하고, 앞으로는 Ollama, Gemini, Cloudflare AI 순으로 기능별 fallback을 적용합니다.
+        </p>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {providerPlans.map((plan) => (
+            <article key={plan.feature} className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-[13px] font-semibold text-slate-900">{plan.feature}</div>
+                  <div className="mt-1 text-[12px] text-slate-500">{plan.current_provider}가 현재 우선 제공자예요.</div>
+                </div>
+                <span className="rounded-full bg-indigo-100 px-2.5 py-1 text-[11px] font-semibold text-indigo-600">
+                  {plan.steps[0]?.status ?? 'planned'}
+                </span>
+              </div>
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                {plan.recommended_chain.map((provider, index) => (
+                  <span
+                    key={provider}
+                    className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
+                      index === 0
+                        ? 'bg-indigo-600 text-white'
+                        : provider === 'demo'
+                          ? 'bg-slate-200 text-slate-600'
+                          : 'bg-white text-slate-600 ring-1 ring-slate-200'
+                    }`}
+                  >
+                    {provider}
+                  </span>
+                ))}
+              </div>
+
+              <ul className="mt-3 space-y-1.5 text-[11px] leading-5 text-slate-500">
+                {plan.steps.slice(0, 3).map((step) => (
+                  <li key={step.provider} className="flex items-center justify-between gap-2">
+                    <span>{step.provider}</span>
+                    <span>{step.reason}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
           ))}
         </div>
       </section>

--- a/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
@@ -70,7 +70,10 @@ export function InstructorDashboardPage({ courses, insights }: InstructorDashboa
             <i className="ri-lightbulb-flash-line text-indigo-600" />
             AI 인사이트
           </h3>
-          <p className="mt-3 text-[13px] leading-6 text-slate-500">{insights.summary.headline}</p>
+          <p className="mt-3 text-[13px] leading-6 text-slate-500">
+            최근 {insights.summary.recent_window_days}일 동안 AI 요청 {insights.summary.total_requests}회,
+            성공률 {insights.summary.success_rate}%입니다.
+          </p>
         </section>
       ) : null}
     </div>

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -24,6 +24,7 @@ type RolePageRouterProps = Pick<
 > & {
   session: LoginResponse;
   page: LmsPageId;
+  providers: LmsDashboardProps['providers'];
 };
 
 export function RolePageRouter({
@@ -33,6 +34,7 @@ export function RolePageRouter({
   enrolledCourses,
   highlightedLecture,
   recommendations,
+  providers,
   courseCards,
   insights,
   onSelectCourse,
@@ -53,7 +55,7 @@ export function RolePageRouter({
       case 'admin-stats':
         return <AdminStatsPage dashboard={dashboard} courses={courseCards} users={demoUsers} insights={insights} />;
       case 'admin-automation':
-        return <AdminAutomationPage />;
+        return <AdminAutomationPage providerCatalog={providers} />;
       default:
         return (
           <RolePageFallback

--- a/frontend/src/features/lms/types.ts
+++ b/frontend/src/features/lms/types.ts
@@ -1,5 +1,6 @@
 import type {
   AIInsights,
+  AIProviderCatalog,
   AIRecommendationOverview,
   AIUserSettings,
   AuthUser,
@@ -53,6 +54,7 @@ export type LmsDashboardProps = {
   loading: boolean;
   notice: string;
   insights: AIInsights | null;
+  providers: AIProviderCatalog | null;
   recommendations: AIRecommendationOverview | null;
   settings: AIUserSettings | null;
   onCompleteLecture: (lectureId: string) => void;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import {
   canEnroll,
   completeLectureProgress,
+  getAIProviderCatalog,
   getAIInsightsForUser,
   getAIRecommendationsForUser,
   getAIUserSettings,
@@ -16,6 +17,7 @@ import {
   type MaterialCreateRequest,
   type ApiResponse,
   type AIInsights,
+  type AIProviderCatalog,
   type AIRecommendationOverview,
   type AIUserSettings,
   type AIUserSettingsUpdateRequest,
@@ -213,6 +215,18 @@ export async function loadAISettings(sessionToken?: string | null): Promise<AIUs
   const userId = getFallbackUserId();
 
   return response?.success && response.data ? response.data : getAIUserSettings(userId);
+}
+
+export async function loadAIProviders(sessionToken?: string | null): Promise<AIProviderCatalog | null> {
+  const token = sessionToken ?? readStoredAuth()?.session_token ?? null;
+
+  if (!token) {
+    return null;
+  }
+
+  const response = await request<AIProviderCatalog>('/api/v1/ai/providers', undefined, token);
+
+  return response?.success && response.data ? response.data : getAIProviderCatalog();
 }
 
 export async function saveAISettings(

--- a/frontend/src/lib/app-state.ts
+++ b/frontend/src/lib/app-state.ts
@@ -1,19 +1,21 @@
 import type { Dispatch, SetStateAction } from 'react';
 import type {
   AIInsights,
+  AIProviderCatalog,
   AIRecommendationOverview,
   AIUserSettings,
   CourseCard,
   Dashboard,
   LoginResponse,
 } from '@myway/shared';
-import { loadAIInsights, loadAIRecommendations, loadAISettings, loadCourses, loadDashboard } from './api';
+import { loadAIInsights, loadAIProviders, loadAIRecommendations, loadAISettings, loadCourses, loadDashboard } from './api';
 
 type RefreshLearningStateDeps = {
   setCourseCards: Dispatch<SetStateAction<CourseCard[]>>;
   setSelectedCourseId: Dispatch<SetStateAction<string>>;
   setDashboard: Dispatch<SetStateAction<Dashboard | null>>;
   setInsights: Dispatch<SetStateAction<AIInsights | null>>;
+  setProviders: Dispatch<SetStateAction<AIProviderCatalog | null>>;
   setRecommendations: Dispatch<SetStateAction<AIRecommendationOverview | null>>;
   setSettings: Dispatch<SetStateAction<AIUserSettings | null>>;
   setNotice: Dispatch<SetStateAction<string>>;
@@ -23,10 +25,11 @@ export async function refreshLearningState(
   deps: RefreshLearningStateDeps,
   activeSession: LoginResponse | null,
 ): Promise<void> {
-  const [courses, dashboardData, insightsData, recommendationsData, settingsData] = await Promise.all([
+  const [courses, dashboardData, insightsData, providersData, recommendationsData, settingsData] = await Promise.all([
     loadCourses(activeSession?.session_token),
     activeSession ? loadDashboard(activeSession.session_token) : Promise.resolve(null),
     activeSession ? loadAIInsights(activeSession.session_token) : Promise.resolve(null),
+    activeSession ? loadAIProviders(activeSession.session_token) : Promise.resolve(null),
     activeSession ? loadAIRecommendations(activeSession.session_token) : Promise.resolve(null),
     activeSession ? loadAISettings(activeSession.session_token) : Promise.resolve(null),
   ]);
@@ -40,12 +43,14 @@ export async function refreshLearningState(
   if (activeSession) {
     deps.setDashboard(dashboardData);
     deps.setInsights(insightsData);
+    deps.setProviders(providersData);
     deps.setRecommendations(recommendationsData);
     deps.setSettings(settingsData);
     deps.setNotice(`${activeSession.user.name} 님, ${activeSession.user.role} 계정으로 로그인했습니다.`);
   } else {
     deps.setDashboard(null);
     deps.setInsights(null);
+    deps.setProviders(null);
     deps.setRecommendations(null);
     deps.setSettings(null);
     deps.setNotice('로그인 후 내 정보와 진도가 활성화됩니다.');

--- a/frontend/src/lib/course-flow.ts
+++ b/frontend/src/lib/course-flow.ts
@@ -118,7 +118,7 @@ export async function addCourseMaterialFlow(
 
 export async function addCourseNoticeFlow(
   deps: FlowDeps,
-  input: { title: string; content: string; pinned: boolean },
+  input: { title: string; content: string; pinned?: boolean },
 ): Promise<boolean> {
   const {
     session,

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -1,0 +1,126 @@
+export type AIProviderName = 'demo' | 'ollama' | 'gemini' | 'cloudflare';
+
+export type AIProviderCapability =
+  | 'intent'
+  | 'search'
+  | 'answer'
+  | 'summary'
+  | 'quiz'
+  | 'smart'
+  | 'insights'
+  | 'recommendations'
+  | 'stt'
+  | 'embedding';
+
+export type AIProviderStatus = 'available' | 'planned' | 'disabled';
+
+export type AIProviderDescriptor = {
+  name: AIProviderName;
+  label: string;
+  description: string;
+  status: AIProviderStatus;
+  capabilities: AIProviderCapability[];
+};
+
+export type AIProviderStep = {
+  provider: AIProviderName;
+  reason: string;
+  status: AIProviderStatus;
+};
+
+export type AIProviderPlan = {
+  feature: AIProviderCapability;
+  current_provider: AIProviderName;
+  recommended_chain: AIProviderName[];
+  steps: AIProviderStep[];
+};
+
+export type AIProviderCatalog = {
+  generated_at: string;
+  providers: AIProviderDescriptor[];
+  plans: AIProviderPlan[];
+};
+
+const PROVIDER_DESCRIPTORS: AIProviderDescriptor[] = [
+  {
+    name: 'demo',
+    label: 'Demo Engine',
+    description: '현재 앱의 기본 동작을 보장하는 내장 데모 엔진입니다.',
+    status: 'available',
+    capabilities: ['intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations', 'stt', 'embedding'],
+  },
+  {
+    name: 'ollama',
+    label: 'Ollama',
+    description: '로컬 또는 자가 호스팅 환경에서 무료로 사용할 수 있는 모델 계층입니다.',
+    status: 'planned',
+    capabilities: ['intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations', 'embedding'],
+  },
+  {
+    name: 'gemini',
+    label: 'Gemini',
+    description: '무료 API 쿼터 기반으로 생성, 분류, 요약 보강에 활용할 수 있는 외부 모델 계층입니다.',
+    status: 'planned',
+    capabilities: ['intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations', 'stt'],
+  },
+  {
+    name: 'cloudflare',
+    label: 'Cloudflare AI',
+    description: 'Workers AI와 연계해 배포 환경에서 안정적으로 붙일 수 있는 인프라 계층입니다.',
+    status: 'planned',
+    capabilities: ['stt', 'embedding', 'intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations'],
+  },
+];
+
+const FEATURE_CHAIN: Record<AIProviderCapability, AIProviderName[]> = {
+  intent: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  search: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  answer: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  summary: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  quiz: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  smart: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  insights: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  recommendations: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  stt: ['cloudflare', 'gemini', 'demo'],
+  embedding: ['cloudflare', 'ollama', 'demo'],
+};
+
+function buildSteps(chain: AIProviderName[]): AIProviderStep[] {
+  return chain.map((provider, index) => {
+    const descriptor = PROVIDER_DESCRIPTORS.find((item) => item.name === provider);
+
+    return {
+      provider,
+      status: descriptor?.status ?? 'planned',
+      reason:
+        index === 0
+          ? '이 기능의 기본 경로'
+          : index === chain.length - 1
+            ? '최후의 안전망'
+            : '기본 경로가 실패할 때의 대체 경로',
+    };
+  });
+}
+
+export function getAIProviderCatalog(): AIProviderCatalog {
+  return {
+    generated_at: new Date().toISOString(),
+    providers: PROVIDER_DESCRIPTORS,
+    plans: Object.entries(FEATURE_CHAIN).map(([feature, chain]) => ({
+      feature: feature as AIProviderCapability,
+      current_provider: chain[0],
+      recommended_chain: chain,
+      steps: buildSteps(chain),
+    })),
+  };
+}
+
+export function getAIProviderPlan(feature: AIProviderCapability): AIProviderPlan {
+  const chain = FEATURE_CHAIN[feature];
+  return {
+    feature,
+    current_provider: chain[0],
+    recommended_chain: chain,
+    steps: buildSteps(chain),
+  };
+}

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -1,5 +1,6 @@
 export * from './ai-intent';
 export * from './ai-learning';
+export * from './ai-provider';
 
 export { classifyAIIntent as buildAIIntentOverview } from './ai-intent';
 export { searchAIContent as buildAISearchOverview } from './ai-intent';


### PR DESCRIPTION
﻿# 변경 요약
AI 기능의 provider 계층과 fallback 순서를 공통 타입과 backend API로 정리했습니다.

## 배경
현재 AI 기능은 demo 기반으로 동작하지만, 향후 Ollama, Gemini, Cloudflare AI를 기능별로 조합할 수 있어야 합니다.

## 변경 내용
- `packages/shared/src/ai-provider.ts`로 provider/feature/fallback 타입을 추가했습니다.
- `backend/src/lib/ai-provider.ts`와 `backend/src/routes/ai-providers.ts`로 provider catalog API를 추가했습니다.
- `frontend`에서 provider overview를 읽어 운영자 자동화 화면에 표시하도록 연결했습니다.
- `docs/project/14-ai-layer.md`, `docs/project/15-api-map.md`, `docs/dev-logs/2026-04-09-ai-provider-strategy.md`를 갱신했습니다.

## 연결 이슈
- Closes #42
- Fixes #42

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
