### PR TITLE
feat: add AI engine provider split

### DIFF
--- a/backend/src/lib/ai-adapter.ts
+++ b/backend/src/lib/ai-adapter.ts
@@ -1,9 +1,7 @@
 import {
   answerAIQuestion,
   classifyAIIntent,
-  generateAIQuiz,
   searchAIContent,
-  createAISummary,
   type AIAnswerRequest,
   type AIAnswerResult,
   type AIIntentRequest,
@@ -17,6 +15,7 @@ import {
   type AISummaryRequest,
   type AISummaryResult,
 } from '@myway/shared';
+import { runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine';
 import { getAIProviderSelection } from './ai-provider';
 
 export type AIAdapterResultMap = {
@@ -56,21 +55,27 @@ export function runAIAnswer(input: AIAnswerRequest, preferredProvider?: AIProvid
   return answerAIQuestion(input);
 }
 
-export function runAISummary(input: AISummaryRequest, preferredProvider?: AIProviderName): AISummaryResult | null {
-  void resolveProvider('summary', preferredProvider);
-  return createAISummary(input);
+export async function runAISummary(
+  input: AISummaryRequest,
+  preferredProvider?: AIProviderName,
+): Promise<AISummaryResult | null> {
+  resolveProvider('summary', preferredProvider);
+  return runAISummaryWithEngine(input, preferredProvider);
 }
 
-export function runAIQuiz(input: AIQuizRequest, preferredProvider?: AIProviderName): AIQuizResult | null {
-  void resolveProvider('quiz', preferredProvider);
-  return generateAIQuiz(input);
+export async function runAIQuiz(
+  input: AIQuizRequest,
+  preferredProvider?: AIProviderName,
+): Promise<AIQuizResult | null> {
+  resolveProvider('quiz', preferredProvider);
+  return runAIQuizWithEngine(input, preferredProvider);
 }
 
-export function runAIFeature<TFeature extends AIAdapterFeature>(
+export async function runAIFeature<TFeature extends AIAdapterFeature>(
   feature: TFeature,
   input: AIAdapterInputMap[TFeature],
   preferredProvider?: AIProviderName,
-): AIAdapterResultMap[TFeature] {
+): Promise<AIAdapterResultMap[TFeature]> {
   switch (feature) {
     case 'intent':
       return runAIIntent(input as AIIntentRequest, preferredProvider) as AIAdapterResultMap[TFeature];
@@ -79,8 +84,10 @@ export function runAIFeature<TFeature extends AIAdapterFeature>(
     case 'answer':
       return runAIAnswer(input as AIAnswerRequest, preferredProvider) as AIAdapterResultMap[TFeature];
     case 'summary':
-      return runAISummary(input as AISummaryRequest, preferredProvider) as AIAdapterResultMap[TFeature];
+      return (await runAISummary(input as AISummaryRequest, preferredProvider)) as AIAdapterResultMap[TFeature];
     case 'quiz':
-      return runAIQuiz(input as AIQuizRequest, preferredProvider) as AIAdapterResultMap[TFeature];
+      return (await runAIQuiz(input as AIQuizRequest, preferredProvider)) as AIAdapterResultMap[TFeature];
+    default:
+      throw new Error(`Unsupported AI feature: ${String(feature)}`);
   }
 }

--- a/backend/src/lib/ai-engine.ts
+++ b/backend/src/lib/ai-engine.ts
@@ -1,0 +1,314 @@
+import {
+  createAISummary,
+  generateAIQuiz,
+  getLectureDetail,
+  getLectureTranscript,
+  listLectureNotes,
+  type AIProviderName,
+  type AIQuizQuestion,
+  type AIQuizRequest,
+  type AIQuizResult,
+  type AISummaryRequest,
+  type AISummaryResult,
+} from '@myway/shared';
+import { getAIProviderSelection } from './ai-provider';
+import { runOllamaChat, type OllamaChatMessage } from './providers';
+
+type JsonObject = Record<string, unknown>;
+
+function normalizeText(value: string): string {
+  return value.replaceAll(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, limit: number): string {
+  if (value.length <= limit) {
+    return value;
+  }
+
+  return `${value.slice(0, limit).trim()}...`;
+}
+
+function extractJsonCandidate(value: string): string | null {
+  const fencedMatch = value.match(/```json\s*([\s\S]*?)```/i) ?? value.match(/```\s*([\s\S]*?)```/i);
+  const candidate = (fencedMatch?.[1] ?? value).trim();
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+
+  if (start < 0 || end < 0 || end <= start) {
+    return null;
+  }
+
+  return candidate.slice(start, end + 1);
+}
+
+function parseJsonObject(value: string): JsonObject | null {
+  const candidate = extractJsonCandidate(value);
+  if (!candidate) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(candidate) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed as JsonObject;
+  } catch {
+    return null;
+  }
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function pickString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function pickDifficulty(value: unknown, fallback: AIQuizResult['difficulty']): AIQuizResult['difficulty'] {
+  if (value === 'easy' || value === 'medium' || value === 'hard') {
+    return value;
+  }
+
+  return fallback;
+}
+
+function normalizeQuizQuestion(
+  candidate: JsonObject | undefined,
+  fallback: AIQuizQuestion,
+): AIQuizQuestion {
+  if (!candidate) {
+    return fallback;
+  }
+
+  const question = pickString(candidate.question, fallback.question);
+  const rawChoices = toStringArray(candidate.choices);
+  const mergedChoices = [...rawChoices];
+
+  for (const choice of fallback.choices) {
+    if (mergedChoices.length >= 4) {
+      break;
+    }
+
+    if (!mergedChoices.includes(choice)) {
+      mergedChoices.push(choice);
+    }
+  }
+
+  while (mergedChoices.length < 4) {
+    const filler = fallback.choices[mergedChoices.length] ?? fallback.choices[0];
+    mergedChoices.push(filler);
+  }
+
+  const correctChoiceIndex =
+    typeof candidate.correct_choice_index === 'number' &&
+    Number.isInteger(candidate.correct_choice_index) &&
+    candidate.correct_choice_index >= 0 &&
+    candidate.correct_choice_index < mergedChoices.length
+      ? candidate.correct_choice_index
+      : fallback.correct_choice_index;
+
+  return {
+    ...fallback,
+    question,
+    choices: mergedChoices.slice(0, 4),
+    correct_choice_index: correctChoiceIndex,
+    explanation: pickString(candidate.explanation, fallback.explanation),
+  };
+}
+
+function buildSummaryPrompt(
+  lectureTitle: string,
+  courseTitle: string,
+  sourceText: string,
+  style: AISummaryRequest['style'],
+  language: AISummaryRequest['language'],
+): OllamaChatMessage[] {
+  return [
+    {
+      role: 'system',
+      content:
+        'You are a careful lecture summarizer. Return valid JSON only. Do not wrap the response in markdown or prose.',
+    },
+    {
+      role: 'user',
+      content: [
+        `Lecture title: ${lectureTitle}`,
+        `Course title: ${courseTitle}`,
+        `Language: ${language ?? 'ko'}`,
+        `Style: ${style ?? 'brief'}`,
+        'Return JSON with the following shape:',
+        '{"title":"string","content":"string","key_points":["string"]}',
+        'Rules:',
+        '- Use only the provided source text.',
+        '- Keep factual claims grounded in the lecture.',
+        '- title should be short and descriptive.',
+        '- content should be concise and readable in the selected language.',
+        '- key_points should contain 3 to 5 short bullets.',
+        'Source text:',
+        sourceText,
+      ].join('\n'),
+    },
+  ];
+}
+
+function buildQuizPrompt(
+  lectureTitle: string,
+  courseTitle: string,
+  sourceText: string,
+  input: AIQuizRequest,
+): OllamaChatMessage[] {
+  const count = Math.max(1, Math.min(5, input.count ?? 4));
+  const difficulty = input.difficulty ?? 'medium';
+
+  return [
+    {
+      role: 'system',
+      content:
+        'You are a careful quiz writer. Return valid JSON only. Do not wrap the response in markdown or prose.',
+    },
+    {
+      role: 'user',
+      content: [
+        `Lecture title: ${lectureTitle}`,
+        `Course title: ${courseTitle}`,
+        `Difficulty: ${difficulty}`,
+        `Question count: ${count}`,
+        'Return JSON with the following shape:',
+        '{"title":"string","difficulty":"easy|medium|hard","questions":[{"question":"string","choices":["string","string","string","string"],"correct_choice_index":0,"explanation":"string"}]}',
+        'Rules:',
+        '- Use only the provided source text.',
+        '- Create exactly four choices per question.',
+        '- Keep one clearly correct choice per question.',
+        '- Explanations should be short and grounded in the lecture.',
+        '- Output between 1 and 5 questions.',
+        'Source text:',
+        sourceText,
+      ].join('\n'),
+    },
+  ];
+}
+
+function getLectureSourceText(lectureId: string): { lectureTitle: string; courseTitle: string; sourceText: string } | null {
+  const lecture = getLectureDetail(lectureId);
+  if (!lecture) {
+    return null;
+  }
+
+  const transcript = getLectureTranscript(lecture.id);
+  const note = listLectureNotes(lecture.id)[0];
+  const sourceText = normalizeText(note?.content ?? transcript?.full_text ?? lecture.content_text);
+
+  return {
+    lectureTitle: lecture.title,
+    courseTitle: lecture.course_title,
+    sourceText,
+  };
+}
+
+function isRemoteFeatureEnabled(feature: 'summary' | 'quiz', preferredProvider?: AIProviderName): boolean {
+  const provider = getAIProviderSelection(feature, preferredProvider);
+  return provider.current_provider === 'ollama';
+}
+
+export async function runAISummaryWithEngine(
+  input: AISummaryRequest,
+  preferredProvider?: AIProviderName,
+): Promise<AISummaryResult | null> {
+  const fallback = createAISummary(input);
+  if (!fallback) {
+    return null;
+  }
+
+  const source = getLectureSourceText(input.lecture_id);
+
+  if (!source || !isRemoteFeatureEnabled('summary', preferredProvider) || input.style === 'timeline') {
+    return fallback;
+  }
+
+  const messages = buildSummaryPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input.style, input.language);
+  const response = await runOllamaChat(messages);
+
+  if (!response) {
+    return fallback;
+  }
+
+  const parsed = parseJsonObject(response);
+  if (!parsed) {
+    return fallback;
+  }
+
+  const title = pickString(parsed.title, fallback.title ?? `${source.lectureTitle} · 요약`);
+  const content = pickString(parsed.content, fallback.content ?? '');
+  const keyPoints = toStringArray(parsed.key_points);
+
+  if (!content) {
+    return fallback;
+  }
+
+  return {
+    lecture_id: input.lecture_id,
+    title,
+    style: input.style ?? 'brief',
+    language: input.language ?? 'ko',
+    content,
+    key_points: keyPoints.length > 0 ? keyPoints.slice(0, 5) : fallback.key_points,
+    references: fallback.references,
+  };
+}
+
+export async function runAIQuizWithEngine(
+  input: AIQuizRequest,
+  preferredProvider?: AIProviderName,
+): Promise<AIQuizResult | null> {
+  const fallback = generateAIQuiz(input);
+  if (!fallback) {
+    return null;
+  }
+
+  const source = getLectureSourceText(input.lecture_id);
+
+  if (!source || !isRemoteFeatureEnabled('quiz', preferredProvider)) {
+    return fallback;
+  }
+
+  const messages = buildQuizPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input);
+  const response = await runOllamaChat(messages);
+
+  if (!response) {
+    return fallback;
+  }
+
+  const parsed = parseJsonObject(response);
+  if (!parsed) {
+    return fallback;
+  }
+
+  const fallbackQuestions = fallback?.questions ?? [];
+  const engineQuestions = Array.isArray(parsed.questions) ? parsed.questions : [];
+
+  if (fallbackQuestions.length === 0 || engineQuestions.length === 0) {
+    return fallback;
+  }
+
+  const questions = fallbackQuestions.map((fallbackQuestion, index) => {
+    const engineQuestion = engineQuestions[index] as JsonObject | undefined;
+    return normalizeQuizQuestion(engineQuestion, fallbackQuestion);
+  });
+
+  return {
+    lecture_id: input.lecture_id,
+    title: pickString(parsed.title, fallback.title),
+    difficulty: pickDifficulty(parsed.difficulty, fallback.difficulty),
+    questions,
+  };
+}

--- a/backend/src/lib/providers/index.ts
+++ b/backend/src/lib/providers/index.ts
@@ -1,0 +1,1 @@
+export { runOllamaChat, type OllamaChatMessage } from './ollama';

--- a/backend/src/lib/providers/ollama.ts
+++ b/backend/src/lib/providers/ollama.ts
@@ -1,0 +1,79 @@
+type RuntimeLike = {
+  process?: {
+    env?: Record<string, string | undefined>;
+  };
+};
+
+export type OllamaChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+type OllamaChatResponse = {
+  message?: {
+    role?: string;
+    content?: string;
+  };
+};
+
+function readRuntimeEnv(key: string): string | undefined {
+  const runtime = globalThis as RuntimeLike;
+  return runtime.process?.env?.[key];
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function getOllamaBaseUrl(): string {
+  return (
+    readRuntimeEnv('MYWAY_OLLAMA_BASE_URL') ??
+    readRuntimeEnv('OLLAMA_BASE_URL') ??
+    'http://127.0.0.1:11434'
+  );
+}
+
+function getOllamaModel(): string {
+  return readRuntimeEnv('MYWAY_OLLAMA_MODEL') ?? readRuntimeEnv('OLLAMA_MODEL') ?? 'llama3.1';
+}
+
+function extractChatContent(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const response = payload as OllamaChatResponse;
+  const content = response.message?.content?.trim();
+
+  return content ? content : null;
+}
+
+export async function runOllamaChat(
+  messages: OllamaChatMessage[],
+  options?: {
+    model?: string;
+    temperature?: number;
+  },
+): Promise<string | null> {
+  const response = await fetch(`${trimTrailingSlash(getOllamaBaseUrl())}/api/chat`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: options?.model ?? getOllamaModel(),
+      messages,
+      stream: false,
+      options: {
+        temperature: options?.temperature ?? 0.2,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json()) as unknown;
+  return extractChatContent(payload);
+}

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -92,7 +92,7 @@ ai.post('/summary', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  const result = runAISummary({
+  const result = await runAISummary({
     lecture_id: lectureId,
     style: body?.style ?? 'brief',
     language: body?.language ?? 'ko',
@@ -117,7 +117,7 @@ ai.post('/quiz', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  const result = runAIQuiz({
+  const result = await runAIQuiz({
     lecture_id: lectureId,
     count: body?.count,
     difficulty: body?.difficulty,

--- a/docs/ai-context/agent.md
+++ b/docs/ai-context/agent.md
@@ -15,7 +15,8 @@
 ## 읽는 순서
 1. 루트 `agent.md`
 2. `docs/ai-context/harness-engineering.md`
-3. 필요한 경우 `docs/dev-logs/`와 관련 문서
+3. `docs/ai-context/ai-engine-provider-connection.md`
+4. 필요한 경우 `docs/dev-logs/`와 관련 문서
 
 ## 특화 규칙
 - 이 문서는 루트 규칙을 반복하지 않는다.

--- a/docs/ai-context/ai-engine-provider-connection.md
+++ b/docs/ai-context/ai-engine-provider-connection.md
@@ -1,0 +1,68 @@
+# AI Engine Provider Connection Guide
+
+## 목적
+실제 AI provider 엔진을 붙일 때, 어떤 파일만 바꾸면 되는지 한눈에 보이게 정리한다.
+
+## 적용 범위
+- backend 내부 provider 클라이언트
+- backend 엔진 오케스트레이션
+- route 비동기 연결
+- 문서와 dev-log 반영
+
+## 기본 원칙
+- provider 카탈로그와 실제 호출 코드는 분리한다.
+- route는 얇게 유지하고, 실제 호출은 `backend/src/lib/` 아래에서 처리한다.
+- 처음 연결한 provider가 실패하면 기존 shared fallback으로 되돌아간다.
+- 실제 엔진 연결은 한 기능부터 시작한다. `summary` 또는 `quiz` 같은 JSON 결과형이 가장 안전하다.
+
+## 추천 파일 구조
+- `backend/src/lib/providers/<provider>.ts`
+  - 실제 HTTP 호출 또는 SDK 호출만 둔다.
+- `backend/src/lib/ai-engine.ts`
+  - provider 선택 후 prompt 생성, JSON 파싱, fallback 처리만 둔다.
+- `backend/src/lib/ai-adapter.ts`
+  - feature별 실행 진입점만 제공한다.
+- `backend/src/routes/ai.ts`
+  - 요청 검증과 응답 반환만 담당한다.
+
+## 실제 연결 순서
+1. 먼저 하나의 provider만 고른다.
+2. provider별 호출 함수를 만든다.
+3. 엔진 wrapper에서 prompt와 응답 파싱 규칙을 정한다.
+4. fallback을 shared 구현으로 연결한다.
+5. route를 async로 바꿔 엔진 wrapper를 호출한다.
+6. 실패 시 기존 응답 형태가 유지되는지 확인한다.
+
+## provider 클라이언트 체크리스트
+- base URL과 모델 이름은 env로 받는다.
+- timeout과 실패 시 null 반환 규칙을 정한다.
+- 응답은 가능한 한 JSON only 프롬프트로 유도한다.
+- 응답 파싱 실패 시 fallback으로 돌린다.
+- provider가 없으면 demo 경로를 유지한다.
+
+## 엔진 wrapper 체크리스트
+- 입력은 shared request 타입을 그대로 쓴다.
+- lecture가 없으면 바로 null 또는 fallback을 반환한다.
+- source text는 transcript, note, lecture content 순으로 고른다.
+- prompt는 짧고 명시적으로 쓴다.
+- JSON 파싱 실패 시 shared 로직으로 되돌린다.
+- 결과에 필요한 필드만 덮어쓴다.
+
+## 우선 적용하기 좋은 순서
+1. `summary`
+2. `quiz`
+3. `answer`
+4. `search`
+5. `smart`
+6. `intent`
+
+## 검증 기준
+- backend build가 통과한다.
+- 실제 provider가 죽어도 기존 기능이 살아 있다.
+- API 응답 shape가 바뀌지 않는다.
+- provider와 fallback 기준이 `docs/project/14-ai-layer.md`와 일치한다.
+
+## 변경 시 함께 고칠 문서
+- `docs/project/14-ai-layer.md`
+- `docs/project/15-api-map.md`
+- `docs/dev-logs/`

--- a/docs/dev-logs/2026-04-09-ai-engine-provider-connection-guide.md
+++ b/docs/dev-logs/2026-04-09-ai-engine-provider-connection-guide.md
@@ -1,0 +1,13 @@
+# AI Engine Provider Connection Guide
+
+## 배경
+- 실제 AI 엔진 연결을 나중에 다시 할 때, 어느 파일만 건드리면 되는지 빠르게 찾을 수 있어야 했다.
+- 구현 코드와 문서를 분리한 뒤에도 연결 절차가 사라지지 않도록, 짧은 가이드를 남겼다.
+
+## 변경 내용
+- `docs/ai-context/ai-engine-provider-connection.md`를 추가해 provider 클라이언트, engine wrapper, route 연결 순서를 정리했다.
+- `docs/ai-context/agent.md`에 새 가이드의 읽는 순서를 추가했다.
+
+## 검증 포인트
+- 새로 들어오는 AI 연결 작업은 이 문서만 보고도 backend 변경 지점을 찾을 수 있다.
+- `summary`와 `quiz` 같은 JSON 결과형부터 붙이면 안전하다.

--- a/docs/dev-logs/2026-04-09-ai-engine-provider-split.md
+++ b/docs/dev-logs/2026-04-09-ai-engine-provider-split.md
@@ -1,0 +1,15 @@
+# AI Engine Provider Split
+
+## 배경
+- AI provider 카탈로그와 fallback 계획은 있었지만, 실제 엔진 호출 코드는 아직 없었다.
+- summary와 quiz는 JSON 형태로 안정적으로 검증할 수 있어서 첫 실제 엔진 적용 대상으로 잡았다.
+
+## 변경 내용
+- `backend/src/lib/providers/ollama.ts`와 `backend/src/lib/providers/index.ts`를 추가해 Ollama HTTP 호출을 backend 내부 provider 클라이언트로 분리했다.
+- `backend/src/lib/ai-engine.ts`를 추가해 summary와 quiz에 대해 Ollama 응답을 먼저 시도하고, 실패 시 기존 shared fallback으로 되돌아가게 했다.
+- `backend/src/lib/ai-adapter.ts`와 `backend/src/routes/ai.ts`를 비동기 처리로 바꿔 실제 엔진 호출을 route 경로에 연결했다.
+
+## 검증 포인트
+- Ollama 응답이 JSON이 아니거나 연결되지 않으면 기존 요약/퀴즈 생성 로직으로 안전하게 fallback한다.
+- summary가 `timeline` 스타일일 때는 아직 기존 shared 로직을 유지한다.
+- provider 분리는 유지하면서도 기존 API 응답 형태는 바꾸지 않는다.

--- a/docs/project/14-ai-layer.md
+++ b/docs/project/14-ai-layer.md
@@ -80,6 +80,7 @@
 - 향후 운영 경로는 `Ollama -> Gemini -> Cloudflare AI -> demo` 순의 fallback 계층을 기본으로 둔다.
 - `STT`와 `embedding`은 `Cloudflare AI`를 우선 고려하고, 텍스트 생성 계열은 `Ollama`를 우선 고려한다.
 - provider 선택과 fallback 순서는 `GET /api/v1/ai/providers`로 조회할 수 있다.
+- backend는 `summary`와 `quiz`에서 Ollama가 가능할 때 실제 JSON 생성 응답을 먼저 시도하고, 실패하면 기존 shared fallback으로 되돌아간다.
 
 ## 현재 구현
 - `POST /api/v1/ai/intent`로 사용자 메시지의 의도를 분류한다.
@@ -87,6 +88,7 @@
 - `POST /api/v1/ai/answer`로 질문 응답과 근거 참조를 함께 돌려준다.
 - `POST /api/v1/ai/summary`로 강의 요약을 생성한다.
 - `POST /api/v1/ai/quiz`로 강의 기반 퀴즈를 생성한다.
+- `POST /api/v1/ai/summary`와 `POST /api/v1/ai/quiz`는 가능한 경우 Ollama 엔진 결과를 우선 사용하고, 실패 시 shared fallback을 사용한다.
 - `GET /api/v1/ai/insights`로 AI 사용량과 역할별 인사이트를 조회한다.
 - `GET /api/v1/ai/providers`로 provider 계층과 fallback 순서를 조회한다.
 - `POST /api/v1/smart/chat`로 의도 분류와 응답 라우팅을 한 번에 처리한다.


### PR DESCRIPTION
# 변경 요약
backend에 provider 호출 레이어를 분리하고, summary와 quiz는 실제 Ollama 호출을 먼저 시도한 뒤 shared fallback으로 되돌아가게 했습니다.

## 배경
AI provider 카탈로그와 fallback 계획만 있으면 실제 엔진을 나중에 쉽게 붙이기 어려워서, backend 내부에 호출 레이어와 연결 가이드를 분리해 두었습니다.

## 변경 내용
- backend/src/lib/providers/ollama.ts와 backend/src/lib/providers/index.ts를 추가했습니다.
- backend/src/lib/ai-engine.ts를 추가해 summary와 quiz에 대해 Ollama JSON 응답을 우선 시도하고 실패 시 shared fallback으로 되돌아가게 했습니다.
- backend/src/lib/ai-adapter.ts와 backend/src/routes/ai.ts를 비동기 흐름으로 바꿨습니다.
- docs/ai-context/ai-engine-provider-connection.md를 추가해 나중에 실제 엔진을 붙일 때 바꿔야 하는 파일만 빠르게 찾을 수 있게 했습니다.
- docs/project/14-ai-layer.md와 docs/dev-logs/를 갱신했습니다.

## 연결 이슈
- Closes none
- Fixes none

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 frontend 담당자 확인이 필요하다
- [x] 백엔드 변경이면 backend 담당자 확인이 필요하다
- [x] 문서 변경이면 docs 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 packages/shared 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] docs/dev-logs에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다