### PR TITLE
feat: add dashboard activity timeline

### DIFF
--- a/docs/dev-logs/2026-04-09-dashboard-activity-timeline.md
+++ b/docs/dev-logs/2026-04-09-dashboard-activity-timeline.md
@@ -1,0 +1,17 @@
+# 2026-04-09 대시보드 활동 타임라인과 학습 통계
+
+## 한줄 요약
+대시보드에 최근 활동 타임라인과 역할별 학습 통계를 추가해서 학습 흐름과 운영 현황을 더 빠르게 읽을 수 있게 했다.
+
+## 구현 내용
+- `Dashboard` 타입에 `stats`, `recent_activities`, `next_action`을 추가했다.
+- enrollment와 lecture progress에 타임스탬프를 넣어 최근 활동을 실제 이벤트 순서로 정렬할 수 있게 했다.
+- shared dashboard 계산 로직에서 학생, 강사, 운영자 역할별 통계와 활동 목록을 구성했다.
+- 학생, 강사, 운영자 대시보드에 통계 카드와 최근 활동 타임라인을 추가했다.
+- 공통 렌더링을 위해 dashboard stats/timeline 컴포넌트를 분리했다.
+
+## 검증
+- `npm exec --workspace @myway/frontend -- tsc -p tsconfig.json --noEmit` 통과
+- `npm run build:backend` 통과
+- `npm install --workspace @myway/backend`로 누락된 `@cloudflare/workers-types` 의존성을 복구했다.
+

