### PR TITLE
feat: add LMS menu aliases

### DIFF
--- a/docs/dev-logs/2026-04-09-lms-menu-aliases.md
+++ b/docs/dev-logs/2026-04-09-lms-menu-aliases.md
@@ -1,0 +1,26 @@
+# LMS menu aliases update
+
+**날짜**: 2026-04-09
+**관련 이슈**: #88
+**브랜치**: `fix/lms-menu-aliases`
+
+## 변경 요약
+- 권한별 사이드바 항목에 aliases 개념을 추가했다.
+- `courses`, `shortform`, `admin-users` 메뉴가 하위 맥락에서도 활성 표시될 수 있도록 준비했다.
+- `LmsDashboard`에서 현재 화면 상태를 반영하는 `activeNavKey`를 분리했다.
+
+## 왜 필요한가
+- 레퍼런스처럼 하위 페이지에서도 상위 메뉴가 자연스럽게 활성화되어야 한다.
+- 향후 강의 시청, 숏폼 위자드, 관리자 상세 화면 같은 서브 플로우를 붙일 때 메뉴 기준을 다시 만들지 않도록 하려는 목적이다.
+
+## 바뀐 파일
+- `frontend/src/features/lms/types.ts`
+- `frontend/src/features/lms/config.ts`
+- `frontend/src/features/lms/components/AppSidebar.tsx`
+- `frontend/src/features/lms/components/AppShell.tsx`
+- `frontend/src/components/LmsDashboard.tsx`
+
+## 확인 포인트
+- 메뉴 활성화 판정이 공통 helper로 정리됐다.
+- `courses` 메뉴는 강의 상세/시청 맥락을 alias로 흡수할 수 있다.
+- 구조만 바뀐 것이 아니라, 실제 sidebar가 `activeNavKey`를 사용하도록 연결됐다.

