### PR TITLE
feat: connect ai provider execution

### DIFF
--- a/backend/src/lib/ai-adapter.ts
+++ b/backend/src/lib/ai-adapter.ts
@@ -1,6 +1,4 @@
 import {
-  answerAIQuestion,
-  classifyAIIntent,
   searchAIContent,
   type AIAnswerRequest,
   type AIAnswerResult,
@@ -15,7 +13,7 @@ import {
   type AISummaryRequest,
   type AISummaryResult,
 } from '@myway/shared';
-import { runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine';
+import { runAIAnswerWithEngine, runAIIntentWithEngine, runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine';
 import { getAIProviderSelection } from './ai-provider';
 import type { RuntimeBindings } from './runtime-env';
 
@@ -41,9 +39,13 @@ function resolveProvider(feature: AIProviderCapability, preferredProvider?: AIPr
   return getAIProviderSelection(feature, preferredProvider).current_provider;
 }
 
-export function runAIIntent(input: AIIntentRequest, preferredProvider?: AIProviderName): AIIntentResult {
-  void resolveProvider('intent', preferredProvider);
-  return classifyAIIntent(input);
+export async function runAIIntent(
+  input: AIIntentRequest,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<AIIntentResult> {
+  resolveProvider('intent', preferredProvider);
+  return runAIIntentWithEngine(input, preferredProvider, env);
 }
 
 export function runAISearch(input: AISearchRequest, preferredProvider?: AIProviderName): AISearchResult {
@@ -51,9 +53,13 @@ export function runAISearch(input: AISearchRequest, preferredProvider?: AIProvid
   return searchAIContent(input);
 }
 
-export function runAIAnswer(input: AIAnswerRequest, preferredProvider?: AIProviderName): AIAnswerResult {
-  void resolveProvider('answer', preferredProvider);
-  return answerAIQuestion(input);
+export async function runAIAnswer(
+  input: AIAnswerRequest,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<AIAnswerResult> {
+  resolveProvider('answer', preferredProvider);
+  return runAIAnswerWithEngine(input, preferredProvider, env);
 }
 
 export async function runAISummary(
@@ -82,11 +88,11 @@ export async function runAIFeature<TFeature extends AIAdapterFeature>(
 ): Promise<AIAdapterResultMap[TFeature]> {
   switch (feature) {
     case 'intent':
-      return runAIIntent(input as AIIntentRequest, preferredProvider) as AIAdapterResultMap[TFeature];
+      return (await runAIIntent(input as AIIntentRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
     case 'search':
       return runAISearch(input as AISearchRequest, preferredProvider) as AIAdapterResultMap[TFeature];
     case 'answer':
-      return runAIAnswer(input as AIAnswerRequest, preferredProvider) as AIAdapterResultMap[TFeature];
+      return (await runAIAnswer(input as AIAnswerRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
     case 'summary':
       return (await runAISummary(input as AISummaryRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
     case 'quiz':

--- a/backend/src/lib/ai-engine.ts
+++ b/backend/src/lib/ai-engine.ts
@@ -1,10 +1,18 @@
 import {
+  answerAIQuestion,
+  classifyAIIntent,
   createAISummary,
   generateAIQuiz,
   getLectureDetail,
   getLectureTranscript,
   listLectureNotes,
+  type AIAction,
+  type AIIntent,
   type AIProviderName,
+  type AIIntentRequest,
+  type AIIntentResult,
+  type AIAnswerRequest,
+  type AIAnswerResult,
   type AIQuizQuestion,
   type AIQuizRequest,
   type AIQuizResult,
@@ -16,6 +24,8 @@ import { runOllamaChat, type OllamaChatMessage } from './providers';
 import type { RuntimeBindings } from './runtime-env';
 
 type JsonObject = Record<string, unknown>;
+
+const OLLAMA_TIMEOUT_MS = 15_000;
 
 function normalizeText(value: string): string {
   return value.replaceAll(/\s+/g, ' ').trim();
@@ -78,6 +88,42 @@ function pickString(value: unknown, fallback: string): string {
 function pickDifficulty(value: unknown, fallback: AIQuizResult['difficulty']): AIQuizResult['difficulty'] {
   if (value === 'easy' || value === 'medium' || value === 'hard') {
     return value;
+  }
+
+  return fallback;
+}
+
+function pickIntent(value: unknown, fallback: AIIntent): AIIntent {
+  const allowed: AIIntent[] = [
+    'request_summary',
+    'generate_quiz',
+    'search_content',
+    'ask_concept',
+    'ask_recommendation',
+    'explain_deeper',
+    'translate',
+    'compare',
+    'create_shortform',
+    'extract_audio',
+    'analyze_progress',
+    'general_chat',
+    'clarify',
+  ];
+
+  return typeof value === 'string' && allowed.includes(value as AIIntent) ? (value as AIIntent) : fallback;
+}
+
+function pickAction(value: unknown, fallback: AIAction): AIAction {
+  if (value === 'SEARCH' || value === 'DIRECT_ANSWER' || value === 'CLARIFY' || value === 'DECOMPOSE') {
+    return value;
+  }
+
+  return fallback;
+}
+
+function pickConfidence(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0.35, Math.min(0.98, value));
   }
 
   return fallback;
@@ -216,9 +262,168 @@ function getLectureSourceText(lectureId: string): { lectureTitle: string; course
   };
 }
 
-function isRemoteFeatureEnabled(feature: 'summary' | 'quiz', preferredProvider?: AIProviderName): boolean {
+function getOllamaModel(env?: RuntimeBindings): string {
+  return env?.MYWAY_OLLAMA_MODEL ?? env?.OLLAMA_MODEL ?? 'llama3.1';
+}
+
+function isRemoteFeatureEnabled(feature: 'intent' | 'answer' | 'summary' | 'quiz', preferredProvider?: AIProviderName): boolean {
   const provider = getAIProviderSelection(feature, preferredProvider);
   return provider.current_provider === 'ollama';
+}
+
+function buildIntentPrompt(input: AIIntentRequest, fallback: AIIntentResult): OllamaChatMessage[] {
+  const lecture = input.lecture_id ? getLectureDetail(input.lecture_id) : undefined;
+
+  return [
+    {
+      role: 'system',
+      content:
+        'You are an AI intent classifier for a learning platform. Return valid JSON only. Do not wrap the response in markdown or prose.',
+    },
+    {
+      role: 'user',
+      content: [
+        `Message: ${input.message}`,
+        `Lecture title: ${lecture?.title ?? 'none'}`,
+        `Course title: ${lecture?.course_title ?? 'none'}`,
+        `Context: ${(input.context ?? []).join(' | ') || 'none'}`,
+        'Return JSON with the following shape:',
+        '{"intent":"request_summary|generate_quiz|search_content|ask_concept|ask_recommendation|explain_deeper|translate|compare|create_shortform|extract_audio|analyze_progress|general_chat|clarify","confidence":0.0,"action":"SEARCH|DIRECT_ANSWER|CLARIFY|DECOMPOSE","reason":"string","entities":["string"],"needs_clarification":true}',
+        'Rules:',
+        '- Keep the confidence between 0 and 1.',
+        '- Keep the action aligned with the intent.',
+        '- Use the lecture and context when it helps classification.',
+        '- Return a concise reason in Korean.',
+        '- entities should contain 2 to 6 short values.',
+        `Fallback intent: ${fallback.intent}`,
+        `Fallback action: ${fallback.action}`,
+      ].join('\n'),
+    },
+  ];
+}
+
+function buildAnswerPrompt(input: AIAnswerRequest, fallback: AIAnswerResult): OllamaChatMessage[] {
+  const lecture = input.lecture_id ? getLectureDetail(input.lecture_id) : undefined;
+  const references = fallback.references.slice(0, 3);
+
+  return [
+    {
+      role: 'system',
+      content:
+        'You are a grounded lecture assistant. Return valid JSON only. Do not wrap the response in markdown or prose.',
+    },
+    {
+      role: 'user',
+      content: [
+        `Question: ${input.question}`,
+        `Lecture title: ${lecture?.title ?? 'none'}`,
+        `Course title: ${lecture?.course_title ?? 'none'}`,
+        `Intent: ${fallback.intent.intent}`,
+        'Reference snippets:',
+        ...references.map((reference, index) => `${index + 1}. ${reference.title}: ${reference.excerpt}`),
+        'Return JSON with the following shape:',
+        '{"answer":"string","suggestions":["string","string"]}',
+        'Rules:',
+        '- Base the answer on the provided references and lecture context.',
+        '- Keep the answer short, direct, and natural in Korean.',
+        '- suggestions should contain 2 short follow-up questions.',
+        '- If the references are weak, acknowledge that briefly.',
+      ].join('\n'),
+    },
+  ];
+}
+
+async function runOllamaStructuredIntent(
+  input: AIIntentRequest,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<AIIntentResult> {
+  const fallback = classifyAIIntent(input);
+
+  if (!isRemoteFeatureEnabled('intent', preferredProvider)) {
+    return fallback;
+  }
+
+  const response = await runOllamaChat(buildIntentPrompt(input, fallback), env, {
+    model: getOllamaModel(env),
+    temperature: 0.1,
+    timeoutMs: OLLAMA_TIMEOUT_MS,
+  });
+
+  const parsed = parseJsonObject(response ?? '');
+  if (!parsed) {
+    return fallback;
+  }
+
+  const intent = pickIntent(parsed.intent, fallback.intent);
+  const confidence = pickConfidence(parsed.confidence, fallback.confidence);
+  const action = pickAction(parsed.action, fallback.action);
+  const entities = toStringArray(parsed.entities);
+  const reason = pickString(parsed.reason, fallback.reason);
+  const needsClarification =
+    typeof parsed.needs_clarification === 'boolean'
+      ? parsed.needs_clarification
+      : fallback.needs_clarification;
+
+  return {
+    ...fallback,
+    intent,
+    confidence,
+    action,
+    entities: entities.length > 0 ? entities.slice(0, 6) : fallback.entities,
+    reason,
+    needs_clarification: needsClarification,
+  };
+}
+
+async function runOllamaStructuredAnswer(
+  input: AIAnswerRequest,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<AIAnswerResult> {
+  const fallback = answerAIQuestion(input);
+
+  if (!isRemoteFeatureEnabled('answer', preferredProvider)) {
+    return fallback;
+  }
+
+  const response = await runOllamaChat(buildAnswerPrompt(input, fallback), env, {
+    model: getOllamaModel(env),
+    temperature: 0.2,
+    timeoutMs: OLLAMA_TIMEOUT_MS,
+  });
+
+  const parsed = parseJsonObject(response ?? '');
+  if (!parsed) {
+    return fallback;
+  }
+
+  const answer = pickString(parsed.answer, fallback.answer);
+  if (!answer) {
+    return fallback;
+  }
+
+  return {
+    ...fallback,
+    answer,
+    suggestions: toStringArray(parsed.suggestions).slice(0, 2).concat(fallback.suggestions).slice(0, 2),
+  };
+}
+
+export async function runAIIntentWithEngine(
+  input: AIIntentRequest,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<AIIntentResult> {
+  return runOllamaStructuredIntent(input, preferredProvider, env);
+}
+
+export async function runAIAnswerWithEngine(
+  input: AIAnswerRequest,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<AIAnswerResult> {
+  return runOllamaStructuredAnswer(input, preferredProvider, env);
 }
 
 export async function runAISummaryWithEngine(
@@ -238,7 +443,10 @@ export async function runAISummaryWithEngine(
   }
 
   const messages = buildSummaryPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input.style, input.language);
-  const response = await runOllamaChat(messages, env);
+  const response = await runOllamaChat(messages, env, {
+    model: getOllamaModel(env),
+    timeoutMs: OLLAMA_TIMEOUT_MS,
+  });
 
   if (!response) {
     return fallback;
@@ -285,7 +493,10 @@ export async function runAIQuizWithEngine(
   }
 
   const messages = buildQuizPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input);
-  const response = await runOllamaChat(messages, env);
+  const response = await runOllamaChat(messages, env, {
+    model: getOllamaModel(env),
+    timeoutMs: OLLAMA_TIMEOUT_MS,
+  });
 
   if (!response) {
     return fallback;

--- a/backend/src/lib/providers/ollama.ts
+++ b/backend/src/lib/providers/ollama.ts
@@ -33,30 +33,41 @@ export async function runOllamaChat(
   options?: {
     model?: string;
     temperature?: number;
+    timeoutMs?: number;
   },
 ): Promise<string | null> {
   const baseUrl = env?.MYWAY_OLLAMA_BASE_URL ?? env?.OLLAMA_BASE_URL ?? 'http://127.0.0.1:11434';
   const model = options?.model ?? env?.MYWAY_OLLAMA_MODEL ?? env?.OLLAMA_MODEL ?? 'llama3.1';
+  const timeoutMs = options?.timeoutMs ?? 15_000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-  const response = await fetch(`${trimTrailingSlash(baseUrl)}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model,
-      messages,
-      stream: false,
-      options: {
-        temperature: options?.temperature ?? 0.2,
+  try {
+    const response = await fetch(`${trimTrailingSlash(baseUrl)}/api/chat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
       },
-    }),
-  });
+      signal: controller.signal,
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: false,
+        options: {
+          temperature: options?.temperature ?? 0.2,
+        },
+      }),
+    });
 
-  if (!response.ok) {
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as unknown;
+    return extractChatContent(payload);
+  } catch {
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  const payload = (await response.json()) as unknown;
-  return extractChatContent(payload);
 }

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -51,6 +51,18 @@ function estimateLatencyMs(inputText: string, outputText: string): number {
   return Math.max(1, Math.round((inputText.length + outputText.length) * 2));
 }
 
+function getOllamaModel(env?: RuntimeBindings): string {
+  return env?.MYWAY_OLLAMA_MODEL ?? env?.OLLAMA_MODEL ?? 'llama3.1';
+}
+
+function buildResponseMetadata(feature: 'intent' | 'search' | 'answer' | 'summary' | 'quiz', env?: RuntimeBindings) {
+  if (feature === 'search') {
+    return { provider: 'demo', model: 'demo-search-v1' };
+  }
+
+  return { provider: getAIProviderSelection(feature).current_provider, model: getOllamaModel(env) };
+}
+
 function recordUsageLog(input: {
   user_id: string | null;
   feature: string;
@@ -83,24 +95,29 @@ ai.post('/intent', async (c) => {
     return jsonFailure('MESSAGE_REQUIRED', 'message가 필요합니다.');
   }
 
-  const result = runAIIntent({
-    message,
-    lecture_id: body?.lecture_id?.trim(),
-    context: body?.context,
-  });
+  const env = c.env as RuntimeBindings | undefined;
+  const metadata = buildResponseMetadata('intent', env);
+  const result = await runAIIntent(
+    {
+      message,
+      lecture_id: body?.lecture_id?.trim(),
+      context: body?.context,
+    },
+    undefined,
+    env,
+  );
 
   if (user) {
-    const provider = getAIProviderSelection('intent').current_provider;
+    const lectureSnapshot = getLectureSnapshot(result.lecture_id ?? body?.lecture_id?.trim());
     recordUsageLog({
       user_id: user.id,
       feature: 'intent',
-      provider,
-      model: 'demo-intent-v1',
+      provider: metadata.provider,
+      model: metadata.model,
       input_text: message,
       output_text: result.reason,
       success: true,
     });
-    const lectureSnapshot = getLectureSnapshot(result.lecture_id ?? body?.lecture_id?.trim());
     appendAIIntentLog({
       user_id: user.id,
       message,
@@ -114,7 +131,7 @@ ai.post('/intent', async (c) => {
     });
   }
 
-  return jsonSuccess(result, '인텐트가 분류되었습니다.');
+  return jsonSuccess({ ...result, provider: metadata.provider, model: metadata.model }, '인텐트가 분류되었습니다.');
 });
 
 ai.post('/search', async (c) => {
@@ -131,6 +148,8 @@ ai.post('/search', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
+  const env = c.env as RuntimeBindings | undefined;
+  const metadata = buildResponseMetadata('search', env);
   const result = runAISearch({
     query,
     lecture_id: lectureId,
@@ -138,19 +157,18 @@ ai.post('/search', async (c) => {
   });
 
   if (user) {
-    const provider = getAIProviderSelection('search').current_provider;
     recordUsageLog({
       user_id: user.id,
       feature: 'search',
-      provider,
-      model: 'demo-search-v1',
+      provider: metadata.provider,
+      model: metadata.model,
       input_text: query,
       output_text: JSON.stringify(result.hits),
       success: true,
     });
   }
 
-  return jsonSuccess(result, '검색 결과를 조회했습니다.');
+  return jsonSuccess({ ...result, provider: metadata.provider, model: metadata.model }, '검색 결과를 조회했습니다.');
 });
 
 ai.post('/answer', async (c) => {
@@ -167,21 +185,26 @@ ai.post('/answer', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  const result = runAIAnswer({
-    question,
-    lecture_id: lectureId,
-    intent_hint: body?.intent_hint,
-    limit: body?.limit,
-  });
+  const env = c.env as RuntimeBindings | undefined;
+  const metadata = buildResponseMetadata('answer', env);
+  const result = await runAIAnswer(
+    {
+      question,
+      lecture_id: lectureId,
+      intent_hint: body?.intent_hint,
+      limit: body?.limit,
+    },
+    undefined,
+    env,
+  );
 
   if (user) {
-    const provider = getAIProviderSelection('answer').current_provider;
     const lectureSnapshot = getLectureSnapshot(result.lecture_id ?? lectureId);
     recordUsageLog({
       user_id: user.id,
       feature: 'answer',
-      provider,
-      model: 'demo-answer-v1',
+      provider: metadata.provider,
+      model: metadata.model,
       input_text: question,
       output_text: result.answer,
       success: true,
@@ -192,12 +215,12 @@ ai.post('/answer', async (c) => {
       course_id: lectureSnapshot.course_id ?? 'crs_unknown',
       question,
       answer: result.answer,
-      model: 'demo-answer-v1',
+      model: metadata.model,
       success: true,
     });
   }
 
-  return jsonSuccess(result, '답변을 생성했습니다.');
+  return jsonSuccess({ ...result, provider: metadata.provider, model: metadata.model }, '답변을 생성했습니다.');
 });
 
 ai.post('/summary', async (c) => {
@@ -214,6 +237,7 @@ ai.post('/summary', async (c) => {
   }
 
   const env = c.env as RuntimeBindings | undefined;
+  const metadata = buildResponseMetadata('summary', env);
   const result = await runAISummary(
     {
       lecture_id: lectureId,
@@ -229,19 +253,18 @@ ai.post('/summary', async (c) => {
   }
 
   if (user) {
-    const provider = getAIProviderSelection('summary').current_provider;
     recordUsageLog({
       user_id: user.id,
       feature: 'summary',
-      provider,
-      model: env?.MYWAY_OLLAMA_MODEL ?? env?.OLLAMA_MODEL ?? 'llama3.1',
+      provider: metadata.provider,
+      model: metadata.model,
       input_text: lectureId,
       output_text: result.content,
       success: true,
     });
   }
 
-  return jsonSuccess(result, '요약이 생성되었습니다.');
+  return jsonSuccess({ ...result, provider: metadata.provider, model: metadata.model }, '요약이 생성되었습니다.');
 });
 
 ai.post('/quiz', async (c) => {
@@ -258,6 +281,7 @@ ai.post('/quiz', async (c) => {
   }
 
   const env = c.env as RuntimeBindings | undefined;
+  const metadata = buildResponseMetadata('quiz', env);
   const result = await runAIQuiz(
     {
       lecture_id: lectureId,
@@ -273,19 +297,18 @@ ai.post('/quiz', async (c) => {
   }
 
   if (user) {
-    const provider = getAIProviderSelection('quiz').current_provider;
     recordUsageLog({
       user_id: user.id,
       feature: 'quiz',
-      provider,
-      model: env?.MYWAY_OLLAMA_MODEL ?? env?.OLLAMA_MODEL ?? 'llama3.1',
+      provider: metadata.provider,
+      model: metadata.model,
       input_text: lectureId,
       output_text: JSON.stringify(result.questions),
       success: true,
     });
   }
 
-  return jsonSuccess(result, '퀴즈가 생성되었습니다.');
+  return jsonSuccess({ ...result, provider: metadata.provider, model: metadata.model }, '퀴즈가 생성되었습니다.');
 });
 
 export default ai;

--- a/docs/dev-logs/2026-04-09-ai-provider-connection-a-b-compare.md
+++ b/docs/dev-logs/2026-04-09-ai-provider-connection-a-b-compare.md
@@ -1,0 +1,39 @@
+# 2026-04-09 ai provider connection A/B compare
+
+## 변경 요약
+- 실제 AI provider 하나를 backend 호출 경로에 연결하고, fallback과 timeout 정책을 고정했다.
+- A/B 워킹트리 비교 후 A안을 선택했다.
+
+## 배경
+- `#72`는 AI provider 카탈로그와 adapter만 있던 상태에서, 실제 LLM 호출까지 이어지는 경로를 만드는 작업이다.
+- 목표는 provider 1개를 먼저 붙이고, 실패 시 기존 shared fallback으로 돌아가게 만드는 것이다.
+
+## 변경 내용
+- `backend/src/lib/providers/ollama.ts`
+  - Ollama chat 호출에 timeout abort를 추가했다.
+- `backend/src/lib/ai-engine.ts`
+  - intent와 answer를 Ollama structured output으로 먼저 시도하고, 실패 시 shared fallback으로 돌아가게 했다.
+  - summary와 quiz에도 같은 timeout 정책을 적용했다.
+- `backend/src/lib/ai-adapter.ts`
+  - intent와 answer를 async provider 경로로 전환했다.
+- `backend/src/routes/ai.ts`
+  - 응답에 provider/model 메타데이터를 함께 돌려주도록 정리했다.
+- `docs/project/20-status-and-next-steps.md`
+  - AI provider 실제 연결 완료 상태를 반영했다.
+
+## 연결 이슈
+- Closes #72
+
+## 검증
+- `npm run build:backend`
+
+## 코드리뷰
+- A안은 provider client와 adapter를 분리해서 나중에 Gemini / Cloudflare 확장이 쉽다.
+- B안은 라우트에 직접 묶는 방식이라 빠르지만, fallback과 timeout 정책이 퍼지기 쉬워서 제외했다.
+
+## 체크 사항
+- [x] A/B 워킹트리 비교 후 A안 선택
+- [x] timeout 정책 적용
+- [x] provider/model 메타데이터 응답 반영
+- [x] backend 빌드 확인
+- [x] 이슈 연결

--- a/docs/project/20-status-and-next-steps.md
+++ b/docs/project/20-status-and-next-steps.md
@@ -10,6 +10,7 @@
 - AI 레이어
   - AI provider 카탈로그와 adapter 분리
   - 실제 엔진 연결 가이드 문서화
+  - 실제 Ollama provider 연결과 fallback / timeout 정책 고정
   - AI 요약, 퀴즈, 채팅, 인사이트 흐름 정리
 - STT / 미디어
   - STT provider adapter와 실제 Cloudflare 전사 경로 연결
@@ -37,7 +38,7 @@
 
 ## 앞으로 해야 할 기능
 - 실제 엔진 연결
-  - AI provider는 실제 호출과 fallback 전략을 계속 확장한다.
+  - AI provider는 Ollama 실제 호출 경로를 붙였고, 이후 Gemini / Cloudflare 확장을 검토한다.
   - STT provider는 실제 호출 경로를 붙였으니, 이후 다른 provider 확장을 검토한다.
 - 데이터 지속성
   - 데모 메모리 기반 append 구조를 유지하면서, DB나 영속 저장소 이관 시점을 검토한다.


### PR DESCRIPTION
# 변경 요약
실제 AI provider 하나를 backend 호출 경로에 연결하고, fallback과 timeout 정책을 고정했습니다.

## 배경
`#72`는 AI provider 카탈로그와 adapter만 있던 상태에서, 실제 LLM 호출까지 이어지는 경로를 만드는 작업입니다.

## 변경 내용
- `backend/src/lib/providers/ollama.ts`에 timeout abort를 추가했습니다.
- `backend/src/lib/ai-engine.ts`에서 intent와 answer를 Ollama structured output으로 먼저 시도하고, 실패 시 shared fallback으로 돌아가게 했습니다.
- `backend/src/lib/ai-adapter.ts`를 통해 intent와 answer를 async provider 경로로 전환했습니다.
- `backend/src/routes/ai.ts`에서 응답에 provider/model 메타데이터를 함께 반환하도록 정리했습니다.
- `docs/project/20-status-and-next-steps.md`와 dev log를 갱신했습니다.

## 연결 이슈
Closes #72

## 검증
- `npm run build:backend`

## 코드리뷰
- A안은 provider client와 adapter를 분리해서 나중에 Gemini / Cloudflare 확장이 쉽습니다.
- B안은 라우트에 직접 묶는 방식이라 빠르지만, fallback과 timeout 정책이 퍼지기 쉬워서 제외했습니다.

## 체크 사항
- [x] A/B 워킹트리 비교 후 A안 선택
- [x] timeout 정책 적용
- [x] provider/model 메타데이터 응답 반영
- [x] backend 빌드 확인
- [x] 이슈 연결