### PR TITLE
feat: add course metadata detail page

### DIFF
--- a/docs/dev-logs/2026-04-09-course-metadata-detail-page.md
+++ b/docs/dev-logs/2026-04-09-course-metadata-detail-page.md
@@ -1,0 +1,16 @@
+# 2026-04-09 코스 메타데이터 상세 페이지
+
+## 한줄 요약
+코스 카드와 강의 상세에 썸네일 팔레트, 평점, 수강생 수, 총 러닝타임, 비디오 URL, transcript excerpt, keywords를 추가하고 상세 페이지를 확장했다.
+
+## 구현 내용
+- `CourseCard`에 `thumbnail_palette`, `rating`, `student_count`, `total_duration_minutes`를 추가했다.
+- `LectureDetail`에 `video_url`, `transcript_excerpt`, `keywords`를 추가했다.
+- shared learning helper에서 코스/강의 메타데이터를 계산하도록 정리했다.
+- `CoursesPage`를 카드형 상세 레이아웃으로 바꿔 코스 목록, 코스 상세, 강의 상세, 강의 목록을 한 화면에서 볼 수 있게 했다.
+- `RolePageRouter`와 `LmsDashboard`에서 새 상세 props를 전달하도록 연결했다.
+
+## 검증
+- `npm exec --workspace @myway/frontend -- tsc -p tsconfig.json --noEmit` 통과
+- `npm run build:backend`는 현재 환경에서 `@cloudflare/workers-types` 타입 정의를 찾지 못해 실패
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -240,15 +240,7 @@ export default function App() {
     refreshLearningState: (activeSession: LoginResponse | null) => refreshLearningState(learningDeps, activeSession),
     setInsights,
   };
