### PR TITLE
feat: add Gemini fallback path for summary and quiz

### DIFF
--- a/backend/src/lib/ai-adapter.ts
+++ b/backend/src/lib/ai-adapter.ts
@@ -13,7 +13,7 @@ import {
   type AISummaryRequest,
   type AISummaryResult,
 } from '@myway/shared';
-import { runAIAnswerWithEngine, runAIIntentWithEngine, runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine';
+import { type AIEngineExecution, runAIAnswerWithEngine, runAIIntentWithEngine, runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine';
 import { getAIProviderSelection } from './ai-provider';
 import type { RuntimeBindings } from './runtime-env';
 
@@ -66,7 +66,7 @@ export async function runAISummary(
   input: AISummaryRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
-): Promise<AISummaryResult | null> {
+): Promise<AIEngineExecution<AISummaryResult> | null> {
   resolveProvider('summary', preferredProvider);
   return runAISummaryWithEngine(input, preferredProvider, env);
 }
@@ -75,7 +75,7 @@ export async function runAIQuiz(
   input: AIQuizRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
-): Promise<AIQuizResult | null> {
+): Promise<AIEngineExecution<AIQuizResult> | null> {
   resolveProvider('quiz', preferredProvider);
   return runAIQuizWithEngine(input, preferredProvider, env);
 }

--- a/backend/src/lib/ai-engine-runners.ts
+++ b/backend/src/lib/ai-engine-runners.ts
@@ -9,9 +9,11 @@ import type {
   AISummaryResult,
   AIProviderName,
 } from '@myway/shared';
-import { runOllamaChat } from './providers';
+import { getAIProviderSelection } from './ai-provider';
+import { runGeminiJsonPrompt, runOllamaChat } from './providers';
 import type { RuntimeBindings } from './runtime-env';
 import {
+  getGeminiModel,
   OLLAMA_TIMEOUT_MS,
   getAnswerFallback,
   getIntentFallback,
@@ -31,6 +33,45 @@ import {
   truncate,
 } from './ai-engine-utils';
 import { buildAnswerPrompt, buildIntentPrompt, buildQuizPrompt, buildSummaryPrompt } from './ai-engine-prompts';
+
+export type AIEngineExecution<T> = {
+  result: T;
+  provider: AIProviderName | 'demo';
+  model: string;
+};
+
+async function runStructuredJsonFallback(
+  feature: 'summary' | 'quiz',
+  messages: ReturnType<typeof buildSummaryPrompt> | ReturnType<typeof buildQuizPrompt>,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<string | null> {
+  const providerPlan = getAIProviderSelection(feature, preferredProvider);
+
+  for (const provider of providerPlan.fallback_chain) {
+    if (provider === 'ollama') {
+      const response = await runOllamaChat(messages, env, {
+        model: getOllamaModel(env),
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      if (response) {
+        return response;
+      }
+    }
+
+    if (provider === 'gemini') {
+      const response = await runGeminiJsonPrompt(messages, env, {
+        model: getGeminiModel(env),
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      if (response) {
+        return response;
+      }
+    }
+  }
+
+  return null;
+}
 
 async function runOllamaStructuredIntent(
   input: AIIntentRequest,
@@ -119,7 +160,7 @@ export async function runAISummaryWithEngine(
   input: AISummaryRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
-): Promise<AISummaryResult | null> {
+): Promise<AIEngineExecution<AISummaryResult> | null> {
   const fallback = getSummaryFallback(input);
   if (!fallback) {
     return null;
@@ -127,22 +168,58 @@ export async function runAISummaryWithEngine(
 
   const source = getLectureSourceText(input.lecture_id);
   if (!source || !isRemoteFeatureEnabled('summary', preferredProvider) || input.style === 'timeline') {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: 'demo-summary-v1',
+    };
   }
 
   const messages = buildSummaryPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input.style, input.language);
-  const response = await runOllamaChat(messages, env, {
-    model: getOllamaModel(env),
-    timeoutMs: OLLAMA_TIMEOUT_MS,
-  });
+  const providerPlan = getAIProviderSelection('summary', preferredProvider);
+  let response: string | null = null;
+  let responseProvider: AIProviderName | null = null;
+  let responseModel = 'demo-summary-v1';
+
+  for (const provider of providerPlan.fallback_chain) {
+    if (provider === 'ollama') {
+      response = await runOllamaChat(messages, env, {
+        model: getOllamaModel(env),
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      responseProvider = response ? 'ollama' : null;
+      responseModel = getOllamaModel(env);
+    }
+
+    if (!response && provider === 'gemini') {
+      response = await runGeminiJsonPrompt(messages, env, {
+        model: getGeminiModel(env),
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      responseProvider = response ? 'gemini' : responseProvider;
+      responseModel = getGeminiModel(env);
+    }
+
+    if (response) {
+      break;
+    }
+  }
 
   if (!response) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: 'demo-summary-v1',
+    };
   }
 
   const parsed = parseJsonObject(response);
   if (!parsed) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: 'demo-summary-v1',
+    };
   }
 
   const title = pickString(parsed.title, fallback.title ?? `${source.lectureTitle} · 요약`);
@@ -150,17 +227,25 @@ export async function runAISummaryWithEngine(
   const keyPoints = toStringArray(parsed.key_points);
 
   if (!content) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: 'demo-summary-v1',
+    };
   }
 
   return {
-    lecture_id: input.lecture_id,
-    title,
-    style: input.style ?? 'brief',
-    language: input.language ?? 'ko',
-    content,
-    key_points: keyPoints.length > 0 ? keyPoints.slice(0, 5) : fallback.key_points,
-    references: fallback.references,
+    result: {
+      lecture_id: input.lecture_id,
+      title,
+      style: input.style ?? 'brief',
+      language: input.language ?? 'ko',
+      content,
+      key_points: keyPoints.length > 0 ? keyPoints.slice(0, 5) : fallback.key_points,
+      references: fallback.references,
+    },
+    provider: responseProvider ?? 'demo',
+    model: responseProvider === 'gemini' ? getGeminiModel(env) : getOllamaModel(env),
   };
 }
 
@@ -168,7 +253,7 @@ export async function runAIQuizWithEngine(
   input: AIQuizRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
-): Promise<AIQuizResult | null> {
+): Promise<AIEngineExecution<AIQuizResult> | null> {
   const fallback = getQuizFallback(input);
   if (!fallback) {
     return null;
@@ -176,28 +261,65 @@ export async function runAIQuizWithEngine(
 
   const source = getLectureSourceText(input.lecture_id);
   if (!source || !isRemoteFeatureEnabled('quiz', preferredProvider)) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: 'demo-quiz-v1',
+    };
   }
 
   const messages = buildQuizPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input);
-  const response = await runOllamaChat(messages, env, {
-    model: getOllamaModel(env),
-    timeoutMs: OLLAMA_TIMEOUT_MS,
-  });
+  const providerPlan = getAIProviderSelection('quiz', preferredProvider);
+  let response: string | null = null;
+  let responseProvider: AIProviderName | null = null;
+
+  for (const provider of providerPlan.fallback_chain) {
+    if (provider === 'ollama') {
+      response = await runOllamaChat(messages, env, {
+        model: getOllamaModel(env),
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      responseProvider = response ? 'ollama' : null;
+    }
+
+    if (!response && provider === 'gemini') {
+      response = await runGeminiJsonPrompt(messages, env, {
+        model: getGeminiModel(env),
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      responseProvider = response ? 'gemini' : responseProvider;
+    }
+
+    if (response) {
+      break;
+    }
+  }
 
   if (!response) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: 'demo-quiz-v1',
+    };
   }
 
   const parsed = parseJsonObject(response);
   if (!parsed) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: 'demo-quiz-v1',
+    };
   }
 
   const fallbackQuestions = fallback.questions ?? [];
   const engineQuestions = Array.isArray(parsed.questions) ? parsed.questions : [];
   if (fallbackQuestions.length === 0 || engineQuestions.length === 0) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: 'demo-quiz-v1',
+    };
   }
 
   const questions = fallbackQuestions.map((fallbackQuestion, index) =>
@@ -205,9 +327,13 @@ export async function runAIQuizWithEngine(
   );
 
   return {
-    lecture_id: input.lecture_id,
-    title: pickString(parsed.title, fallback.title),
-    difficulty: pickDifficulty(parsed.difficulty, fallback.difficulty),
-    questions,
+    result: {
+      lecture_id: input.lecture_id,
+      title: pickString(parsed.title, fallback.title),
+      difficulty: pickDifficulty(parsed.difficulty, fallback.difficulty),
+      questions,
+    },
+    provider: responseProvider ?? 'demo',
+    model: responseProvider === 'gemini' ? getGeminiModel(env) : getOllamaModel(env),
   };
 }

--- a/backend/src/lib/ai-engine-utils.ts
+++ b/backend/src/lib/ai-engine-utils.ts
@@ -182,9 +182,13 @@ export function getOllamaModel(env?: RuntimeBindings): string {
   return env?.MYWAY_OLLAMA_MODEL ?? env?.OLLAMA_MODEL ?? 'llama3.1';
 }
 
+export function getGeminiModel(env?: RuntimeBindings): string {
+  return env?.MYWAY_GEMINI_MODEL ?? env?.GEMINI_MODEL ?? 'gemini-2.0-flash';
+}
+
 export function isRemoteFeatureEnabled(feature: 'intent' | 'answer' | 'summary' | 'quiz', preferredProvider?: AIProviderName): boolean {
   const provider = getAIProviderSelection(feature, preferredProvider);
-  return provider.current_provider === 'ollama';
+  return provider.current_provider === 'ollama' || provider.current_provider === 'gemini';
 }
 
 export function getIntentFallback(input: AIIntentRequest): AIIntentResult {

--- a/backend/src/lib/ai-engine.ts
+++ b/backend/src/lib/ai-engine.ts
@@ -1,1 +1,2 @@
 export { runAIIntentWithEngine, runAIAnswerWithEngine, runAISummaryWithEngine, runAIQuizWithEngine } from './ai-engine-runners';
+export type { AIEngineExecution } from './ai-engine-runners';

--- a/backend/src/lib/providers/gemini.ts
+++ b/backend/src/lib/providers/gemini.ts
@@ -1,0 +1,107 @@
+import type { RuntimeBindings } from '../runtime-env';
+import { getGeminiRuntimeSettings } from '../runtime-env';
+import type { OllamaChatMessage } from './ollama';
+
+type GeminiGenerateContentResponse = {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+      }>;
+    };
+  }>;
+};
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function toGeminiRole(role: OllamaChatMessage['role']): 'user' | 'model' {
+  return role === 'assistant' ? 'model' : 'user';
+}
+
+function extractText(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const response = payload as GeminiGenerateContentResponse;
+  const text = response.candidates
+    ?.flatMap((candidate) => candidate.content?.parts ?? [])
+    .map((part) => part.text?.trim() ?? '')
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+
+  return text ? text : null;
+}
+
+export async function runGeminiJsonPrompt(
+  messages: OllamaChatMessage[],
+  env?: RuntimeBindings,
+  options?: {
+    model?: string;
+    temperature?: number;
+    timeoutMs?: number;
+  },
+): Promise<string | null> {
+  const settings = getGeminiRuntimeSettings(env);
+  if (!settings.api_key || !settings.model) {
+    return null;
+  }
+
+  const timeoutMs = options?.timeoutMs ?? 15_000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  const systemInstruction = messages
+    .filter((message) => message.role === 'system')
+    .map((message) => message.content.trim())
+    .filter(Boolean)
+    .join('\n');
+
+  const contents = messages
+    .filter((message) => message.role !== 'system')
+    .map((message) => ({
+      role: toGeminiRole(message.role),
+      parts: [{ text: message.content }],
+    }));
+
+  try {
+    const response = await fetch(
+      `${trimTrailingSlash(settings.base_url)}/models/${encodeURIComponent(options?.model ?? settings.model)}:generateContent?key=${encodeURIComponent(settings.api_key)}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+        body: JSON.stringify({
+          ...(systemInstruction
+            ? {
+                systemInstruction: {
+                  parts: [{ text: systemInstruction }],
+                },
+              }
+            : {}),
+          contents,
+          generationConfig: {
+            temperature: options?.temperature ?? 0.2,
+            responseMimeType: 'application/json',
+          },
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as unknown;
+    return extractText(payload);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/backend/src/lib/providers/index.ts
+++ b/backend/src/lib/providers/index.ts
@@ -1,2 +1,3 @@
 export { runOllamaChat, type OllamaChatMessage } from './ollama';
+export { runGeminiJsonPrompt } from './gemini';
 export { runCloudflareTranscription, type CloudflareTranscriptionOutput } from './cloudflare';

--- a/backend/src/lib/runtime-env.ts
+++ b/backend/src/lib/runtime-env.ts
@@ -38,6 +38,12 @@ export type RuntimeBindings = {
   OLLAMA_BASE_URL?: string;
   MYWAY_OLLAMA_MODEL?: string;
   OLLAMA_MODEL?: string;
+  MYWAY_GEMINI_API_KEY?: string;
+  GEMINI_API_KEY?: string;
+  MYWAY_GEMINI_MODEL?: string;
+  GEMINI_MODEL?: string;
+  MYWAY_GEMINI_BASE_URL?: string;
+  GEMINI_BASE_URL?: string;
   MYWAY_CLOUDFLARE_STT_MODEL?: string;
   CLOUDFLARE_STT_MODEL?: string;
   MYWAY_MEDIA_PROCESSOR_URL?: string;
@@ -81,6 +87,23 @@ export function getCloudflareSTTRuntimeSettings(env?: RuntimeBindings): {
         'MYWAY_CLOUDFLARE_STT_MODEL',
         getRuntimeValue(env, 'CLOUDFLARE_STT_MODEL', '@cf/openai/whisper-large-v3-turbo'),
       ) ?? '@cf/openai/whisper-large-v3-turbo',
+  };
+}
+
+export function getGeminiRuntimeSettings(env?: RuntimeBindings): {
+  api_key?: string;
+  model?: string;
+  base_url: string;
+} {
+  return {
+    api_key: getRuntimeValue(env, 'MYWAY_GEMINI_API_KEY', getRuntimeValue(env, 'GEMINI_API_KEY')),
+    model: getRuntimeValue(env, 'MYWAY_GEMINI_MODEL', getRuntimeValue(env, 'GEMINI_MODEL', 'gemini-2.0-flash')),
+    base_url:
+      getRuntimeValue(
+        env,
+        'MYWAY_GEMINI_BASE_URL',
+        getRuntimeValue(env, 'GEMINI_BASE_URL', 'https://generativelanguage.googleapis.com/v1beta'),
+      ) ?? 'https://generativelanguage.googleapis.com/v1beta',
   };
 }
 

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -237,8 +237,7 @@ ai.post('/summary', async (c) => {
   }
 
   const env = c.env as RuntimeBindings | undefined;
-  const metadata = buildResponseMetadata('summary', env);
-  const result = await runAISummary(
+  const execution = await runAISummary(
     {
       lecture_id: lectureId,
       style: body?.style ?? 'brief',
@@ -248,9 +247,12 @@ ai.post('/summary', async (c) => {
     env,
   );
 
-  if (!result) {
+  if (!execution) {
     return jsonFailure('SUMMARY_FAILED', '요약을 생성할 수 없습니다.', 400);
   }
+
+  const metadata = { provider: execution.provider, model: execution.model };
+  const result = execution.result;
 
   if (user) {
     recordUsageLog({
@@ -281,8 +283,7 @@ ai.post('/quiz', async (c) => {
   }
 
   const env = c.env as RuntimeBindings | undefined;
-  const metadata = buildResponseMetadata('quiz', env);
-  const result = await runAIQuiz(
+  const execution = await runAIQuiz(
     {
       lecture_id: lectureId,
       count: body?.count,
@@ -292,9 +293,12 @@ ai.post('/quiz', async (c) => {
     env,
   );
 
-  if (!result) {
+  if (!execution) {
     return jsonFailure('QUIZ_FAILED', '퀴즈를 생성할 수 없습니다.', 400);
   }
+
+  const metadata = { provider: execution.provider, model: execution.model };
+  const result = execution.result;
 
   if (user) {
     recordUsageLog({

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -16,7 +16,10 @@
     "MYWAY_MEDIA_PROCESSOR_TOKEN": "local-media-processor-token",
     "MYWAY_MEDIA_CALLBACK_SECRET": "local-media-callback-secret",
     "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
-    "MYWAY_OLLAMA_MODEL": "llama3.1"
+    "MYWAY_OLLAMA_MODEL": "llama3.1",
+    "MYWAY_GEMINI_API_KEY": "replace-with-local-gemini-key",
+    "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
+    "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
   },
   "ai": {
     "binding": "AI"
@@ -31,7 +34,10 @@
         "MYWAY_MEDIA_PROCESSOR_TOKEN": "local-media-processor-token",
         "MYWAY_MEDIA_CALLBACK_SECRET": "local-media-callback-secret",
         "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
-        "MYWAY_OLLAMA_MODEL": "llama3.1"
+        "MYWAY_OLLAMA_MODEL": "llama3.1",
+        "MYWAY_GEMINI_API_KEY": "replace-with-local-gemini-key",
+        "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
+        "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
       }
     },
     "staging": {
@@ -43,7 +49,10 @@
         "MYWAY_MEDIA_PROCESSOR_TOKEN": "replace-with-staging-token",
         "MYWAY_MEDIA_CALLBACK_SECRET": "replace-with-staging-secret",
         "MYWAY_OLLAMA_BASE_URL": "https://ollama.staging.mywayclass.com",
-        "MYWAY_OLLAMA_MODEL": "llama3.1"
+        "MYWAY_OLLAMA_MODEL": "llama3.1",
+        "MYWAY_GEMINI_API_KEY": "replace-with-staging-gemini-key",
+        "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
+        "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
       }
     },
     "production": {
@@ -55,7 +64,10 @@
         "MYWAY_MEDIA_PROCESSOR_TOKEN": "replace-with-production-token",
         "MYWAY_MEDIA_CALLBACK_SECRET": "replace-with-production-secret",
         "MYWAY_OLLAMA_BASE_URL": "https://ollama.mywayclass.com",
-        "MYWAY_OLLAMA_MODEL": "llama3.1"
+        "MYWAY_OLLAMA_MODEL": "llama3.1",
+        "MYWAY_GEMINI_API_KEY": "replace-with-production-gemini-key",
+        "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
+        "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
       }
     }
   }

--- a/docs/dev-logs/2026-04-10-gemini-fallback-summary-quiz.md
+++ b/docs/dev-logs/2026-04-10-gemini-fallback-summary-quiz.md
@@ -1,0 +1,21 @@
+# Gemini fallback 연동
+
+## 왜 바꿨는가
+- 이슈 #100은 AI provider 계층에 이미 정의된 Gemini를 실제 fallback 호출 경로로 연결하는 작업이다.
+- 현재 summary와 quiz는 Ollama만 실제로 시도하고, 실패 시 바로 shared fallback으로 내려가 있어서 Gemini 계층이 비어 있었다.
+
+## 무엇을 바꿨는가
+- `backend/src/lib/providers/gemini.ts`를 추가해 Gemini `generateContent` JSON 호출 클라이언트를 만들었다.
+- `summary`, `quiz` 엔진 실행에서 `Ollama -> Gemini -> shared fallback` 순으로 응답을 시도하게 바꿨다.
+- Gemini 런타임 env와 wrangler 예시 값을 추가하고, provider 카탈로그에서 Ollama/Gemini 상태를 `available`로 맞췄다.
+- AI 레이어 문서에 실제 fallback 순서를 반영했다.
+
+## A/B 비교와 선택 이유
+- A안: summary와 quiz 같은 JSON 결과형 기능부터 Gemini fallback을 연결하는 방식
+- B안: intent, answer까지 한 번에 Gemini fallback을 넓히는 방식
+- 이번에는 A안을 선택했다. 응답 shape가 더 안정적이고, 이슈의 Must인 fallback 호출과 Should인 우선순위 정책을 적은 변경으로 검증할 수 있었다.
+
+## 어떻게 검증했는가
+- `npm run build:backend`
+- `npm exec --workspace @myway/frontend -- tsc -p tsconfig.json --noEmit`
+- 로컬 `wrangler dev`에서 `POST /api/v1/ai/summary`, `POST /api/v1/ai/quiz`를 호출해 Gemini/Ollama 미설정 환경에서도 `demo` fallback 응답과 provider/model 메타데이터가 유지되는지 확인했다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-10-gemini-fallback-summary-quiz.md`
 - `2026-04-10-media-pipeline-failure-retry.md`
 - `2026-04-10-media-pipeline-refresh-and-history.md`
 - `2026-04-10-media-pipeline-ui-status-refresh.md`

--- a/docs/project/14-ai-layer.md
+++ b/docs/project/14-ai-layer.md
@@ -80,7 +80,7 @@
 - 향후 운영 경로는 `Ollama -> Gemini -> Cloudflare AI -> demo` 순의 fallback 계층을 기본으로 둔다.
 - `STT`와 `embedding`은 `Cloudflare AI`를 우선 고려하고, 텍스트 생성 계열은 `Ollama`를 우선 고려한다.
 - provider 선택과 fallback 순서는 `GET /api/v1/ai/providers`로 조회할 수 있다.
-- backend는 `summary`와 `quiz`에서 Ollama가 가능할 때 실제 JSON 생성 응답을 먼저 시도하고, 실패하면 기존 shared fallback으로 되돌아간다.
+- backend는 `summary`와 `quiz`에서 `Ollama -> Gemini -> shared fallback` 순으로 실제 JSON 생성 응답을 시도한다.
 - `POST /api/v1/media/transcribe`는 `audio_url`이 있을 때 Cloudflare Workers AI 전사를 먼저 시도하고, 실패하면 demo 경로로 되돌아간다.
 
 ## 현재 구현
@@ -89,7 +89,7 @@
 - `POST /api/v1/ai/answer`로 질문 응답과 근거 참조를 함께 돌려준다.
 - `POST /api/v1/ai/summary`로 강의 요약을 생성한다.
 - `POST /api/v1/ai/quiz`로 강의 기반 퀴즈를 생성한다.
-- `POST /api/v1/ai/summary`와 `POST /api/v1/ai/quiz`는 가능한 경우 Ollama 엔진 결과를 우선 사용하고, 실패 시 shared fallback을 사용한다.
+- `POST /api/v1/ai/summary`와 `POST /api/v1/ai/quiz`는 가능한 경우 Ollama 엔진 결과를 먼저 시도하고, 실패 시 Gemini JSON 응답을 한 번 더 시도한 뒤 shared fallback을 사용한다.
 - `GET /api/v1/ai/insights`로 AI 사용량과 역할별 인사이트를 조회한다.
 - `GET /api/v1/ai/providers`로 provider 계층과 fallback 순서를 조회한다.
 - `POST /api/v1/smart/chat`로 의도 분류와 응답 라우팅을 한 번에 처리한다.

--- a/packages/shared/src/ai/ai-provider.ts
+++ b/packages/shared/src/ai/ai-provider.ts
@@ -53,14 +53,14 @@ const PROVIDER_DESCRIPTORS: AIProviderDescriptor[] = [
     name: 'ollama',
     label: 'Ollama',
     description: '로컬 또는 자가 호스팅 환경에서 무료로 사용할 수 있는 모델 계층입니다.',
-    status: 'planned',
+    status: 'available',
     capabilities: ['intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations', 'embedding'],
   },
   {
     name: 'gemini',
     label: 'Gemini',
     description: '무료 API 쿼터 기반으로 생성, 분류, 요약 보강에 활용할 수 있는 외부 모델 계층입니다.',
-    status: 'planned',
+    status: 'available',
     capabilities: ['intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations', 'stt'],
   },
   {


### PR DESCRIPTION
﻿# 변경 요약
summary/quiz 엔진이 Ollama -> Gemini -> shared fallback 순서로 실제 JSON fallback을 타도록 연결했습니다.

## 배경
이슈 #100에서 Gemini provider가 선언만 되어 있고 summary/quiz 경로에는 실제 fallback 호출이 없었습니다.

## 변경 내용
- Gemini generateContent 클라이언트와 runtime env를 추가했습니다.
- summary/quiz 실행을 Ollama -> Gemini -> shared fallback 순서로 연결했습니다.
- provider 상태, 문서, dev log를 실제 동작과 맞췄습니다.

## 연결 이슈
- Closes #100
- Fixes #100

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