--- a/frontend/src/components/LmsDashboard.tsx
+++ b/frontend/src/components/LmsDashboard.tsx
@@ -8,6 +8,10 @@ import type { LmsDashboardProps, LmsPageId } from '../features/lms/types';
 
 export function LmsDashboard(props: LmsDashboardProps) {
   const [activePage, setActivePage] = useState<LmsPageId>(defaultPageForRole(props.session));
+  const activeNavKey =
+    activePage === 'courses' && props.selectedLectureId
+      ? 'lecture-watch'
+      : activePage;
 
   useEffect(() => {
     setActivePage(defaultPageForRole(props.session));
@@ -36,6 +40,7 @@ export function LmsDashboard(props: LmsDashboardProps) {
     <AppShell
       session={props.session}
       activePage={activePage}
+      activeNavKey={activeNavKey}
       title={pageTitle(activePage, props.session.user.role)}
       onNavigate={setActivePage}
       onLogout={props.onLogout}

--- a/frontend/src/features/lms/components/AppShell.tsx
+++ b/frontend/src/features/lms/components/AppShell.tsx
@@ -1,21 +1,22 @@
 import type { LoginResponse } from '@myway/shared';
 import { AppHeader } from './AppHeader';
 import { AppSidebar } from './AppSidebar';
-import type { LmsPageId } from '../types';
+import type { LmsNavKey, LmsPageId } from '../types';
 
 type AppShellProps = {
   session: LoginResponse;
   activePage: LmsPageId;
+  activeNavKey: LmsNavKey;
   title: string;
   onNavigate: (page: LmsPageId) => void;
   onLogout: () => void;
   children: React.ReactNode;
 };
 
-export function AppShell({ session, activePage, title, onNavigate, onLogout, children }: AppShellProps) {
+export function AppShell({ session, activePage, activeNavKey, title, onNavigate, onLogout, children }: AppShellProps) {
   return (
     <div className="min-h-screen bg-[#f8f9fb]">
-      <AppSidebar session={session} activePage={activePage} onNavigate={onNavigate} onLogout={onLogout} />
+      <AppSidebar session={session} activePage={activePage} activeNavKey={activeNavKey} onNavigate={onNavigate} onLogout={onLogout} />
       <div className="min-h-screen lg:ml-64">
         <AppHeader title={title} />
         <main className="mx-auto max-w-[1320px] px-4 py-5 sm:px-6 lg:px-8">{children}</main>

--- a/frontend/src/features/lms/components/AppSidebar.tsx
+++ b/frontend/src/features/lms/components/AppSidebar.tsx
@@ -1,15 +1,16 @@
 import type { LoginResponse } from '@myway/shared';
-import { navGroupsForRole, roleLabel } from '../config';
-import type { LmsPageId } from '../types';
+import { isNavItemActive, navGroupsForRole, roleLabel } from '../config';
+import type { LmsNavKey, LmsPageId } from '../types';
 
 type AppSidebarProps = {
   session: LoginResponse;
   activePage: LmsPageId;
+  activeNavKey: LmsNavKey;
   onNavigate: (page: LmsPageId) => void;
   onLogout: () => void;
 };
 
-export function AppSidebar({ session, activePage, onNavigate, onLogout }: AppSidebarProps) {
+export function AppSidebar({ session, activePage, activeNavKey, onNavigate, onLogout }: AppSidebarProps) {
   const groups = navGroupsForRole(session.user.role);
   const avatarTone =
     session.user.role === 'ADMIN'
@@ -35,7 +36,7 @@ export function AppSidebar({ session, activePage, onNavigate, onLogout }: AppSid
             </div>
             <div className="space-y-0.5">
               {group.items.map((item) => {
-                const active = item.page === activePage;
+                const active = isNavItemActive(item, activeNavKey) || item.page === activePage;
                 return (
                   <button
                     key={item.page}

--- a/frontend/src/features/lms/config.ts
+++ b/frontend/src/features/lms/config.ts
@@ -1,5 +1,5 @@
 import type { AuthUser, LoginResponse, UserRole } from '@myway/shared';
-import type { LmsNavGroup, LmsPageId } from './types';
+import type { LmsNavGroup, LmsNavKey, LmsPageId } from './types';
 
 export function roleLabel(role: UserRole): string {
   if (role === 'ADMIN') return '운영자';
@@ -51,7 +51,7 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
       label: '주요 메뉴',
       items: [
         { page: 'dashboard', icon: 'ri-dashboard-line', label: '대시보드' },
-        { page: 'courses', icon: 'ri-book-2-line', label: '강의 목록' },
+        { page: 'courses', icon: 'ri-book-2-line', label: '강의 목록', aliases: ['lecture-watch'] },
       ],
     },
   ];
@@ -60,7 +60,7 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
     groups.push({
       label: '학습 도구',
       items: [
-        { page: 'shortform', icon: 'ri-scissors-cut-line', label: '숏폼 제작' },
+        { page: 'shortform', icon: 'ri-scissors-cut-line', label: '숏폼 제작', aliases: ['shortform-wizard'] },
         { page: 'community', icon: 'ri-group-line', label: '숏폼 커뮤니티' },
         { page: 'my-shortforms', icon: 'ri-folder-video-line', label: '내 숏폼' },
         { page: 'ai-chat', icon: 'ri-robot-line', label: 'AI 학습 챗' },
@@ -93,7 +93,7 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
     groups.push(
       {
         label: '운영 관리',
-        items: [{ page: 'admin-users', icon: 'ri-user-settings-line', label: '사용자 관리' }],
+        items: [{ page: 'admin-users', icon: 'ri-user-settings-line', label: '사용자 관리', aliases: ['admin-user-detail'] }],
       },
       {
         label: '강의 관리',
@@ -108,4 +108,8 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
   }
 
   return groups;
+}
+
+export function isNavItemActive(item: LmsNavGroup['items'][number], activeNavKey: LmsNavKey): boolean {
+  return item.page === activeNavKey || item.aliases?.includes(activeNavKey) === true;
 }

--- a/frontend/src/features/lms/types.ts
+++ b/frontend/src/features/lms/types.ts
@@ -29,8 +29,11 @@ export type LmsPageId =
   | 'admin-stats'
   | 'admin-automation';
 
+export type LmsNavKey = LmsPageId | 'lecture-watch' | 'shortform-wizard' | 'admin-user-detail';
+
 export type LmsNavItem = {
   page: LmsPageId;
+  aliases?: LmsNavKey[];
   icon: string;
   label: string;
   badge?: string;
@@ -76,6 +79,7 @@ export type LmsDashboardProps = {
   selectedCourse: CourseDetail | null;
   selectedCourseId: string;
   selectedLectureId: string;
+  activeNavKey?: LmsNavKey;
   session: LoginResponse | null;
 };
 


### PR DESCRIPTION
# 변경 요약
권한별 LMS 메뉴에 aliases를 추가하고, 현재 화면 상태를 sidebar 활성 표시와 분리해 하위 맥락에서도 상위 메뉴가 유지되도록 정리했습니다.

## 배경
강의 시청, 숏폼 위자드, 관리자 상세 같은 하위 화면이 붙을 때마다 메뉴 활성 기준을 새로 만들지 않도록 공통 alias 체계가 필요했습니다.

## 변경 내용
- `LmsNavItem`에 `aliases`를 추가했습니다.
- `navGroupsForRole()`에서 강의 목록, 숏폼 제작, 사용자 관리에 alias를 부여했습니다.
- `AppSidebar`가 alias 기반 활성 판정을 사용하도록 바꿨습니다.
- `LmsDashboard`에서 `activeNavKey`를 분리해 현재 문맥을 sidebar에 전달했습니다.
- 변경 요약을 `docs/dev-logs/2026-04-09-lms-menu-aliases.md`에 남겼습니다.

## 연결 이슈
- Closes #88
- Fixes #88

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다