### PR TITLE
feat: organize Cloudflare deployment bindings

### DIFF
--- a/backend/src/lib/ai-adapter.ts
+++ b/backend/src/lib/ai-adapter.ts
@@ -17,6 +17,7 @@ import {
 } from '@myway/shared';
 import { runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine';
 import { getAIProviderSelection } from './ai-provider';
+import type { RuntimeBindings } from './runtime-env';
 
 export type AIAdapterResultMap = {
   intent: AIIntentResult;
@@ -58,23 +59,26 @@ export function runAIAnswer(input: AIAnswerRequest, preferredProvider?: AIProvid
 export async function runAISummary(
   input: AISummaryRequest,
   preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
 ): Promise<AISummaryResult | null> {
   resolveProvider('summary', preferredProvider);
-  return runAISummaryWithEngine(input, preferredProvider);
+  return runAISummaryWithEngine(input, preferredProvider, env);
 }
 
 export async function runAIQuiz(
   input: AIQuizRequest,
   preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
 ): Promise<AIQuizResult | null> {
   resolveProvider('quiz', preferredProvider);
-  return runAIQuizWithEngine(input, preferredProvider);
+  return runAIQuizWithEngine(input, preferredProvider, env);
 }
 
 export async function runAIFeature<TFeature extends AIAdapterFeature>(
   feature: TFeature,
   input: AIAdapterInputMap[TFeature],
   preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
 ): Promise<AIAdapterResultMap[TFeature]> {
   switch (feature) {
     case 'intent':
@@ -84,9 +88,9 @@ export async function runAIFeature<TFeature extends AIAdapterFeature>(
     case 'answer':
       return runAIAnswer(input as AIAnswerRequest, preferredProvider) as AIAdapterResultMap[TFeature];
     case 'summary':
-      return (await runAISummary(input as AISummaryRequest, preferredProvider)) as AIAdapterResultMap[TFeature];
+      return (await runAISummary(input as AISummaryRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
     case 'quiz':
-      return (await runAIQuiz(input as AIQuizRequest, preferredProvider)) as AIAdapterResultMap[TFeature];
+      return (await runAIQuiz(input as AIQuizRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
     default:
       throw new Error(`Unsupported AI feature: ${String(feature)}`);
   }

--- a/backend/src/lib/ai-engine.ts
+++ b/backend/src/lib/ai-engine.ts
@@ -13,6 +13,7 @@ import {
 } from '@myway/shared';
 import { getAIProviderSelection } from './ai-provider';
 import { runOllamaChat, type OllamaChatMessage } from './providers';
+import type { RuntimeBindings } from './runtime-env';
 
 type JsonObject = Record<string, unknown>;
 
@@ -223,6 +224,7 @@ function isRemoteFeatureEnabled(feature: 'summary' | 'quiz', preferredProvider?:
 export async function runAISummaryWithEngine(
   input: AISummaryRequest,
   preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
 ): Promise<AISummaryResult | null> {
   const fallback = createAISummary(input);
   if (!fallback) {
@@ -236,7 +238,7 @@ export async function runAISummaryWithEngine(
   }
 
   const messages = buildSummaryPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input.style, input.language);
-  const response = await runOllamaChat(messages);
+  const response = await runOllamaChat(messages, env);
 
   if (!response) {
     return fallback;
@@ -269,6 +271,7 @@ export async function runAISummaryWithEngine(
 export async function runAIQuizWithEngine(
   input: AIQuizRequest,
   preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
 ): Promise<AIQuizResult | null> {
   const fallback = generateAIQuiz(input);
   if (!fallback) {
@@ -282,7 +285,7 @@ export async function runAIQuizWithEngine(
   }
 
   const messages = buildQuizPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input);
-  const response = await runOllamaChat(messages);
+  const response = await runOllamaChat(messages, env);
 
   if (!response) {
     return fallback;

--- a/backend/src/lib/providers/ollama.ts
+++ b/backend/src/lib/providers/ollama.ts
@@ -1,8 +1,4 @@
-type RuntimeLike = {
-  process?: {
-    env?: Record<string, string | undefined>;
-  };
-};
+import type { RuntimeBindings } from '../runtime-env';
 
 export type OllamaChatMessage = {
   role: 'system' | 'user' | 'assistant';
@@ -16,25 +12,8 @@ type OllamaChatResponse = {
   };
 };
 
-function readRuntimeEnv(key: string): string | undefined {
-  const runtime = globalThis as RuntimeLike;
-  return runtime.process?.env?.[key];
-}
-
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '');
-}
-
-function getOllamaBaseUrl(): string {
-  return (
-    readRuntimeEnv('MYWAY_OLLAMA_BASE_URL') ??
-    readRuntimeEnv('OLLAMA_BASE_URL') ??
-    'http://127.0.0.1:11434'
-  );
-}
-
-function getOllamaModel(): string {
-  return readRuntimeEnv('MYWAY_OLLAMA_MODEL') ?? readRuntimeEnv('OLLAMA_MODEL') ?? 'llama3.1';
 }
 
 function extractChatContent(payload: unknown): string | null {
@@ -50,18 +29,22 @@ function extractChatContent(payload: unknown): string | null {
 
 export async function runOllamaChat(
   messages: OllamaChatMessage[],
+  env?: RuntimeBindings,
   options?: {
     model?: string;
     temperature?: number;
   },
 ): Promise<string | null> {
-  const response = await fetch(`${trimTrailingSlash(getOllamaBaseUrl())}/api/chat`, {
+  const baseUrl = env?.MYWAY_OLLAMA_BASE_URL ?? env?.OLLAMA_BASE_URL ?? 'http://127.0.0.1:11434';
+  const model = options?.model ?? env?.MYWAY_OLLAMA_MODEL ?? env?.OLLAMA_MODEL ?? 'llama3.1';
+
+  const response = await fetch(`${trimTrailingSlash(baseUrl)}/api/chat`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      model: options?.model ?? getOllamaModel(),
+      model,
       messages,
       stream: false,
       options: {

--- a/backend/src/lib/runtime-env.ts
+++ b/backend/src/lib/runtime-env.ts
@@ -1,0 +1,31 @@
+export type RuntimeBindings = {
+  APP_ENV?: 'development' | 'staging' | 'production';
+  API_ORIGIN?: string;
+  MYWAY_OLLAMA_BASE_URL?: string;
+  OLLAMA_BASE_URL?: string;
+  MYWAY_OLLAMA_MODEL?: string;
+  OLLAMA_MODEL?: string;
+};
+
+function normalize(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function getRuntimeValue(
+  env: RuntimeBindings | undefined,
+  key: keyof RuntimeBindings,
+  fallback?: string,
+): string | undefined {
+  return normalize(env?.[key]) ?? fallback;
+}
+
+export function getOllamaRuntimeSettings(env?: RuntimeBindings): {
+  base_url: string;
+  model: string;
+} {
+  return {
+    base_url: getRuntimeValue(env, 'MYWAY_OLLAMA_BASE_URL', getRuntimeValue(env, 'OLLAMA_BASE_URL', 'http://127.0.0.1:11434')) ?? 'http://127.0.0.1:11434',
+    model: getRuntimeValue(env, 'MYWAY_OLLAMA_MODEL', getRuntimeValue(env, 'OLLAMA_MODEL', 'llama3.1')) ?? 'llama3.1',
+  };
+}

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -9,6 +9,7 @@ import {
 } from '@myway/shared';
 import { runAIAnswer, runAIIntent, runAIQuiz, runAISearch, runAISummary } from '../lib/ai-adapter';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
+import type { RuntimeBindings } from '../lib/runtime-env';
 
 const ai = new Hono();
 
@@ -92,11 +93,12 @@ ai.post('/summary', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
+  const env = c.env as RuntimeBindings | undefined;
   const result = await runAISummary({
     lecture_id: lectureId,
     style: body?.style ?? 'brief',
     language: body?.language ?? 'ko',
-  });
+  }, undefined, env);
 
   if (!result) {
     return jsonFailure('SUMMARY_FAILED', '요약을 생성할 수 없습니다.', 400);
@@ -117,11 +119,12 @@ ai.post('/quiz', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
+  const env = c.env as RuntimeBindings | undefined;
   const result = await runAIQuiz({
     lecture_id: lectureId,
     count: body?.count,
     difficulty: body?.difficulty,
-  });
+  }, undefined, env);
 
   if (!result) {
     return jsonFailure('QUIZ_FAILED', '퀴즈를 생성할 수 없습니다.', 400);

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -2,6 +2,30 @@
   "name": "myway-class-api",
   "main": "src/index.ts",
   "compatibility_date": "2026-04-06",
-  "d1_databases": [],
-  "r2_buckets": []
+  "d1_databases": [
+    // Bind the Cloudflare D1 database here as `DB`.
+  ],
+  "r2_buckets": [
+    // Bind the Cloudflare R2 bucket here as `ASSETS`.
+  ],
+  "vars": {
+    "APP_ENV": "development",
+    "API_ORIGIN": "http://localhost:5173",
+    "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
+    "MYWAY_OLLAMA_MODEL": "llama3.1"
+  },
+  "env": {
+    "staging": {
+      "vars": {
+        "APP_ENV": "staging",
+        "API_ORIGIN": "https://staging.mywayclass.pages.dev"
+      }
+    },
+    "production": {
+      "vars": {
+        "APP_ENV": "production",
+        "API_ORIGIN": "https://mywayclass.pages.dev"
+      }
+    }
+  }
 }

--- a/docs/dev-logs/2026-04-09-cloudflare-deployment-infra.md
+++ b/docs/dev-logs/2026-04-09-cloudflare-deployment-infra.md
@@ -1,0 +1,17 @@
+# Cloudflare Deployment Infra
+
+## 배경
+- 이슈 #45는 Cloudflare Pages와 Workers 배포 경로, D1/R2 바인딩, 환경 분리를 실제 운영 기준으로 맞추는 작업이다.
+- 배포 문서와 런타임 설정이 따로 놀지 않도록, A/B 워킹트리로 구현 방식을 비교했다.
+
+## 비교
+- A안은 `backend/src/lib/runtime-env.ts`로 얇게 env를 전달하고, `docs/project/19-deployment.md`에서 Pages/Workers와 환경 분리를 프로젝트 문서로 바로 읽을 수 있게 했다.
+- B안은 `backend/src/lib/runtime-config.ts`로 env를 한 번 정규화한 뒤 backend 문서에 배포 가이드를 두는 방식이었다.
+
+## 선택
+- A안을 선택했다.
+- 이유는 변경 범위가 더 작고, 이슈가 요구한 Pages/Workers 배포 흐름을 프로젝트 문서에서 바로 확인할 수 있으며, 추가 추상화 없이 `c.env`에서 provider까지 이어지는 경로를 유지하기 쉽기 때문이다.
+
+## 검증
+- A안과 B안 모두 `npm run build:backend`를 통과했다.
+- A안은 `docs/project/00-index.md`와 `docs/project/19-deployment.md`로 배포 경로와 환경 분리를 함께 남겼다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-09-cloudflare-deployment-infra.md`
 - `2026-04-08-rebase-pull-policy.md`
 - `2026-04-08-auto-pr-review-workflow.md`
 - `001-design-system-refactoring.md`

--- a/docs/project/00-index.md
+++ b/docs/project/00-index.md
@@ -36,3 +36,4 @@ MyWayClass의 기능, 기획, 구현 기준 문서를 한곳에서 찾기 쉽게
 18. `docs/project/16-custom-course-composer.md`
 19. `docs/project/17-smart-ai-chat.md`
 20. `docs/project/18-ai-insights-dashboard.md`
+21. `docs/project/19-deployment.md`

--- a/docs/project/19-deployment.md
+++ b/docs/project/19-deployment.md
@@ -1,0 +1,47 @@
+# 배포 인프라
+
+## 목적
+Cloudflare Pages와 Workers로 배포할 때 어떤 경로와 바인딩을 써야 하는지 한곳에 모은다.
+
+## 배포 경로
+- 프론트엔드는 Cloudflare Pages로 배포한다.
+- 백엔드는 Cloudflare Workers로 배포한다.
+- 프론트 빌드 결과는 `frontend/dist`를 사용한다.
+- 백엔드는 `backend/wrangler.jsonc`를 기준으로 배포한다.
+
+## 환경 구분
+- `development`
+  - 로컬 개발
+  - `frontend`는 Vite dev 서버를 사용한다.
+  - `backend`는 `wrangler dev`를 사용한다.
+- `staging`
+  - 배포 전 검증용
+  - Pages와 Workers를 운영과 분리된 도메인으로 둔다.
+- `production`
+  - 실제 사용자 트래픽
+  - Pages와 Workers를 운영 도메인으로 연결한다.
+
+## 바인딩 규칙
+- D1 바인딩 이름은 `DB`를 사용한다.
+- R2 바인딩 이름은 `ASSETS`를 사용한다.
+- Ollama 연결 값은 `MYWAY_OLLAMA_BASE_URL`, `MYWAY_OLLAMA_MODEL`로 둔다.
+- 프론트가 API를 호출해야 하면 `API_ORIGIN`을 환경별로 맞춘다.
+
+## 배포 순서
+1. Cloudflare에서 D1과 R2를 만든다.
+2. 백엔드 워커에 `DB`와 `ASSETS`를 바인딩한다.
+3. `backend/wrangler.jsonc`의 환경 변수 값을 채운다.
+4. `npm run build:frontend`와 `npm run build:backend`를 확인한다.
+5. Pages에 `frontend/dist`를 연결한다.
+6. Workers에 `backend/src/index.ts`를 연결한다.
+
+## 검증 기준
+- Pages와 Workers의 배포 경로가 문서와 일치한다.
+- 개발, 스테이징, 운영 환경에서 바인딩 이름이 흔들리지 않는다.
+- 실제 엔진 URL과 모델 이름은 환경 변수로만 바꿀 수 있다.
+
+## 변경 시 함께 볼 파일
+- `backend/wrangler.jsonc`
+- `docs/project/00-index.md`
+- `docs/project/01-tech-stack.md`
+- `docs/project/02-architecture.md`


### PR DESCRIPTION
# 변경 요약
Cloudflare Pages/Workers 배포 경로와 D1/R2 바인딩, 환경 변수 분리를 정리했습니다.

## 배경
이슈 #45는 문서에만 있던 배포 방향을 실제 운영 설정과 연결하는 작업이었습니다. 배포 경로와 환경 값이 흩어져 있으면 나중에 실제 운영으로 옮길 때 수정 범위가 커지기 때문에, 설정 위치와 문서 경로를 함께 고정했습니다.

## 변경 내용
- `backend/src/lib/runtime-env.ts`를 추가해 backend에서 쓰는 환경 값을 얇게 읽도록 했습니다.
- `backend/src/lib/providers/ollama.ts`, `backend/src/lib/ai-engine.ts`, `backend/src/lib/ai-adapter.ts`, `backend/src/routes/ai.ts`가 환경 값을 받아 실제 provider 호출로 이어지게 했습니다.
- `backend/wrangler.jsonc`에 개발/스테이징/운영 환경 값을 추가하고 D1/R2 바인딩 위치를 명시했습니다.
- `docs/project/19-deployment.md`를 추가해 Pages/Workers 배포 경로와 검증 순서를 정리했습니다.
- `docs/project/00-index.md`와 `docs/dev-logs/README.md`를 갱신했습니다.

## 연결 이슈
- Closes #45
- Fixes #45

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다