### PR TITLE
[Feature] STT 엔진 연동과 트랜스크립트 파이프라인 구현

### DIFF
--- a/backend/src/lib/stt-adapter.ts
+++ b/backend/src/lib/stt-adapter.ts
@@ -1,0 +1,51 @@
+import { createLectureTranscript, type TranscriptCreateRequest, type LecturePipeline } from '@myway/shared';
+import { getSTTProviderSelection } from './stt-provider';
+
+export type STTAdapterResult =
+  | {
+      ok: true;
+      transcript_id: string;
+      lecture_id: string;
+      segment_count: number;
+      duration_ms: number;
+      word_count: number;
+      stt_provider: string;
+      stt_model: string;
+      pipeline: LecturePipeline;
+    }
+  | {
+      ok: false;
+      reason: 'lecture_not_found' | 'transcript_failed';
+    };
+
+export function runTranscriptGeneration(
+  userId: string,
+  input: TranscriptCreateRequest,
+  preferredProvider?: 'demo' | 'cloudflare' | 'gemini',
+): STTAdapterResult {
+  const provider = getSTTProviderSelection('transcribe', preferredProvider);
+  const result = createLectureTranscript(userId, {
+    ...input,
+    stt_provider: provider.current_provider,
+    stt_model: input.stt_model ?? 'pseudo-stt-v1',
+  });
+
+  if (!result) {
+    return {
+      ok: false,
+      reason: 'transcript_failed',
+    };
+  }
+
+  return {
+    ok: true,
+    transcript_id: result.transcript.id,
+    lecture_id: result.transcript.lecture_id,
+    segment_count: result.transcript.segments.length,
+    duration_ms: result.transcript.duration_ms,
+    word_count: result.transcript.word_count,
+    stt_provider: result.transcript.stt_provider,
+    stt_model: result.transcript.stt_model,
+    pipeline: result.pipeline,
+  };
+}

--- a/backend/src/lib/stt-provider.ts
+++ b/backend/src/lib/stt-provider.ts
@@ -1,0 +1,37 @@
+import { getSTTProviderCatalog, getSTTProviderPlan, type STTProviderCapability, type STTProviderName } from '@myway/shared';
+
+export type STTProviderSelection = {
+  feature: STTProviderCapability;
+  current_provider: STTProviderName;
+  recommended_chain: STTProviderName[];
+  fallback_chain: STTProviderName[];
+};
+
+const DEFAULT_FALLBACK_ORDER: Record<STTProviderCapability, STTProviderName[]> = {
+  transcribe: ['cloudflare', 'gemini', 'demo'],
+  segment: ['cloudflare', 'gemini', 'demo'],
+  pipeline: ['cloudflare', 'gemini', 'demo'],
+};
+
+function uniqueProviders(chain: STTProviderName[]): STTProviderName[] {
+  return Array.from(new Set(chain));
+}
+
+export function getSTTProviderSelection(feature: STTProviderCapability, preferredProvider?: STTProviderName): STTProviderSelection {
+  const plan = getSTTProviderPlan(feature);
+  const fallback_chain = uniqueProviders([
+    ...(preferredProvider ? [preferredProvider] : []),
+    ...DEFAULT_FALLBACK_ORDER[feature],
+  ]);
+
+  return {
+    feature: plan.feature,
+    current_provider: preferredProvider ?? plan.current_provider,
+    recommended_chain: plan.recommended_chain,
+    fallback_chain,
+  };
+}
+
+export function getSTTProviderOverview() {
+  return getSTTProviderCatalog();
+}

