### PR TITLE
feat: mark cloudflare stt as available

### DIFF
--- a/docs/dev-logs/2026-04-10-stt-provider-cloudflare-available.md
+++ b/docs/dev-logs/2026-04-10-stt-provider-cloudflare-available.md
@@ -1,0 +1,14 @@
+# STT Provider Cloudflare Available
+
+## 왜 바꿨나
+- Workers AI 기반 STT가 실제 전사 경로로 동작하는데도, provider 카탈로그와 일부 문서가 `planned`처럼 보여서 상태를 맞출 필요가 있었다.
+- 배포 시 `AI` binding만 있으면 되는 구조라, 별도 API 키보다 Cloudflare binding과 fallback 문서 정리가 더 중요했다.
+
+## 무엇을 바꿨나
+- `packages/shared/src/ai/stt-provider.ts`에서 Cloudflare STT 상태를 `available`로 바꿨다.
+- `docs/project/07-stt-media-pipeline.md`의 provider 설명을 실제 동작 기준으로 정리했다.
+- `docs/project/14-ai-layer.md`에 `audio_url` 기반 Cloudflare 전사 우선 경로를 명시했다.
+
+## 어떻게 검증했나
+- 코드상 `backend/src/lib/providers/cloudflare.ts`가 `env.AI.run(...)`으로 실제 Workers AI 전사를 수행하는지 확인했다.
+- `backend/src/routes/media.ts`가 `audio_url`이 있을 때 실제 전사 결과를 `runTranscriptGeneration`으로 전달하는지 확인했다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-10-stt-provider-cloudflare-available.md`
 - `2026-04-10-cloudflare-pages-deploy.md`
 - `2026-04-10-cloudflare-deploy-setup.md`
 - `2026-04-09-file-split-rule-cleanup.md`

--- a/docs/project/07-stt-media-pipeline.md
+++ b/docs/project/07-stt-media-pipeline.md
@@ -60,9 +60,9 @@
 - 타임스탬프 정렬이 깨지는 경우
 
 ## Provider 계층
-- 현재 구현은 `demo` STT를 기본 경로로 유지한다.
-- 향후 운영 경로는 `Cloudflare AI -> Gemini -> demo` 순의 fallback 계층을 기본으로 둔다.
-- `POST /api/v1/media/transcribe`는 provider 메타데이터를 함께 기록하고, `audio_url`이 주어지면 Cloudflare Workers AI 전사를 먼저 시도한다.
+- 현재 구현은 `audio_url`이 있으면 `Cloudflare AI` 전사를 먼저 시도하고, 텍스트 전용이나 실패 시에는 `demo` STT로 되돌아간다.
+- 운영 경로는 `Cloudflare AI -> Gemini -> demo` 순의 fallback 계층을 기본으로 둔다.
+- `POST /api/v1/media/transcribe`는 provider 메타데이터를 함께 기록한다.
 - `GET /api/v1/media/providers`로 provider 계층을 조회할 수 있다.
 - STT 결과에는 `stt_provider`, `stt_model`, `segments`, `word_count`가 함께 남아야 한다.
 

--- a/docs/project/14-ai-layer.md
+++ b/docs/project/14-ai-layer.md
@@ -81,6 +81,7 @@
 - `STT`와 `embedding`은 `Cloudflare AI`를 우선 고려하고, 텍스트 생성 계열은 `Ollama`를 우선 고려한다.
 - provider 선택과 fallback 순서는 `GET /api/v1/ai/providers`로 조회할 수 있다.
 - backend는 `summary`와 `quiz`에서 Ollama가 가능할 때 실제 JSON 생성 응답을 먼저 시도하고, 실패하면 기존 shared fallback으로 되돌아간다.
+- `POST /api/v1/media/transcribe`는 `audio_url`이 있을 때 Cloudflare Workers AI 전사를 먼저 시도하고, 실패하면 demo 경로로 되돌아간다.
 
 ## 현재 구현
 - `POST /api/v1/ai/intent`로 사용자 메시지의 의도를 분류한다.

--- a/packages/shared/src/ai/stt-provider.ts
+++ b/packages/shared/src/ai/stt-provider.ts
@@ -42,8 +42,8 @@ const PROVIDERS: STTProviderDescriptor[] = [
   {
     name: 'cloudflare',
     label: 'Cloudflare AI',
-    description: '배포 환경에서 안정적으로 붙일 수 있는 STT 및 파이프라인 계층입니다.',
-    status: 'planned',
+    description: '배포 환경에서 실제 Workers AI 전사를 수행하는 STT 계층입니다.',
+    status: 'available',
     capabilities: ['transcribe', 'segment', 'pipeline'],
   },
   {


### PR DESCRIPTION
﻿# 변경 요약
Cloudflare Workers AI 기반 STT가 실제 전사 경로라는 점을 코드와 문서에 맞게 정리했습니다.

## 배경
STT 전사 경로는 이미 구현되어 있었지만, provider 카탈로그와 문서에 `planned`처럼 남아 있어 실제 배포 가능 상태와 표현이 어긋나 있었습니다.

## 변경 내용
- `packages/shared/src/ai/stt-provider.ts`에서 Cloudflare STT 상태를 `available`로 변경했습니다.
- `docs/project/07-stt-media-pipeline.md`의 provider 설명을 실제 동작 기준으로 정리했습니다.
- `docs/project/14-ai-layer.md`에 `audio_url` 기반 Cloudflare 전사 우선 경로를 추가했습니다.
- `docs/dev-logs/2026-04-10-stt-provider-cloudflare-available.md`를 추가했습니다.
- `docs/dev-logs/README.md`에 최신 로그를 반영했습니다.

## 연결 이슈
- Closes #99
- Fixes #99

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
