### PR TITLE
fix: align frontend vite and shared react deps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "vite": "^6.3.5"
   },
   "scripts": {
-    "dev": "vite --config ../vite.config.mjs --configLoader native --host 0.0.0.0 --port 5173 --strictPort",
-    "build": "vite build --config ../vite.config.mjs --configLoader native"
+    "dev": "node ../node_modules/vite/bin/vite.js --config ../vite.config.mjs --configLoader native --host 0.0.0.0 --port 5173 --strictPort",
+    "build": "node ../node_modules/vite/bin/vite.js build --config ../vite.config.mjs --configLoader native"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3178,7 +3178,11 @@
     },
     "packages/shared": {
       "name": "@myway/shared",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "peerDependencies": {
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      }
     }
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,5 +7,9 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "peerDependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   }
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,11 +9,13 @@ const frontendRoot = resolve(repoRoot, 'frontend');
 export default defineConfig({
   root: frontendRoot,
   plugins: [react()],
-  resolve: {
+   resolve: {
     alias: {
       '@myway/shared': resolve(repoRoot, 'packages/shared/src'),
     },
+    dedupe: ['react', 'react-dom'], 
   },
+  
   server: {
     port: 5173,
     host: '0.0.0.0',


### PR DESCRIPTION
# 변경 요약
프론트 Vite 실행 방식과 shared 패키지의 React 의존성 경계를 정리해, Windows 환경에서 dev 서버가 안정적으로 뜨도록 맞췄습니다.

## 배경
`vite` 직접 실행이 frontend workspace에서 잡히지 않았고, React 런타임이 Vite optimizer에서 불안정하게 스캔되면서 `spawn EPERM`이 발생했습니다.

## 변경 내용
- frontend dev/build 스크립트를 루트 Vite 바이너리 직접 실행으로 변경했습니다.
- `packages/shared`에 `react` / `react-dom` peerDependencies를 추가했습니다.
- Vite resolver에 `dedupe: ['react', 'react-dom']`를 넣어 React 중복 해석을 방지했습니다.
- lockfile을 갱신해 workspace 의존성 메타를 맞췄습니다.

## 연결 이슈
- 없음

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다