-  const highlightedLecture =
-    selectedLecture ??
-    (selectedCourse?.lectures[0]
-      ? {
-          ...selectedCourse.lectures[0],
-          course_title: selectedCourse.title,
-          course_instructor: selectedCourse.instructor_name,
-        }
-      : null);
+  const highlightedLecture = selectedLecture ?? null;
   return (
     <LmsDashboard
       busy={busy}

--- a/frontend/src/components/LmsDashboard.tsx
+++ b/frontend/src/components/LmsDashboard.tsx
@@ -36,8 +36,10 @@ export function LmsDashboard(props: LmsDashboardProps) {
         insights={props.insights}
         providers={props.providers}
         onSelectCourse={props.onSelectCourse}
+        onSelectLecture={props.onSelectLecture}
         demoUsers={props.demoUsers}
         selectedCourse={props.selectedCourse}
+        selectedLectureId={props.selectedLectureId}
       />
     </AppShell>
   );

--- a/frontend/src/features/lms/pages/CoursesPage.tsx
+++ b/frontend/src/features/lms/pages/CoursesPage.tsx
@@ -1,8 +1,12 @@
-import type { CourseCard } from '@myway/shared';
+import type { CourseCard, CourseDetail, LectureDetail } from '@myway/shared';
 
 type CoursesPageProps = {
   courses: CourseCard[];
+  selectedCourse: CourseDetail | null;
+  highlightedLecture: LectureDetail | null;
+  selectedLectureId: string;
   onSelectCourse: (courseId: string) => void;
+  onSelectLecture: (lectureId: string) => void;
 };
 
 const difficultyLabel: Record<CourseCard['difficulty'], string> = {
@@ -11,43 +15,288 @@ const difficultyLabel: Record<CourseCard['difficulty'], string> = {
   advanced: '고급',
 };
 
-export function CoursesPage({ courses, onSelectCourse }: CoursesPageProps) {
+const paletteClasses: Record<CourseCard['thumbnail_palette'], { panel: string; chip: string; line: string; icon: string }> = {
+  indigo: {
+    panel: 'bg-[linear-gradient(135deg,#4338ca,#1d4ed8)]',
+    chip: 'bg-indigo-50 text-indigo-600',
+    line: 'bg-indigo-500',
+    icon: 'ri-brain-line',
+  },
+  emerald: {
+    panel: 'bg-[linear-gradient(135deg,#047857,#10b981)]',
+    chip: 'bg-emerald-50 text-emerald-600',
+    line: 'bg-emerald-500',
+    icon: 'ri-layout-grid-line',
+  },
+  violet: {
+    panel: 'bg-[linear-gradient(135deg,#6d28d9,#8b5cf6)]',
+    chip: 'bg-violet-50 text-violet-600',
+    line: 'bg-violet-500',
+    icon: 'ri-video-line',
+  },
+  amber: {
+    panel: 'bg-[linear-gradient(135deg,#b45309,#f59e0b)]',
+    chip: 'bg-amber-50 text-amber-700',
+    line: 'bg-amber-500',
+    icon: 'ri-lightbulb-flash-line',
+  },
+};
+
+function formatDuration(minutes: number): string {
+  if (minutes < 60) {
+    return `${minutes}분`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remain = minutes % 60;
+  return remain > 0 ? `${hours}시간 ${remain}분` : `${hours}시간`;
+}
+
+function formatLectureUrl(url: string): string {
+  return url.replace('/static/media/', '/media/');
+}
+
+function formatLectureLabel(lectureId: string): string {
+  return lectureId.replace(/^lec_/, '').toUpperCase();
+}
+
+export function CoursesPage({
+  courses,
+  selectedCourse,
+  highlightedLecture,
+  selectedLectureId,
+  onSelectCourse,
+  onSelectLecture,
+}: CoursesPageProps) {
+  const course = selectedCourse;
+  const detailLecture = highlightedLecture;
+
   return (
-    <div className="space-y-5">
-      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-[15px] font-bold text-slate-900">강의 목록</h2>
-            <p className="mt-1 text-[12px] text-slate-500">우리 프로젝트의 코스 데이터를 레퍼런스 스타일 카드에 연결한 화면입니다.</p>
+    <div className="grid grid-cols-1 gap-5 xl:grid-cols-[1.05fr_0.95fr]">
+      <section className="space-y-5">
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <h2 className="text-[15px] font-bold text-slate-900">강의 목록</h2>
+              <p className="mt-1 text-[12px] text-slate-500">
+                썸네일, 평점, 수강생 수, 총 러닝타임을 함께 보여주어 코스 선택에 필요한 신호를 한눈에 확인합니다.
+              </p>
+            </div>
+            <span className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">{courses.length}개 강의</span>
           </div>
-          <span className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">{courses.length}개 강의</span>
-        </div>
+        </article>
+
+        <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-2">
+          {courses.map((course) => {
+            const palette = paletteClasses[course.thumbnail_palette];
+            const selected = selectedCourse?.id === course.id;
+
+            return (
+              <button
+                key={course.id}
+                type="button"
+                onClick={() => onSelectCourse(course.id)}
+                className={`overflow-hidden rounded-3xl border bg-white text-left shadow-[0_1px_3px_rgba(15,23,42,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)] ${
+                  selected ? 'border-indigo-400 ring-2 ring-indigo-100' : 'border-slate-200'
+                }`}
+              >
+                <div className={`flex h-36 flex-col justify-between px-5 py-4 text-white ${palette.panel}`}>
+                  <div className="flex items-center justify-between gap-3 text-[11px] font-semibold opacity-90">
+                    <span>{course.category}</span>
+                    <span>{difficultyLabel[course.difficulty]}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="text-[14px] font-semibold opacity-90">{course.instructor_name}</div>
+                      <div className="mt-1 text-[20px] font-extrabold tracking-[-0.03em]">{course.title}</div>
+                    </div>
+                    <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-[24px]">
+                      <i className={palette.icon} />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="px-5 py-4">
+                  <div className="mb-3 flex flex-wrap items-center gap-2">
+                    <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${palette.chip}`}>{course.rating.toFixed(1)}점</span>
+                    <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">
+                      수강생 {course.student_count}명
+                    </span>
+                    <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">
+                      {formatDuration(course.total_duration_minutes)}
+                    </span>
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between text-[12px] text-slate-500">
+                      <span>{course.lecture_count}개 강의</span>
+                      <span>{course.enrolled ? `${course.progress_percent}% 진행` : course.category}</span>
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+                      <div className={`h-2 ${palette.line}`} style={{ width: `${Math.max(course.progress_percent, 12)}%` }} />
+                    </div>
+                  </div>
+
+                  <p className="mt-4 line-clamp-2 text-[13px] leading-6 text-slate-500">{course.description}</p>
+                </div>
+              </button>
+            );
+          })}
+        </section>
       </section>
 
-      <section className="grid grid-cols-1 gap-4 xl:grid-cols-3 md:grid-cols-2">
-        {courses.map((course) => (
-          <button
-            key={course.id}
-            type="button"
-            onClick={() => onSelectCourse(course.id)}
-            className="overflow-hidden rounded-3xl border border-slate-200 bg-white text-left shadow-[0_1px_3px_rgba(15,23,42,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)]"
-          >
-            <div className="h-32 bg-[linear-gradient(135deg,#eef2ff,#f5f3ff)]" />
-            <div className="px-5 py-4">
-              <div className="mb-3 flex items-center gap-2">
-                <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-600">{difficultyLabel[course.difficulty]}</span>
-                <span className="text-[12px] text-slate-400">{course.lecture_count} 강의</span>
+      <aside className="space-y-5">
+        <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="text-[15px] font-bold text-slate-900">코스 상세</h3>
+              <p className="mt-1 text-[12px] text-slate-500">선택한 코스의 전반적인 메타데이터와 강의 상세를 함께 확인합니다.</p>
+            </div>
+            {selectedCourse ? <span className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">{selectedCourse.category}</span> : null}
+          </div>
+
+          {course ? (
+            <div className="mt-4 space-y-4">
+              <div className={`overflow-hidden rounded-3xl ${paletteClasses[course.thumbnail_palette].panel} p-5 text-white`}>
+                <div className="flex items-center justify-between gap-3 text-[11px] font-semibold opacity-90">
+                  <span>{difficultyLabel[course.difficulty]}</span>
+                  <span>{course.rating.toFixed(1)} / 5.0</span>
+                </div>
+                <div className="mt-4 flex items-end justify-between gap-4">
+                  <div>
+                    <div className="text-[13px] font-semibold opacity-90">{course.instructor_name}</div>
+                    <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em]">{course.title}</div>
+                  </div>
+                  <div className="text-right text-[11px] opacity-90">
+                    <div>수강생 {course.student_count}명</div>
+                    <div>{formatDuration(course.total_duration_minutes)}</div>
+                  </div>
+                </div>
               </div>
-              <h3 className="text-[15px] font-bold leading-7 tracking-[-0.02em] text-slate-900">{course.title}</h3>
-              <p className="mt-2 line-clamp-2 text-[13px] leading-6 text-slate-500">{course.description}</p>
-              <div className="mt-4 flex items-center justify-between text-[12px] text-slate-500">
-                <span>{course.instructor_name}</span>
-                <span>{course.enrolled ? `${course.progress_percent}% 진행` : course.category}</span>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-2xl bg-slate-50 px-4 py-4">
+                  <div className="text-[12px] text-slate-500">총 강의 수</div>
+                  <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">{course.lecture_count}</div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-4">
+                  <div className="text-[12px] text-slate-500">총 러닝타임</div>
+                  <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">{formatDuration(course.total_duration_minutes)}</div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-4">
+                  <div className="text-[12px] text-slate-500">평점</div>
+                  <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">{course.rating.toFixed(1)}</div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-4">
+                  <div className="text-[12px] text-slate-500">수강생</div>
+                  <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">{course.student_count}</div>
+                </div>
+              </div>
+
+              <div>
+                <div className="text-[12px] font-semibold text-slate-500">설명</div>
+                <p className="mt-2 text-[13px] leading-7 text-slate-500">{course.description}</p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {course.tags.map((tag) => (
+                  <span key={tag} className="rounded-full border border-slate-200 px-3 py-1 text-[11px] text-slate-500">
+                    #{tag}
+                  </span>
+                ))}
               </div>
             </div>
-          </button>
-        ))}
-      </section>
+          ) : (
+            <p className="mt-4 text-[13px] leading-6 text-slate-500">코스를 선택하면 상세 메타데이터가 여기에 표시됩니다.</p>
+          )}
+        </section>
+
+        <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+          <h3 className="text-[15px] font-bold text-slate-900">강의 상세</h3>
+          {detailLecture ? (
+            <div className="mt-4 space-y-4">
+              <div className="rounded-3xl bg-slate-50 px-4 py-4">
+                <div className="text-[12px] text-slate-500">{detailLecture.course_title}</div>
+                <div className="mt-1 text-[16px] font-bold text-slate-900">{detailLecture.title}</div>
+                <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-slate-500">
+                  <span>{detailLecture.course_instructor}</span>
+                  <span>·</span>
+                  <span>{formatDuration(detailLecture.duration_minutes)}</span>
+                  <span>·</span>
+                  <span>{formatLectureLabel(detailLecture.id)}</span>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl bg-slate-50 px-4 py-4">
+                  <div className="text-[12px] text-slate-500">비디오 URL</div>
+                  <div className="mt-1 break-all text-[12px] font-semibold text-slate-900">{formatLectureUrl(detailLecture.video_url)}</div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-4">
+                  <div className="text-[12px] text-slate-500">키워드</div>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {detailLecture.keywords.map((keyword) => (
+                      <span key={keyword} className="rounded-full bg-white px-2.5 py-1 text-[11px] text-slate-500">
+                        {keyword}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                <div className="text-[12px] font-semibold text-slate-500">전사 미리보기</div>
+                <p className="mt-2 text-[13px] leading-7 text-slate-600">{detailLecture.transcript_excerpt}</p>
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+                <div className="text-[12px] font-semibold text-slate-500">강의 목록</div>
+                <div className="mt-3 space-y-2">
+                  {course!.lectures.map((lecture) => {
+                    const isActive = lecture.id === selectedLectureId;
+                    return (
+                      <button
+                        key={lecture.id}
+                        type="button"
+                        onClick={() => onSelectLecture(lecture.id)}
+                        className={`flex w-full items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition ${
+                          isActive ? 'border-indigo-300 bg-indigo-50' : 'border-slate-200 hover:bg-slate-50'
+                        }`}
+                      >
+                        <div>
+                          <div className="text-[13px] font-semibold text-slate-900">{lecture.title}</div>
+                          <div className="mt-1 text-[11px] text-slate-500">{formatDuration(lecture.duration_minutes)} · {lecture.content_type}</div>
+                        </div>
+                        <span className="rounded-full bg-white px-2.5 py-1 text-[11px] text-slate-500">
+                          {isActive ? '선택됨' : '보기'}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-4 text-[13px] leading-6 text-slate-500">강의를 선택하면 transcript, keywords, video URL이 표시됩니다.</p>
+          )}
+        </section>
+
+        {course ? (
+          <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+            <h3 className="text-[15px] font-bold text-slate-900">부가 정보</h3>
+            <div className="mt-4 grid grid-cols-1 gap-3">
+              <div className="rounded-2xl bg-slate-50 px-4 py-4">
+                <div className="text-[12px] text-slate-500">materials</div>
+                <div className="mt-1 text-[14px] font-semibold text-slate-900">{course.materials.length}개</div>
+              </div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-4">
+                <div className="text-[12px] text-slate-500">notices</div>
+                <div className="mt-1 text-[14px] font-semibold text-slate-900">{course.notices.length}개</div>
+              </div>
+            </div>
+          </section>
+        ) : null}
+      </aside>
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -20,7 +20,7 @@ import type { LmsDashboardProps, LmsPageId } from '../types';
 
 type RolePageRouterProps = Pick<
   LmsDashboardProps,
-  'dashboard' | 'aiLogs' | 'enrolledCourses' | 'highlightedLecture' | 'recommendations' | 'courseCards' | 'insights' | 'onSelectCourse' | 'demoUsers' | 'selectedCourse'
+  'dashboard' | 'aiLogs' | 'enrolledCourses' | 'highlightedLecture' | 'recommendations' | 'courseCards' | 'insights' | 'onSelectCourse' | 'onSelectLecture' | 'demoUsers' | 'selectedCourse' | 'selectedLectureId'
 > & {
   session: LoginResponse;
   page: LmsPageId;
@@ -39,8 +39,10 @@ export function RolePageRouter({
   courseCards,
   insights,
   onSelectCourse,
+  onSelectLecture,
   demoUsers,
   selectedCourse,
+  selectedLectureId,
 }: RolePageRouterProps) {
   const sessionToken = session.session_token;
 
@@ -49,7 +51,16 @@ export function RolePageRouter({
       case 'dashboard':
         return <AdminDashboardPage dashboard={dashboard} users={demoUsers} courses={courseCards} insights={insights} />;
       case 'courses':
-        return <CoursesPage courses={courseCards} onSelectCourse={onSelectCourse} />;
+        return (
+          <CoursesPage
+            courses={courseCards}
+            selectedCourse={selectedCourse}
+            highlightedLecture={highlightedLecture}
+            selectedLectureId={selectedLectureId}
+            onSelectCourse={onSelectCourse}
+            onSelectLecture={onSelectLecture}
+          />
+        );
       case 'admin-users':
         return <AdminUsersPage users={demoUsers} />;
       case 'admin-instructors':
@@ -73,7 +84,16 @@ export function RolePageRouter({
 
   if (session.user.role === 'INSTRUCTOR') {
     if (page === 'courses') {
-      return <CoursesPage courses={courseCards} onSelectCourse={onSelectCourse} />;
+      return (
+        <CoursesPage
+          courses={courseCards}
+          selectedCourse={selectedCourse}
+          highlightedLecture={highlightedLecture}
+          selectedLectureId={selectedLectureId}
+          onSelectCourse={onSelectCourse}
+          onSelectLecture={onSelectLecture}
+        />
+      );
     }
 
     if (page === 'shortform') {
@@ -112,7 +132,16 @@ export function RolePageRouter({
   }
 
   if (page === 'courses') {
-    return <CoursesPage courses={courseCards} onSelectCourse={onSelectCourse} />;
+    return (
+      <CoursesPage
+        courses={courseCards}
+        selectedCourse={selectedCourse}
+        highlightedLecture={highlightedLecture}
+        selectedLectureId={selectedLectureId}
+        onSelectCourse={onSelectCourse}
+        onSelectLecture={onSelectLecture}
+      />
+    );
   }
 
   if (page === 'shortform') {

--- a/packages/shared/src/lms/learning/catalog.ts
+++ b/packages/shared/src/lms/learning/catalog.ts
@@ -1,6 +1,13 @@
 import { demoCourses, demoLectureProgress, demoLectures } from '../../data/demo-data';
 import type { CourseCard, CourseDetail, LectureDetail } from '../../types';
-import { createCourseCard, getCourseLectures, getLectureInstructorName } from './helpers';
+import {
+  createCourseCard,
+  getCourseLectures,
+  getLectureInstructorName,
+  getLectureKeywords,
+  getLectureTranscriptExcerpt,
+  getLectureVideoUrl,
+} from './helpers';
 import { getCourseMaterials } from './content';
 import { getCourseNotices } from './content';
 
@@ -41,5 +48,8 @@ export function getLectureDetail(lectureId: string, userId?: string): LectureDet
     is_completed: userId
       ? demoLectureProgress.some((progress) => progress.user_id === userId && progress.lecture_id === lectureId && progress.is_completed)
       : undefined,
+    video_url: getLectureVideoUrl(lecture.id),
+    transcript_excerpt: getLectureTranscriptExcerpt(lecture),
+    keywords: getLectureKeywords(lecture),
   };
 }

--- a/packages/shared/src/lms/learning/course.ts
+++ b/packages/shared/src/lms/learning/course.ts
@@ -1,5 +1,5 @@
 import { demoEnrollments, demoLectureProgress, demoLectures, getDemoUser, instructorNames } from '../../data/demo-data';
-import type { Course, CourseCard, Lecture } from '../../types';
+import type { Course, CourseCard, CourseThumbnailPalette, Lecture } from '../../types';
 
 export function getLectureInstructorName(instructorId: string): string {
   return getDemoUser(instructorId)?.name ?? instructorNames[instructorId] ?? '알 수 없는 강사';
@@ -39,6 +39,53 @@ export function getCourseProgress(userId: string, courseId: string): number {
   return Math.round((completed / lectureCount) * 100);
 }
 
+export function getCourseThumbnailPalette(course: Course): CourseThumbnailPalette {
+  if (course.category === 'AI') {
+    return course.difficulty === 'advanced' ? 'violet' : 'indigo';
+  }
+
+  if (course.category === 'Web') {
+    return 'emerald';
+  }
+
+  return 'amber';
+}
+
+export function getCourseRating(course: Course): number {
+  if (course.difficulty === 'beginner') return 4.7;
+  if (course.difficulty === 'intermediate') return 4.8;
+  return 4.9;
+}
+
+export function getCourseStudentCount(courseId: string): number {
+  return demoEnrollments.filter((enrollment) => enrollment.course_id === courseId && enrollment.status === 'active').length;
+}
+
+export function getCourseTotalDurationMinutes(courseId: string): number {
+  return getCourseLectures(courseId).reduce((sum, lecture) => sum + lecture.duration_minutes, 0);
+}
+
+export function getLectureKeywords(lecture: Lecture): string[] {
+  const keywordMap: Record<string, string[]> = {
+    lec_ai_001: ['AI', '머신러닝', '딥러닝', '정의'],
+    lec_ai_002: ['데이터셋', '라벨링', '검증', '모델'],
+    lec_web_001: ['React', '컴포넌트', '상태 관리', 'props'],
+    lec_web_002: ['TypeScript', '폼', '검증', '타입 안정성'],
+    lec_llm_001: ['RAG', '청킹', '임베딩', '검색'],
+    lec_llm_002: ['요약', '질문응답', '학습 흐름', '챗봇'],
+  };
+
+  return keywordMap[lecture.id] ?? lecture.content_text.split(/[\s,·]+/).filter(Boolean).slice(0, 4);
+}
+
+export function getLectureTranscriptExcerpt(lecture: Lecture): string {
+  return lecture.content_text;
+}
+
+export function getLectureVideoUrl(lectureId: string): string {
+  return `/static/media/${lectureId}.mp4`;
+}
+
 export function createCourseCard(course: Course, userId: string): CourseCard {
   return {
     ...course,
@@ -47,5 +94,9 @@ export function createCourseCard(course: Course, userId: string): CourseCard {
     enrolled: isEnrolled(userId, course.id),
     progress_percent: getCourseProgress(userId, course.id),
     completed_lectures: getCompletedLectureCount(userId, course.id),
+    thumbnail_palette: getCourseThumbnailPalette(course),
+    rating: getCourseRating(course),
+    student_count: getCourseStudentCount(course.id),
+    total_duration_minutes: getCourseTotalDurationMinutes(course.id),
   };
 }

--- a/packages/shared/src/lms/learning/helpers.ts
+++ b/packages/shared/src/lms/learning/helpers.ts
@@ -6,4 +6,11 @@ export {
   getLectureCount,
   getCourseProgress,
   createCourseCard,
+  getCourseThumbnailPalette,
+  getCourseRating,
+  getCourseStudentCount,
+  getCourseTotalDurationMinutes,
+  getLectureKeywords,
+  getLectureTranscriptExcerpt,
+  getLectureVideoUrl,
 } from './course';

--- a/packages/shared/src/types/lms.ts
+++ b/packages/shared/src/types/lms.ts
@@ -11,6 +11,8 @@ export type Course = {
   tags: string[];
 };
 
+export type CourseThumbnailPalette = 'indigo' | 'emerald' | 'violet' | 'amber';
+
 export type Lecture = {
   id: string;
   course_id: string;
@@ -164,6 +166,10 @@ export type CourseCard = Course & {
   enrolled: boolean;
   progress_percent: number;
   completed_lectures: number;
+  thumbnail_palette: CourseThumbnailPalette;
+  rating: number;
+  student_count: number;
+  total_duration_minutes: number;
 };
 
 export type CourseDetail = CourseCard & {
@@ -178,6 +184,9 @@ export type LectureDetail = Lecture & {
   previous_lecture_id?: string;
   next_lecture_id?: string;
   is_completed?: boolean;
+  video_url: string;
+  transcript_excerpt: string;
+  keywords: string[];
 };
 
 export type Dashboard = {


### PR DESCRIPTION
# 변경 요약
코스 카드와 강의 상세에 메타데이터를 추가하고, 상세 페이지를 한 화면에서 볼 수 있게 확장했습니다.

## 배경
코스 선택 시 썸네일, 평점, 수강생 수, 총 러닝타임, 강의 메타데이터를 함께 보여주면 탐색이 훨씬 쉬워집니다.

## 변경 내용
- CourseCard에 썸네일 팔레트, 평점, 수강생 수, 총 러닝타임을 추가했습니다.
- LectureDetail에 video URL, transcript excerpt, keywords를 추가했습니다.
- CoursesPage를 코스 카드 + 코스 상세 + 강의 상세 구조로 재구성했습니다.
- RolePageRouter와 LmsDashboard에서 새 상세 props를 전달하도록 연결했습니다.
- 변경 요약을 docs/dev-logs/2026-04-09-course-metadata-detail-page.md에 남겼습니다.

## 연결 이슈
- Closes #49
- Fixes #49

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 frontend/ 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 backend/ 담당자 확인이 필요하다
- [x] 문서 변경이면 docs/ 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 packages/shared/ 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] docs/dev-logs/에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다