--- a/backend/src/routes/media.ts
+++ b/backend/src/routes/media.ts
@@ -3,7 +3,6 @@ import {
   buildPipelineOverview,
   createAudioExtraction,
   createLectureSummaryNote,
-  createLectureTranscript,
   getLectureDetail,
   listAudioExtractions,
   listLectureNotes,
@@ -11,9 +10,12 @@ import {
   type AudioExtractionRequest,
   type MediaSummaryRequest,
   type TranscriptCreateRequest,
+  type STTProviderCatalog,
 } from '@myway/shared';
 import { getAuthenticatedUser, hasRole } from '../lib/auth';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
+import { getSTTProviderOverview } from '../lib/stt-provider';
+import { runTranscriptGeneration } from '../lib/stt-adapter';
 
 const media = new Hono();
 
@@ -38,30 +40,36 @@ media.post('/transcribe', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  const result = createLectureTranscript(user.id, {
+  const result = runTranscriptGeneration(user.id, {
     lecture_id: lectureId,
     text: body?.text?.trim(),
     duration_ms: body?.duration_ms,
     language: body?.language ?? 'ko',
+    stt_provider: body?.stt_provider?.trim(),
+    stt_model: body?.stt_model?.trim(),
   });
 
-  if (!result) {
+  if (!result.ok) {
     return jsonFailure('TRANSCRIPT_FAILED', '트랜스크립트를 생성할 수 없습니다.', 400);
   }
 
   return jsonSuccess(
     {
-      transcript_id: result.transcript.id,
-      lecture_id: result.transcript.lecture_id,
-      segment_count: result.transcript.segments.length,
-      duration_ms: result.transcript.duration_ms,
-      word_count: result.transcript.word_count,
+      transcript_id: result.transcript_id,
+      lecture_id: result.lecture_id,
+      segment_count: result.segment_count,
+      duration_ms: result.duration_ms,
+      word_count: result.word_count,
+      stt_provider: result.stt_provider,
+      stt_model: result.stt_model,
       pipeline: result.pipeline,
     },
     '트랜스크립트가 생성되었습니다.',
     201,
   );
 });
+
+media.get('/providers', (c) => jsonSuccess(getSTTProviderOverview() satisfies STTProviderCatalog, 'STT provider 계층을 조회했습니다.'));
 
 media.post('/summarize', async (c) => {
   const user = getAuthenticatedUser(c.req.raw);

--- a/docs/dev-logs/2026-04-09-stt-provider-adapter.md
+++ b/docs/dev-logs/2026-04-09-stt-provider-adapter.md
@@ -1,0 +1,17 @@
+# STT Provider Adapter
+
+## 배경
+- 이슈 #44에서는 미디어 파이프라인이 demo 트랜스크립트 생성에만 머무르지 않도록 provider 계층을 먼저 정리했다.
+- STT 결과와 파이프라인 상태는 이후 청킹, RAG, 요약, 숏폼 연결의 입력이 되므로 실행 계층이 필요했다.
+
+## 변경 내용
+- `packages/shared/src/stt-provider.ts`를 추가해 STT provider 이름, 기능 범위, fallback 순서를 공통 타입으로 정리했다.
+- `backend/src/lib/stt-provider.ts`와 `backend/src/lib/stt-adapter.ts`를 추가해 transcript 생성 시 provider 선택을 분리했다.
+- `backend/src/routes/media.ts`가 adapter를 통해 트랜스크립트를 생성하고, `GET /api/v1/media/providers`로 provider 계층을 조회할 수 있게 했다.
+- `packages/shared/src/media.ts`는 transcript 메타데이터에 `stt_provider`와 `stt_model`을 기록하도록 정리했다.
+- `docs/project/07-stt-media-pipeline.md`, `docs/project/15-api-map.md`를 업데이트했다.
+
+## 검증 포인트
+- STT provider fallback은 `Cloudflare AI -> Gemini -> demo`를 기본으로 둔다.
+- 텍스트 전용 트랜스크립트도 provider 메타데이터를 함께 남긴다.
+- 파이프라인 조회 API는 기존 응답 구조를 유지한다.

--- a/docs/project/07-stt-media-pipeline.md
+++ b/docs/project/07-stt-media-pipeline.md
@@ -59,6 +59,12 @@
 - 큰 미디어를 D1에 저장하는 경우
 - 타임스탬프 정렬이 깨지는 경우
 
+## Provider 계층
+- 현재 구현은 `demo` STT를 기본 경로로 유지한다.
+- 향후 운영 경로는 `Cloudflare AI -> Gemini -> demo` 순의 fallback 계층을 기본으로 둔다.
+- `POST /api/v1/media/transcribe`는 provider 메타데이터를 함께 기록하고, `GET /api/v1/media/providers`로 provider 계층을 조회할 수 있다.
+- STT 결과에는 `stt_provider`와 `stt_model`이 함께 남아야 한다.
+
 ## 검증 기준
 - 미디어 내용을 검색 가능한 트랜스크립트 데이터로 바꿀 수 있다.
 - 데모 경로와 운영 경로를 구분할 수 있다.

--- a/docs/project/15-api-map.md
+++ b/docs/project/15-api-map.md
@@ -84,6 +84,8 @@
   - 강의 완료와 진도 저장
 - `POST /api/v1/media/transcribe`
   - 트랜스크립트 생성
+- `GET /api/v1/media/providers`
+  - STT provider 계층과 fallback 순서
 - `POST /api/v1/media/summarize`
   - 요약 노트 생성
 - `POST /api/v1/media/extract-audio`

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from './learning';
 export * from './ai';
 export * from './ai-insights';
 export * from './ai-recommendations';
+export * from './stt-provider';
 export * from './smart';
 export * from './media';
 export * from './custom-course';

--- a/packages/shared/src/media.ts
+++ b/packages/shared/src/media.ts
@@ -228,8 +228,8 @@ export function createLectureTranscript(
     segments: splitIntoSegments(fullText, durationMs),
     word_count: fullText.split(/\s+/).filter(Boolean).length,
     duration_ms: durationMs,
-    stt_provider: input.text ? 'text-derived-stt' : 'demo-stt',
-    stt_model: 'pseudo-stt-v1',
+    stt_provider: input.stt_provider ?? (input.text ? 'text-derived-stt' : 'demo-stt'),
+    stt_model: input.stt_model ?? 'pseudo-stt-v1',
     created_at: now(),
   };
 

--- a/packages/shared/src/stt-provider.ts
+++ b/packages/shared/src/stt-provider.ts
@@ -1,0 +1,103 @@
+export type STTProviderName = 'demo' | 'cloudflare' | 'gemini';
+
+export type STTProviderCapability = 'transcribe' | 'segment' | 'pipeline';
+
+export type STTProviderStatus = 'available' | 'planned' | 'disabled';
+
+export type STTProviderDescriptor = {
+  name: STTProviderName;
+  label: string;
+  description: string;
+  status: STTProviderStatus;
+  capabilities: STTProviderCapability[];
+};
+
+export type STTProviderStep = {
+  provider: STTProviderName;
+  reason: string;
+  status: STTProviderStatus;
+};
+
+export type STTProviderPlan = {
+  feature: STTProviderCapability;
+  current_provider: STTProviderName;
+  recommended_chain: STTProviderName[];
+  steps: STTProviderStep[];
+};
+
+export type STTProviderCatalog = {
+  generated_at: string;
+  providers: STTProviderDescriptor[];
+  plans: STTProviderPlan[];
+};
+
+const PROVIDERS: STTProviderDescriptor[] = [
+  {
+    name: 'demo',
+    label: 'Demo STT',
+    description: '현재 텍스트 기반 트랜스크립트를 안전하게 유지하는 기본 경로입니다.',
+    status: 'available',
+    capabilities: ['transcribe', 'segment', 'pipeline'],
+  },
+  {
+    name: 'cloudflare',
+    label: 'Cloudflare AI',
+    description: '배포 환경에서 안정적으로 붙일 수 있는 STT 및 파이프라인 계층입니다.',
+    status: 'planned',
+    capabilities: ['transcribe', 'segment', 'pipeline'],
+  },
+  {
+    name: 'gemini',
+    label: 'Gemini',
+    description: '무료 API 쿼터 기반으로 전사 보조와 정리 작업에 활용할 수 있습니다.',
+    status: 'planned',
+    capabilities: ['transcribe', 'segment', 'pipeline'],
+  },
+];
+
+const FEATURE_CHAIN: Record<STTProviderCapability, STTProviderName[]> = {
+  transcribe: ['cloudflare', 'gemini', 'demo'],
+  segment: ['cloudflare', 'gemini', 'demo'],
+  pipeline: ['cloudflare', 'gemini', 'demo'],
+};
+
+function buildSteps(chain: STTProviderName[]): STTProviderStep[] {
+  return chain.map((provider, index) => {
+    const descriptor = PROVIDERS.find((item) => item.name === provider);
+
+    return {
+      provider,
+      status: descriptor?.status ?? 'planned',
+      reason:
+        index === 0
+          ? '이 기능의 기본 경로'
+          : index === chain.length - 1
+            ? '최후의 안전망'
+            : '기본 경로가 실패할 때의 대체 경로',
+    };
+  });
+}
+
+export function getSTTProviderCatalog(): STTProviderCatalog {
+  return {
+    generated_at: new Date().toISOString(),
+    providers: PROVIDERS,
+    plans: Object.entries(FEATURE_CHAIN).map(([feature, chain]) => ({
+      feature: feature as STTProviderCapability,
+      current_provider: chain[0],
+      recommended_chain: chain,
+      steps: buildSteps(chain),
+    })),
+  };
+}
+
+export function getSTTProviderPlan(feature: STTProviderCapability): STTProviderPlan {
+  const chain = FEATURE_CHAIN[feature];
+
+  return {
+    feature,
+    current_provider: chain[0],
+    recommended_chain: chain,
+    steps: buildSteps(chain),
+  };
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -192,6 +192,8 @@ export type TranscriptCreateRequest = {
   text?: string;
   duration_ms?: number;
   language?: string;
+  stt_provider?: string;
+  stt_model?: string;
 };
 
 export type MediaSummaryRequest = {


### PR DESCRIPTION
﻿# 변경 요약
STT 트랜스크립트 생성 경로에 provider 계층과 fallback 순서를 분리해, 이후 실제 엔진 연동으로 확장할 수 있는 실행 구조를 추가했습니다.

## 배경
현재 미디어 파이프라인은 demo 기반 전사에 의존하고 있어서, STT 엔진을 바꾸거나 운영 환경으로 옮길 때 실행 계층을 분리할 필요가 있었습니다.

## 변경 내용
- `packages/shared/src/stt-provider.ts`로 STT provider 이름, 기능 범위, fallback 순서를 공통 타입으로 추가했습니다.
- `backend/src/lib/stt-provider.ts`와 `backend/src/lib/stt-adapter.ts`를 추가해 트랜스크립트 생성 시 provider 선택을 분리했습니다.
- `backend/src/routes/media.ts`가 adapter를 통해 트랜스크립트를 생성하고, `GET /api/v1/media/providers`로 STT provider 계층을 조회할 수 있게 했습니다.
- `packages/shared/src/media.ts`는 transcript 메타데이터에 `stt_provider`와 `stt_model`을 기록하도록 정리했습니다.
- `docs/project/07-stt-media-pipeline.md`, `docs/project/15-api-map.md`, `docs/dev-logs/2026-04-09-stt-provider-adapter.md`를 갱신했습니다.

## 연결 이슈
- Closes #44
- Fixes #44

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