--- a/frontend/src/features/lms/components/DashboardStatsGrid.tsx
+++ b/frontend/src/features/lms/components/DashboardStatsGrid.tsx
@@ -1,0 +1,54 @@
+import type { DashboardStat } from '@myway/shared';
+
+type DashboardStatsGridProps = {
+  stats: DashboardStat[];
+};
+
+const toneClasses: Record<DashboardStat['tone'], { panel: string; icon: string; value: string }> = {
+  indigo: {
+    panel: 'bg-indigo-50 text-indigo-600',
+    icon: 'bg-indigo-100 text-indigo-600',
+    value: 'text-slate-900',
+  },
+  emerald: {
+    panel: 'bg-emerald-50 text-emerald-600',
+    icon: 'bg-emerald-100 text-emerald-600',
+    value: 'text-slate-900',
+  },
+  violet: {
+    panel: 'bg-violet-50 text-violet-600',
+    icon: 'bg-violet-100 text-violet-600',
+    value: 'text-slate-900',
+  },
+  amber: {
+    panel: 'bg-amber-50 text-amber-700',
+    icon: 'bg-amber-100 text-amber-700',
+    value: 'text-slate-900',
+  },
+  slate: {
+    panel: 'bg-slate-50 text-slate-600',
+    icon: 'bg-slate-100 text-slate-600',
+    value: 'text-slate-900',
+  },
+};
+
+export function DashboardStatsGrid({ stats }: DashboardStatsGridProps) {
+  return (
+    <section className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {stats.map((stat) => {
+        const tone = toneClasses[stat.tone];
+
+        return (
+          <article key={stat.id} className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+            <div className={`mb-3 flex h-11 w-11 items-center justify-center rounded-2xl text-[20px] ${tone.icon}`}>
+              <i className={stat.icon} />
+            </div>
+            <div className={`text-[28px] font-extrabold tracking-[-0.03em] ${tone.value}`}>{stat.value}</div>
+            <div className="mt-1 text-[12px] font-semibold text-slate-500">{stat.label}</div>
+            <div className={`mt-2 inline-flex rounded-full px-2.5 py-1 text-[11px] font-semibold ${tone.panel}`}>{stat.hint}</div>
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/frontend/src/features/lms/components/DashboardTimeline.tsx
+++ b/frontend/src/features/lms/components/DashboardTimeline.tsx
@@ -1,0 +1,101 @@
+import type { DashboardActivity } from '@myway/shared';
+
+type DashboardTimelineProps = {
+  title: string;
+  subtitle: string;
+  activities: DashboardActivity[];
+  emptyMessage: string;
+};
+
+const toneClasses: Record<DashboardActivity['tone'], { icon: string; line: string; badge: string }> = {
+  indigo: {
+    icon: 'bg-indigo-100 text-indigo-600',
+    line: 'border-indigo-200',
+    badge: 'bg-indigo-50 text-indigo-600',
+  },
+  emerald: {
+    icon: 'bg-emerald-100 text-emerald-600',
+    line: 'border-emerald-200',
+    badge: 'bg-emerald-50 text-emerald-600',
+  },
+  violet: {
+    icon: 'bg-violet-100 text-violet-600',
+    line: 'border-violet-200',
+    badge: 'bg-violet-50 text-violet-600',
+  },
+  amber: {
+    icon: 'bg-amber-100 text-amber-700',
+    line: 'border-amber-200',
+    badge: 'bg-amber-50 text-amber-700',
+  },
+  slate: {
+    icon: 'bg-slate-100 text-slate-600',
+    line: 'border-slate-200',
+    badge: 'bg-slate-50 text-slate-600',
+  },
+};
+
+function formatRelativeTime(timestamp: string): string {
+  const diffMs = Date.now() - new Date(timestamp).getTime();
+  const diffMinutes = Math.max(Math.round(diffMs / 60000), 0);
+
+  if (diffMinutes < 1) {
+    return '방금 전';
+  }
+  if (diffMinutes < 60) {
+    return `${diffMinutes}분 전`;
+  }
+
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `${diffHours}시간 전`;
+  }
+
+  const diffDays = Math.round(diffHours / 24);
+  return `${diffDays}일 전`;
+}
+
+export function DashboardTimeline({ title, subtitle, activities, emptyMessage }: DashboardTimelineProps) {
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h3 className="text-[15px] font-bold text-slate-900">{title}</h3>
+          <p className="mt-1 text-[12px] text-slate-500">{subtitle}</p>
+        </div>
+        <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-500">{activities.length}개 활동</span>
+      </div>
+
+      {activities.length ? (
+        <div className="mt-4 space-y-3">
+          {activities.map((activity) => {
+            const tone = toneClasses[activity.tone];
+            const meta = [activity.course_title, activity.lecture_title].filter(Boolean).join(' · ');
+
+            return (
+              <article key={activity.id} className={`rounded-2xl border ${tone.line} px-4 py-4`}>
+                <div className="flex items-start gap-3">
+                  <div className={`mt-0.5 flex h-10 w-10 items-center justify-center rounded-xl text-[18px] ${tone.icon}`}>
+                    <i className={activity.icon} />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h4 className="text-[13px] font-semibold text-slate-900">{activity.title}</h4>
+                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${tone.badge}`}>{formatRelativeTime(activity.timestamp)}</span>
+                    </div>
+                    <p className="mt-1 text-[12px] leading-6 text-slate-500">{activity.detail}</p>
+                    {meta ? <div className="mt-2 text-[11px] text-slate-500">{meta}</div> : null}
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-[13px] leading-6 text-slate-500">
+          {emptyMessage}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/lms/pages/AdminDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/AdminDashboardPage.tsx
@@ -1,4 +1,6 @@
 import type { AIInsights, AuthUser, CourseCard, Dashboard } from '@myway/shared';
+import { DashboardStatsGrid } from '../components/DashboardStatsGrid';
+import { DashboardTimeline } from '../components/DashboardTimeline';
 
 type AdminDashboardPageProps = {
   dashboard: Dashboard | null;
@@ -8,8 +10,70 @@ type AdminDashboardPageProps = {
 };
 
 export function AdminDashboardPage({ dashboard, users, courses, insights }: AdminDashboardPageProps) {
+  const stats =
+    dashboard?.stats ?? [
+      {
+        id: 'users',
+        label: '전체 사용자',
+        value: String(users.length),
+        hint: '운영 중인 학습자와 관리자',
+        icon: 'ri-team-line',
+        tone: 'indigo' as const,
+      },
+      {
+        id: 'courses',
+        label: '전체 강의',
+        value: String(courses.length),
+        hint: '시스템에 등록된 강의 수',
+        icon: 'ri-book-shelf-line',
+        tone: 'emerald' as const,
+      },
+      {
+        id: 'enrollments',
+        label: '활성 수강',
+        value: String(dashboard?.active_enrollments ?? 0),
+        hint: '현재 활성 상태의 수강 등록',
+        icon: 'ri-user-follow-line',
+        tone: 'violet' as const,
+      },
+      {
+        id: 'ai',
+        label: 'AI 요청',
+        value: String(insights?.summary.total_requests ?? 0),
+        hint: '최근 AI 사용량',
+        icon: 'ri-robot-line',
+        tone: 'amber' as const,
+      },
+    ];
+  const activities = dashboard?.recent_activities ?? [];
+
   return (
     <div className="space-y-5">
+      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 px-6 py-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-indigo-200">Admin Dashboard</div>
+            <h2 className="mt-2 text-[24px] font-extrabold tracking-[-0.04em]">운영 현황과 최근 학습 흐름을 함께 확인합니다.</h2>
+            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-300">
+              {dashboard?.next_action ?? '운영 통계와 AI 사용량을 확인하고 병목이 생긴 코스를 점검하세요.'}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+            <div className="font-semibold text-white">{dashboard?.learner_name ?? '운영자'}</div>
+            <div className="mt-1">{dashboard?.role ?? 'ADMIN'}</div>
+          </div>
+        </div>
+      </section>
+
+      <DashboardStatsGrid stats={stats} />
+
+      <DashboardTimeline
+        title="최근 활동"
+        subtitle="운영 등록, 수강 흐름, AI 사용 현황을 시간순으로 확인합니다."
+        activities={activities}
+        emptyMessage="아직 최근 활동이 없습니다. 수강 등록이나 AI 요청이 발생하면 여기에 표시됩니다."
+      />
+
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
           <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{users.length}</div>

--- a/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
@@ -1,6 +1,9 @@
-import type { AIInsights, CourseCard } from '@myway/shared';
+import type { AIInsights, CourseCard, Dashboard } from '@myway/shared';
+import { DashboardStatsGrid } from '../components/DashboardStatsGrid';
+import { DashboardTimeline } from '../components/DashboardTimeline';
 
 type InstructorDashboardPageProps = {
+  dashboard: Dashboard | null;
   courses: CourseCard[];
   insights: AIInsights | null;
 };
@@ -26,9 +29,70 @@ const tools = [
   },
 ];
 
-export function InstructorDashboardPage({ courses, insights }: InstructorDashboardPageProps) {
+export function InstructorDashboardPage({ dashboard, courses, insights }: InstructorDashboardPageProps) {
+  const stats =
+    dashboard?.stats ?? [
+      {
+        id: 'courses',
+        label: '개설 강의',
+        value: String(courses.length),
+        hint: '운영 중인 내 강의 수',
+        icon: 'ri-book-shelf-line',
+        tone: 'indigo' as const,
+      },
+      {
+        id: 'materials',
+        label: '자료 업로드',
+        value: String(courses.length * 2),
+        hint: '자료와 실습 콘텐츠를 확장하세요',
+        icon: 'ri-folder-3-line',
+        tone: 'emerald' as const,
+      },
+      {
+        id: 'progress',
+        label: '평균 진도',
+        value: `${Math.round(courses.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courses.length, 1))}%`,
+        hint: '강의별 진도 평균',
+        icon: 'ri-line-chart-line',
+        tone: 'violet' as const,
+      },
+      {
+        id: 'ai',
+        label: 'AI 요청',
+        value: String(insights?.summary.total_requests ?? 0),
+        hint: '강의 보조 기능 사용량',
+        icon: 'ri-robot-line',
+        tone: 'amber' as const,
+      },
+    ];
+  const activities = dashboard?.recent_activities ?? [];
+  const nextAction = dashboard?.next_action ?? '최근 업로드 자료와 공지를 확인하고 학생 진도 변화를 살펴보세요.';
+
   return (
     <div className="space-y-5">
+      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-violet-950 px-6 py-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-violet-200">Instructor Dashboard</div>
+            <h2 className="mt-2 text-[24px] font-extrabold tracking-[-0.04em]">강의 운영과 학습 반응을 빠르게 확인합니다.</h2>
+            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-300">{nextAction}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+            <div className="font-semibold text-white">{dashboard?.learner_name ?? '강사'}</div>
+            <div className="mt-1">{dashboard?.role ?? 'INSTRUCTOR'}</div>
+          </div>
+        </div>
+      </section>
+
+      <DashboardStatsGrid stats={stats} />
+
+      <DashboardTimeline
+        title="최근 활동"
+        subtitle="자료 업로드, 공지, 수강자 진도와 AI 요청을 확인합니다."
+        activities={activities}
+        emptyMessage="아직 최근 활동이 없습니다. 자료 업로드나 공지 등록이 여기에 표시됩니다."
+      />
+
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         {tools.map((tool) => (
           <article key={tool.title} className="rounded-3xl border border-slate-200 bg-white px-5 py-6">

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -115,7 +115,7 @@ export function RolePageRouter({
     if (page === 'ai-summary' || page === 'dashboard') {
       return page === 'ai-summary'
         ? <AISummaryPage highlightedLecture={highlightedLecture} insights={insights} />
-        : <InstructorDashboardPage courses={courseCards} insights={insights} />;
+        : <InstructorDashboardPage dashboard={dashboard} courses={courseCards} insights={insights} />;
     }
 
     if (page === 'assignment-check') {

--- a/frontend/src/features/lms/pages/StudentDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/StudentDashboardPage.tsx
@@ -1,4 +1,6 @@
 import type { AIRecommendationOverview, CourseCard, Dashboard, LectureDetail } from '@myway/shared';
+import { DashboardStatsGrid } from '../components/DashboardStatsGrid';
+import { DashboardTimeline } from '../components/DashboardTimeline';
 
 type StudentDashboardPageProps = {
   dashboard: Dashboard | null;
@@ -17,25 +19,68 @@ export function StudentDashboardPage({
 }: StudentDashboardPageProps) {
   const averageProgress =
     dashboard?.average_progress ?? Math.round(courses.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courses.length, 1));
+  const stats =
+    dashboard?.stats ?? [
+      {
+        id: 'courses',
+        label: '수강 중 강의',
+        value: String(courses.filter((course) => course.enrolled).length),
+        hint: '현재 활성화된 학습 코스',
+        icon: 'ri-book-open-line',
+        tone: 'indigo' as const,
+      },
+      {
+        id: 'completed',
+        label: '완료 강의',
+        value: String(courses.reduce((sum, course) => sum + course.completed_lectures, 0)),
+        hint: '누적 완료한 강의 수',
+        icon: 'ri-check-double-line',
+        tone: 'emerald' as const,
+      },
+      {
+        id: 'progress',
+        label: '평균 진도',
+        value: `${averageProgress}%`,
+        hint: '전체 코스 기준 평균 진도',
+        icon: 'ri-line-chart-line',
+        tone: 'violet' as const,
+      },
+      {
+        id: 'minutes',
+        label: '총 학습 시간',
+        value: `${Math.round(courses.reduce((sum, course) => sum + course.total_duration_minutes * (course.progress_percent / 100), 0))}분`,
+        hint: '진도 기준 예상 학습 시간',
+        icon: 'ri-time-line',
+        tone: 'amber' as const,
+      },
+    ];
+  const activities = dashboard?.recent_activities ?? [];
+  const nextAction = dashboard?.next_action ?? '로그인 후 개인 학습 흐름을 확인할 수 있습니다.';
 
   return (
     <div className="space-y-5">
-      <section className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-[18px] text-indigo-600">
-            <i className="ri-book-open-line" />
+      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 px-6 py-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-indigo-200">Dashboard</div>
+            <h2 className="mt-2 text-[24px] font-extrabold tracking-[-0.04em]">학습 흐름과 최근 활동을 한눈에 확인합니다.</h2>
+            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-300">{nextAction}</p>
           </div>
-          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{courses.length}</div>
-          <div className="mt-1 text-[12px] text-slate-500">수강 중인 강의</div>
-        </article>
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100 text-[18px] text-emerald-600">
-            <i className="ri-check-double-line" />
+          <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+            <div className="font-semibold text-white">{dashboard?.learner_name ?? '학습자'}</div>
+            <div className="mt-1">{dashboard?.role ?? 'STUDENT'}</div>
           </div>
-          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{averageProgress}%</div>
-          <div className="mt-1 text-[12px] text-slate-500">평균 학습 진도</div>
-        </article>
+        </div>
       </section>
+
+      <DashboardStatsGrid stats={stats} />
+
+      <DashboardTimeline
+        title="최근 활동"
+        subtitle="수강 신청, 강의 완료, AI 요청을 시간순으로 확인합니다."
+        activities={activities}
+        emptyMessage="최근 활동이 아직 없습니다. 첫 수강 신청이나 강의 완료가 생기면 여기에 표시됩니다."
+      />
 
       <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
         <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">

--- a/packages/shared/src/data/courses.ts
+++ b/packages/shared/src/data/courses.ts
@@ -108,6 +108,7 @@ export const demoEnrollments: Enrollment[] = [
     course_id: 'crs_ai_001',
     status: 'active',
     progress_percent: 50,
+    created_at: '2026-04-06T09:10:00.000Z',
   },
   {
     id: 'enr_002',
@@ -115,12 +116,38 @@ export const demoEnrollments: Enrollment[] = [
     course_id: 'crs_llm_001',
     status: 'active',
     progress_percent: 20,
+    created_at: '2026-04-06T09:40:00.000Z',
   },
 ];
 
 export const demoLectureProgress: LectureProgress[] = [
-  { id: 'prg_001', user_id: 'usr_std_001', lecture_id: 'lec_ai_001', is_completed: true },
-  { id: 'prg_002', user_id: 'usr_std_001', lecture_id: 'lec_ai_002', is_completed: false },
-  { id: 'prg_003', user_id: 'usr_std_001', lecture_id: 'lec_llm_001', is_completed: false },
-  { id: 'prg_004', user_id: 'usr_std_001', lecture_id: 'lec_llm_002', is_completed: false },
+  {
+    id: 'prg_001',
+    user_id: 'usr_std_001',
+    lecture_id: 'lec_ai_001',
+    is_completed: true,
+    completed_at: '2026-04-08T07:40:00.000Z',
+    updated_at: '2026-04-08T07:40:00.000Z',
+  },
+  {
+    id: 'prg_002',
+    user_id: 'usr_std_001',
+    lecture_id: 'lec_ai_002',
+    is_completed: false,
+    updated_at: '2026-04-08T07:50:00.000Z',
+  },
+  {
+    id: 'prg_003',
+    user_id: 'usr_std_001',
+    lecture_id: 'lec_llm_001',
+    is_completed: false,
+    updated_at: '2026-04-08T08:10:00.000Z',
+  },
+  {
+    id: 'prg_004',
+    user_id: 'usr_std_001',
+    lecture_id: 'lec_llm_002',
+    is_completed: false,
+    updated_at: '2026-04-08T08:15:00.000Z',
+  },
 ];

--- a/packages/shared/src/lms/learning/dashboard.ts
+++ b/packages/shared/src/lms/learning/dashboard.ts
@@ -1,22 +1,365 @@
-import { getDemoUser } from '../../data/demo-data';
-import type { Dashboard } from '../../types';
+import {
+  demoAIIntentLogs,
+  demoAIQuestionLogs,
+  demoAIUsageLogs,
+  demoCourses,
+  demoEnrollments,
+  demoLectureProgress,
+  demoLectures,
+  demoMaterials,
+  demoNotices,
+  demoUsers,
+  getDemoUser,
+} from '../../data/demo-data';
+import type { Dashboard, DashboardActivity, DashboardStat, CourseCard } from '../../types';
 import { listCourseCards } from './catalog';
+
+function formatMinutes(minutes: number): string {
+  if (minutes < 60) {
+    return `${minutes}분`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remain = minutes % 60;
+  return remain > 0 ? `${hours}시간 ${remain}분` : `${hours}시간`;
+}
+
+function getCourseTitle(courseId: string): string {
+  return demoCourses.find((course) => course.id === courseId)?.title ?? '알 수 없는 강의';
+}
+
+function getLectureTitle(lectureId: string): string {
+  return demoLectures.find((lecture) => lecture.id === lectureId)?.title ?? '알 수 없는 강의';
+}
+
+function getActivityTone(type: DashboardActivity['type']): DashboardStat['tone'] {
+  if (type === 'enrollment') return 'emerald';
+  if (type === 'lecture_complete') return 'indigo';
+  if (type === 'material' || type === 'notice') return 'violet';
+  if (type === 'insight') return 'amber';
+  return 'slate';
+}
+
+function getActivityIcon(type: DashboardActivity['type']): string {
+  if (type === 'enrollment') return 'ri-book-open-line';
+  if (type === 'lecture_complete') return 'ri-check-double-line';
+  if (type === 'ai_summary') return 'ri-file-text-line';
+  if (type === 'quiz') return 'ri-question-line';
+  if (type === 'shortform') return 'ri-scissors-cut-line';
+  if (type === 'material') return 'ri-folder-3-line';
+  if (type === 'notice') return 'ri-megaphone-line';
+  if (type === 'insight') return 'ri-lightbulb-flash-line';
+  return 'ri-chat-3-line';
+}
+
+function createActivity(input: Omit<DashboardActivity, 'icon' | 'tone'> & { type: DashboardActivity['type'] }): DashboardActivity {
+  return {
+    ...input,
+    icon: getActivityIcon(input.type),
+    tone: getActivityTone(input.type),
+  };
+}
+
+function stat(id: string, label: string, value: string, hint: string, icon: string, tone: DashboardStat['tone']): DashboardStat {
+  return { id, label, value, hint, icon, tone };
+}
+
+function getCourseStats(courses: CourseCard[]): DashboardStat[] {
+  const activeCourses = courses.filter((course) => course.enrolled);
+  const completedLectures = demoLectureProgress.filter((progress) => progress.is_completed).length;
+  const totalLearningMinutes = Math.round(
+    activeCourses.reduce((sum, course) => sum + course.total_duration_minutes * (course.progress_percent / 100), 0),
+  );
+
+  return [
+    stat('courses', '수강 중 강의', String(activeCourses.length), '현재 활성화된 학습 코스', 'ri-book-open-line', 'indigo'),
+    stat('completed', '완료 강의', String(completedLectures), '학습 완료로 표시된 강의 수', 'ri-check-double-line', 'emerald'),
+    stat('progress', '평균 진도', `${courses.length === 0 ? 0 : Math.round(courses.reduce((sum, course) => sum + course.progress_percent, 0) / courses.length)}%`, '모든 코스를 포함한 평균 진도', 'ri-line-chart-line', 'violet'),
+    stat('minutes', '총 학습 시간', formatMinutes(totalLearningMinutes), '진도 기준으로 환산한 예상 학습 시간', 'ri-time-line', 'amber'),
+  ];
+}
+
+function getStudentActivities(userId: string): DashboardActivity[] {
+  const enrollmentActivities = demoEnrollments
+    .filter((enrollment) => enrollment.user_id === userId)
+    .map((enrollment) =>
+      createActivity({
+        id: `activity-enrollment-${enrollment.id}`,
+        type: 'enrollment',
+        title: `${getCourseTitle(enrollment.course_id)} 수강을 시작했습니다`,
+        detail: `진도 ${enrollment.progress_percent}%로 학습을 이어가고 있습니다.`,
+        timestamp: enrollment.created_at ?? '2026-04-06T09:00:00.000Z',
+        course_id: enrollment.course_id,
+        course_title: getCourseTitle(enrollment.course_id),
+      }),
+    );
+
+  const lectureActivities = demoLectureProgress
+    .filter((progress) => progress.user_id === userId && progress.is_completed)
+    .map((progress) => {
+      const lecture = demoLectures.find((item) => item.id === progress.lecture_id);
+      return createActivity({
+        id: `activity-complete-${progress.id}`,
+        type: 'lecture_complete',
+        title: `${getLectureTitle(progress.lecture_id)}를 완료했습니다`,
+        detail: lecture ? `${getCourseTitle(lecture.course_id)} · ${lecture.duration_minutes}분 학습 완료` : '강의 완료 기록',
+        timestamp: progress.completed_at ?? progress.updated_at ?? '2026-04-08T07:40:00.000Z',
+        course_id: lecture?.course_id,
+        course_title: lecture ? getCourseTitle(lecture.course_id) : undefined,
+        lecture_id: progress.lecture_id,
+        lecture_title: getLectureTitle(progress.lecture_id),
+      });
+    });
+
+  const aiIntentActivities = demoAIIntentLogs
+    .filter((log) => log.user_id === userId)
+    .map((log) => {
+      const type = log.feature === 'summary' ? 'ai_summary' : log.feature === 'quiz' ? 'quiz' : log.feature === 'insights' ? 'insight' : 'ai_chat';
+      return createActivity({
+        id: `activity-intent-${log.id}`,
+        type,
+        title: log.feature === 'summary'
+          ? 'AI 요약을 생성했습니다'
+          : log.feature === 'quiz'
+            ? '퀴즈를 생성했습니다'
+            : log.feature === 'insights'
+              ? 'AI 인사이트를 확인했습니다'
+              : 'AI 채팅을 이어갔습니다',
+        detail: log.message,
+        timestamp: log.created_at,
+        course_id: log.course_id ?? undefined,
+        course_title: log.course_id ? getCourseTitle(log.course_id) : undefined,
+        lecture_id: log.lecture_id ?? undefined,
+        lecture_title: log.lecture_id ? getLectureTitle(log.lecture_id) : undefined,
+      });
+    });
+
+  const aiQuestionActivities = demoAIQuestionLogs
+    .filter((log) => log.user_id === userId)
+    .map((log) =>
+      createActivity({
+        id: `activity-question-${log.id}`,
+        type: 'ai_chat',
+        title: '질문에 대한 답변을 확인했습니다',
+        detail: log.question,
+        timestamp: log.created_at,
+        course_id: log.course_id,
+        course_title: getCourseTitle(log.course_id),
+        lecture_id: log.lecture_id,
+        lecture_title: getLectureTitle(log.lecture_id),
+      }),
+    );
+
+  const aiUsageActivities = demoAIUsageLogs
+    .filter((log) => log.user_id === userId)
+    .map((log) =>
+      createActivity({
+        id: `activity-usage-${log.id}`,
+        type: log.feature === 'summary' ? 'ai_summary' : log.feature === 'quiz' ? 'quiz' : log.feature === 'insights' ? 'insight' : 'ai_chat',
+        title:
+          log.feature === 'summary'
+            ? 'AI 요약 요청'
+            : log.feature === 'quiz'
+              ? 'AI 퀴즈 요청'
+              : log.feature === 'insights'
+                ? 'AI 인사이트 요청'
+                : 'AI 대화 요청',
+        detail: `${log.provider} · ${log.model} · ${log.latency_ms}ms`,
+        timestamp: log.created_at,
+      }),
+    );
+
+  return [...enrollmentActivities, ...lectureActivities, ...aiIntentActivities, ...aiQuestionActivities, ...aiUsageActivities]
+    .sort((left, right) => right.timestamp.localeCompare(left.timestamp))
+    .slice(0, 5);
+}
+
+function getInstructorStats(userId: string): DashboardStat[] {
+  const courseIds = new Set(demoCourses.filter((course) => course.instructor_id === userId).map((course) => course.id));
+  const materials = demoMaterials.filter((material) => courseIds.has(material.course_id));
+  const notices = demoNotices.filter((notice) => courseIds.has(notice.course_id));
+  const activeEnrollments = demoEnrollments.filter((enrollment) => courseIds.has(enrollment.course_id) && enrollment.status === 'active');
+  const avgProgress = activeEnrollments.length === 0 ? 0 : Math.round(activeEnrollments.reduce((sum, enrollment) => sum + enrollment.progress_percent, 0) / activeEnrollments.length);
+
+  return [
+    stat('courses', '개설 강의', String(courseIds.size), '운영 중인 내 강의 수', 'ri-book-shelf-line', 'indigo'),
+    stat('materials', '자료 업로드', String(materials.length), '강의 자료와 첨부 파일', 'ri-folder-3-line', 'emerald'),
+    stat('notices', '공지 등록', String(notices.length), '학생에게 전달한 공지 수', 'ri-megaphone-line', 'violet'),
+    stat('progress', '평균 진도', `${avgProgress}%`, '내 강의 전체 수강 평균', 'ri-line-chart-line', 'amber'),
+  ];
+}
+
+function getInstructorActivities(userId: string): DashboardActivity[] {
+  const instructorCourseIds = new Set(demoCourses.filter((course) => course.instructor_id === userId).map((course) => course.id));
+
+  const materialActivities = demoMaterials
+    .filter((material) => instructorCourseIds.has(material.course_id))
+    .map((material) =>
+      createActivity({
+        id: `activity-material-${material.id}`,
+        type: 'material',
+        title: `${material.title} 자료를 업로드했습니다`,
+        detail: `${getCourseTitle(material.course_id)} · ${material.file_name}`,
+        timestamp: material.uploaded_at,
+        course_id: material.course_id,
+        course_title: getCourseTitle(material.course_id),
+      }),
+    );
+
+  const noticeActivities = demoNotices
+    .filter((notice) => instructorCourseIds.has(notice.course_id))
+    .map((notice) =>
+      createActivity({
+        id: `activity-notice-${notice.id}`,
+        type: 'notice',
+        title: `${notice.title} 공지를 등록했습니다`,
+        detail: `${getCourseTitle(notice.course_id)} · ${notice.pinned ? '고정 공지' : '일반 공지'}`,
+        timestamp: notice.created_at,
+        course_id: notice.course_id,
+        course_title: getCourseTitle(notice.course_id),
+      }),
+    );
+
+  const completionActivities = demoLectureProgress
+    .filter((progress) => progress.is_completed)
+    .map((progress) => {
+      const lecture = demoLectures.find((item) => item.id === progress.lecture_id);
+      if (!lecture || !instructorCourseIds.has(lecture.course_id)) {
+        return null;
+      }
+
+      return createActivity({
+        id: `activity-instructor-complete-${progress.id}`,
+        type: 'lecture_complete',
+        title: `${getLectureTitle(progress.lecture_id)}가 완료되었습니다`,
+        detail: `${getCourseTitle(lecture.course_id)} 수강생 진도에 반영되었습니다.`,
+        timestamp: progress.completed_at ?? progress.updated_at ?? '2026-04-08T07:40:00.000Z',
+        course_id: lecture.course_id,
+        course_title: getCourseTitle(lecture.course_id),
+        lecture_id: lecture.id,
+        lecture_title: lecture.title,
+      });
+    })
+    .filter((activity): activity is DashboardActivity => activity !== null);
+
+  const aiActivities = demoAIUsageLogs
+    .filter((log) => log.user_id === userId)
+    .map((log) =>
+      createActivity({
+        id: `activity-instructor-ai-${log.id}`,
+        type: log.feature === 'summary' ? 'ai_summary' : log.feature === 'quiz' ? 'quiz' : 'ai_chat',
+        title:
+          log.feature === 'summary'
+            ? '강의 요약을 요청했습니다'
+            : log.feature === 'quiz'
+              ? '퀴즈를 요청했습니다'
+              : 'AI 도우미를 사용했습니다',
+        detail: `${log.provider} · ${log.model} · ${log.latency_ms}ms`,
+        timestamp: log.created_at,
+      }),
+    );
+
+  return [...materialActivities, ...noticeActivities, ...completionActivities, ...aiActivities]
+    .sort((left, right) => right.timestamp.localeCompare(left.timestamp))
+    .slice(0, 5);
+}
+
+function getAdminStats(courses: CourseCard[]): DashboardStat[] {
+  const activeEnrollments = demoEnrollments.filter((enrollment) => enrollment.status === 'active').length;
+  const averageProgress = courses.length === 0 ? 0 : Math.round(courses.reduce((sum, course) => sum + course.progress_percent, 0) / courses.length);
+
+  return [
+    stat('users', '전체 사용자', String(demoUsers.length), '운영 중인 학습자와 관리자', 'ri-team-line', 'indigo'),
+    stat('courses', '전체 강의', String(demoCourses.length), '시스템에 등록된 강의 수', 'ri-book-shelf-line', 'emerald'),
+    stat('enrollments', '활성 수강', String(activeEnrollments), '현재 활성 상태의 수강 등록', 'ri-user-follow-line', 'violet'),
+    stat('progress', '평균 진도', `${averageProgress}%`, '플랫폼 전체 평균 진도', 'ri-line-chart-line', 'amber'),
+  ];
+}
+
+function getAdminActivities(): DashboardActivity[] {
+  const enrollmentActivities = demoEnrollments.map((enrollment) =>
+    createActivity({
+      id: `activity-admin-enrollment-${enrollment.id}`,
+      type: 'enrollment',
+      title: `${getCourseTitle(enrollment.course_id)}에 새로운 수강이 있습니다`,
+      detail: `진도 ${enrollment.progress_percent}% · ${enrollment.status === 'active' ? '활성' : enrollment.status}`,
+      timestamp: enrollment.created_at ?? '2026-04-06T09:10:00.000Z',
+      course_id: enrollment.course_id,
+      course_title: getCourseTitle(enrollment.course_id),
+    }),
+  );
+
+  const aiActivities = demoAIUsageLogs.map((log) =>
+    createActivity({
+      id: `activity-admin-ai-${log.id}`,
+      type: log.feature === 'summary' ? 'ai_summary' : log.feature === 'quiz' ? 'quiz' : log.feature === 'insights' ? 'insight' : 'ai_chat',
+      title:
+        log.feature === 'summary'
+          ? 'AI 요약 사용량'
+          : log.feature === 'quiz'
+            ? 'AI 퀴즈 사용량'
+            : log.feature === 'insights'
+              ? 'AI 인사이트 사용량'
+              : 'AI 채팅 사용량',
+      detail: `${log.provider} · ${log.model} · ${log.latency_ms}ms`,
+      timestamp: log.created_at,
+    }),
+  );
+
+  return [...enrollmentActivities, ...aiActivities]
+    .sort((left, right) => right.timestamp.localeCompare(left.timestamp))
+    .slice(0, 5);
+}
+
+function buildNextAction(role: Dashboard['role'], courses: CourseCard[]): string {
+  const enrolledCourses = courses.filter((course) => course.enrolled);
+  if (role === 'STUDENT') {
+    const nextCourse = enrolledCourses.slice().sort((left, right) => left.progress_percent - right.progress_percent)[0];
+    return nextCourse
+      ? `${nextCourse.title} ${nextCourse.progress_percent}% 진행 중입니다. 이어서 학습해보세요.`
+      : '수강 중인 강의가 없습니다. 관심 있는 코스를 선택해 첫 학습을 시작해보세요.';
+  }
+
+  if (role === 'INSTRUCTOR') {
+    return '최근 업로드한 자료와 공지를 확인하고 학생 진도 변화를 살펴보세요.';
+  }
+
+  return '운영 통계와 AI 사용량을 확인하고 병목이 생긴 코스를 점검하세요.';
+}
 
 export function getDashboard(userId: string): Dashboard {
   const courses = listCourseCards(userId);
   const activeEnrollments = courses.filter((course) => course.enrolled).length;
   const user = getDemoUser(userId);
+  const role = user?.role ?? 'STUDENT';
   const averageProgress =
     courses.length === 0
       ? 0
       : Math.round(courses.reduce((sum, course) => sum + course.progress_percent, 0) / courses.length);
 
+  const stats =
+    role === 'ADMIN'
+      ? getAdminStats(courses)
+      : role === 'INSTRUCTOR'
+      ? getInstructorStats(userId)
+        : getCourseStats(courses);
+
+  const recentActivities =
+    role === 'ADMIN'
+      ? getAdminActivities()
+      : role === 'INSTRUCTOR'
+        ? getInstructorActivities(userId)
+        : getStudentActivities(userId);
+
   return {
     learner_name: user?.name ?? '학습자',
-    role: user?.role ?? 'STUDENT',
+    role,
     total_courses: courses.length,
     active_enrollments: activeEnrollments,
     average_progress: averageProgress,
     courses,
+    stats,
+    recent_activities: recentActivities,
+    next_action: buildNextAction(role, courses),
   };
 }

--- a/packages/shared/src/lms/learning/progress.ts
+++ b/packages/shared/src/lms/learning/progress.ts
@@ -2,6 +2,10 @@ import { demoEnrollments, demoLectureProgress, demoLectures } from '../../data/d
 import type { Enrollment, LectureCompletionResult } from '../../types';
 import { getCourseLectures } from './helpers';
 
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
 export function completeLectureProgress(userId: string, lectureId: string): LectureCompletionResult {
   const lecture = demoLectures.find((item) => item.id === lectureId);
   if (!lecture) {
@@ -22,12 +26,17 @@ export function completeLectureProgress(userId: string, lectureId: string): Lect
 
   if (existingProgress) {
     existingProgress.is_completed = true;
+    existingProgress.completed_at = nowIso();
+    existingProgress.updated_at = existingProgress.completed_at;
   } else {
+    const completedAt = nowIso();
     demoLectureProgress.push({
       id: `prg_${String(demoLectureProgress.length + 1).padStart(3, '0')}`,
       user_id: userId,
       lecture_id: lectureId,
       is_completed: true,
+      completed_at: completedAt,
+      updated_at: completedAt,
     });
   }
 
@@ -69,6 +78,7 @@ export function enrollUser(userId: string, courseId: string): Enrollment {
     course_id: courseId,
     status: 'active',
     progress_percent: 0,
+    created_at: nowIso(),
   };
 
   demoEnrollments.push(enrollment);

--- a/packages/shared/src/types/lms.ts
+++ b/packages/shared/src/types/lms.ts
@@ -30,6 +30,7 @@ export type Enrollment = {
   course_id: string;
   status: EnrollmentStatus;
   progress_percent: number;
+  created_at?: string;
 };
 
 export type LectureProgress = {
@@ -37,6 +38,8 @@ export type LectureProgress = {
   user_id: string;
   lecture_id: string;
   is_completed: boolean;
+  completed_at?: string;
+  updated_at?: string;
 };
 
 export type Material = {
@@ -47,6 +50,42 @@ export type Material = {
   file_name: string;
   uploaded_by: string;
   uploaded_at: string;
+};
+
+export type DashboardTone = 'indigo' | 'emerald' | 'violet' | 'amber' | 'slate';
+
+export type DashboardStat = {
+  id: string;
+  label: string;
+  value: string;
+  hint: string;
+  icon: string;
+  tone: DashboardTone;
+};
+
+export type DashboardActivityType =
+  | 'enrollment'
+  | 'lecture_complete'
+  | 'ai_chat'
+  | 'ai_summary'
+  | 'quiz'
+  | 'shortform'
+  | 'material'
+  | 'notice'
+  | 'insight';
+
+export type DashboardActivity = {
+  id: string;
+  type: DashboardActivityType;
+  title: string;
+  detail: string;
+  timestamp: string;
+  icon: string;
+  tone: DashboardTone;
+  course_id?: string;
+  course_title?: string;
+  lecture_id?: string;
+  lecture_title?: string;
 };
 
 export type Notice = {
@@ -196,6 +235,9 @@ export type Dashboard = {
   active_enrollments: number;
   average_progress: number;
   courses: CourseCard[];
+  stats: DashboardStat[];
+  recent_activities: DashboardActivity[];
+  next_action: string;
 };
 
 export type LectureCompletionResult =


### PR DESCRIPTION
# 변경 요약
대시보드에 최근 활동 타임라인과 역할별 통계 카드를 추가해 학습 흐름과 운영 현황을 더 빠르게 파악할 수 있게 했습니다.

## 배경
현재 대시보드는 핵심 요약만 보여줘서 사용자가 최근에 무엇을 했는지, 다음에 무엇을 해야 하는지 읽기 어렵습니다. 최근 활동과 학습 통계를 함께 보여주면 맥락 파악이 쉬워집니다.

## 변경 내용
- `Dashboard` 타입에 `stats`, `recent_activities`, `next_action`을 추가했습니다.
- enrollment와 lecture progress에 타임스탬프를 넣어 최근 활동을 실제 순서로 정렬할 수 있게 했습니다.
- shared dashboard 계산 로직에서 학생, 강사, 운영자 역할별 통계와 활동 목록을 구성했습니다.
- 학생, 강사, 운영자 대시보드에 통계 카드와 최근 활동 타임라인을 추가했습니다.
- 대시보드 통계와 타임라인 공통 렌더링 컴포넌트를 분리했습니다.
- 변경 요약을 `docs/dev-logs/2026-04-09-dashboard-activity-timeline.md`에 남겼습니다.

## 연결 이슈
- Closes #50
- Fixes #50

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 frontend/ 담당자 확인이 필요하다
- [x] 백엔드 변경이면 backend/ 담당자 확인이 필요하다
- [x] 문서 변경이면 docs/ 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 packages/shared/ 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다