### PR TITLE
feat: add Ollama smart chat routing

### DIFF
--- a/backend/src/lib/ai-engine-runners.ts
+++ b/backend/src/lib/ai-engine-runners.ts
@@ -22,6 +22,7 @@ import {
   getLectureSourceText,
   getOllamaModel,
   isRemoteFeatureEnabled,
+  OLLAMA_QUIZ_TIMEOUT_MS,
   normalizeQuizQuestion,
   parseJsonObject,
   pickAction,
@@ -40,6 +41,9 @@ export type AIEngineExecution<T> = {
   model: string;
 };
 
+const DEMO_INTENT_MODEL = 'demo-intent-v1';
+const DEMO_ANSWER_MODEL = 'demo-answer-v1';
+
 async function runStructuredJsonFallback(
   feature: 'summary' | 'quiz',
   messages: ReturnType<typeof buildSummaryPrompt> | ReturnType<typeof buildQuizPrompt>,
@@ -52,7 +56,7 @@ async function runStructuredJsonFallback(
     if (provider === 'ollama') {
       const response = await runOllamaChat(messages, env, {
         model: getOllamaModel(env),
-        timeoutMs: OLLAMA_TIMEOUT_MS,
+        timeoutMs: OLLAMA_QUIZ_TIMEOUT_MS,
       });
       if (response) {
         return response;
@@ -62,7 +66,7 @@ async function runStructuredJsonFallback(
     if (provider === 'gemini') {
       const response = await runGeminiJsonPrompt(messages, env, {
         model: getGeminiModel(env),
-        timeoutMs: OLLAMA_TIMEOUT_MS,
+        timeoutMs: OLLAMA_QUIZ_TIMEOUT_MS,
       });
       if (response) {
         return response;
@@ -77,11 +81,15 @@ async function runOllamaStructuredIntent(
   input: AIIntentRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
-): Promise<AIIntentResult> {
+): Promise<AIEngineExecution<AIIntentResult>> {
   const fallback = getIntentFallback(input);
 
   if (!isRemoteFeatureEnabled('intent', preferredProvider)) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: DEMO_INTENT_MODEL,
+    };
   }
 
   const response = await runOllamaChat(buildIntentPrompt(input, fallback), env, {
@@ -92,17 +100,25 @@ async function runOllamaStructuredIntent(
 
   const parsed = parseJsonObject(response ?? '');
   if (!parsed) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: DEMO_INTENT_MODEL,
+    };
   }
 
   return {
-    ...fallback,
-    intent: pickIntent(parsed.intent, fallback.intent),
-    confidence: pickConfidence(parsed.confidence, fallback.confidence),
-    action: pickAction(parsed.action, fallback.action),
-    entities: toStringArray(parsed.entities).slice(0, 6) || fallback.entities,
-    reason: pickString(parsed.reason, fallback.reason),
-    needs_clarification: typeof parsed.needs_clarification === 'boolean' ? parsed.needs_clarification : fallback.needs_clarification,
+    result: {
+      ...fallback,
+      intent: pickIntent(parsed.intent, fallback.intent),
+      confidence: pickConfidence(parsed.confidence, fallback.confidence),
+      action: pickAction(parsed.action, fallback.action),
+      entities: toStringArray(parsed.entities).slice(0, 6) || fallback.entities,
+      reason: pickString(parsed.reason, fallback.reason),
+      needs_clarification: typeof parsed.needs_clarification === 'boolean' ? parsed.needs_clarification : fallback.needs_clarification,
+    },
+    provider: 'ollama',
+    model: getOllamaModel(env),
   };
 }
 
@@ -110,11 +126,15 @@ async function runOllamaStructuredAnswer(
   input: AIAnswerRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
-): Promise<AIAnswerResult> {
+): Promise<AIEngineExecution<AIAnswerResult>> {
   const fallback = getAnswerFallback(input);
 
   if (!isRemoteFeatureEnabled('answer', preferredProvider)) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: DEMO_ANSWER_MODEL,
+    };
   }
 
   const response = await runOllamaChat(buildAnswerPrompt(input, fallback), env, {
@@ -125,19 +145,39 @@ async function runOllamaStructuredAnswer(
 
   const parsed = parseJsonObject(response ?? '');
   if (!parsed) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: DEMO_ANSWER_MODEL,
+    };
   }
 
   const answer = pickString(parsed.answer, fallback.answer);
   if (!answer) {
-    return fallback;
+    return {
+      result: fallback,
+      provider: 'demo',
+      model: DEMO_ANSWER_MODEL,
+    };
   }
 
   return {
-    ...fallback,
-    answer,
-    suggestions: toStringArray(parsed.suggestions).slice(0, 2).concat(fallback.suggestions).slice(0, 2),
+    result: {
+      ...fallback,
+      answer,
+      suggestions: toStringArray(parsed.suggestions).slice(0, 2).concat(fallback.suggestions).slice(0, 2),
+    },
+    provider: 'ollama',
+    model: getOllamaModel(env),
   };
+}
+
+export async function runAIIntentWithExecution(
+  input: AIIntentRequest,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<AIEngineExecution<AIIntentResult>> {
+  return runOllamaStructuredIntent(input, preferredProvider, env);
 }
 
 export async function runAIIntentWithEngine(
@@ -145,7 +185,15 @@ export async function runAIIntentWithEngine(
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
 ): Promise<AIIntentResult> {
-  return runOllamaStructuredIntent(input, preferredProvider, env);
+  return (await runAIIntentWithExecution(input, preferredProvider, env)).result;
+}
+
+export async function runAIAnswerWithExecution(
+  input: AIAnswerRequest,
+  preferredProvider?: AIProviderName,
+  env?: RuntimeBindings,
+): Promise<AIEngineExecution<AIAnswerResult>> {
+  return runOllamaStructuredAnswer(input, preferredProvider, env);
 }
 
 export async function runAIAnswerWithEngine(
@@ -153,7 +201,7 @@ export async function runAIAnswerWithEngine(
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
 ): Promise<AIAnswerResult> {
-  return runOllamaStructuredAnswer(input, preferredProvider, env);
+  return (await runAIAnswerWithExecution(input, preferredProvider, env)).result;
 }
 
 export async function runAISummaryWithEngine(
@@ -179,25 +227,22 @@ export async function runAISummaryWithEngine(
   const providerPlan = getAIProviderSelection('summary', preferredProvider);
   let response: string | null = null;
   let responseProvider: AIProviderName | null = null;
-  let responseModel = 'demo-summary-v1';
 
   for (const provider of providerPlan.fallback_chain) {
     if (provider === 'ollama') {
       response = await runOllamaChat(messages, env, {
         model: getOllamaModel(env),
-        timeoutMs: OLLAMA_TIMEOUT_MS,
+        timeoutMs: OLLAMA_QUIZ_TIMEOUT_MS,
       });
       responseProvider = response ? 'ollama' : null;
-      responseModel = getOllamaModel(env);
     }
 
     if (!response && provider === 'gemini') {
       response = await runGeminiJsonPrompt(messages, env, {
         model: getGeminiModel(env),
-        timeoutMs: OLLAMA_TIMEOUT_MS,
+        timeoutMs: OLLAMA_QUIZ_TIMEOUT_MS,
       });
       responseProvider = response ? 'gemini' : responseProvider;
-      responseModel = getGeminiModel(env);
     }
 
     if (response) {
@@ -277,7 +322,7 @@ export async function runAIQuizWithEngine(
     if (provider === 'ollama') {
       response = await runOllamaChat(messages, env, {
         model: getOllamaModel(env),
-        timeoutMs: OLLAMA_TIMEOUT_MS,
+        timeoutMs: OLLAMA_QUIZ_TIMEOUT_MS,
       });
       responseProvider = response ? 'ollama' : null;
     }
@@ -285,7 +330,7 @@ export async function runAIQuizWithEngine(
     if (!response && provider === 'gemini') {
       response = await runGeminiJsonPrompt(messages, env, {
         model: getGeminiModel(env),
-        timeoutMs: OLLAMA_TIMEOUT_MS,
+        timeoutMs: OLLAMA_QUIZ_TIMEOUT_MS,
       });
       responseProvider = response ? 'gemini' : responseProvider;
     }

--- a/backend/src/lib/ai-engine-utils.ts
+++ b/backend/src/lib/ai-engine-utils.ts
@@ -24,7 +24,8 @@ import type { RuntimeBindings } from './runtime-env';
 
 export type JsonObject = Record<string, unknown>;
 
-export const OLLAMA_TIMEOUT_MS = 15_000;
+export const OLLAMA_TIMEOUT_MS = 60_000;
+export const OLLAMA_QUIZ_TIMEOUT_MS = 120_000;
 
 export function normalizeText(value: string): string {
   return value.replaceAll(/\s+/g, ' ').trim();

--- a/backend/src/lib/smart-chat.ts
+++ b/backend/src/lib/smart-chat.ts
@@ -1,0 +1,177 @@
+import {
+  buildSmartChatOverview,
+  type AIProviderName,
+  type SmartChatRequest,
+  type SmartChatResult,
+  type SmartChatRoute,
+} from '@myway/shared';
+import { runAIAnswerWithExecution, runAIIntentWithExecution, runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine-runners';
+import type { RuntimeBindings } from './runtime-env';
+
+type SmartChatMetadata = {
+  provider: AIProviderName;
+  model: string;
+};
+
+function normalizeRoute(intent: SmartChatResult['intent']['intent']): SmartChatRoute {
+  if (intent === 'request_summary') return 'summary';
+  if (intent === 'generate_quiz') return 'quiz';
+  if (intent === 'search_content') return 'search';
+  if (intent === 'translate') return 'translate';
+  if (intent === 'compare') return 'compare';
+  if (intent === 'clarify') return 'clarify';
+  return 'answer';
+}
+
+function attachMetadata(result: SmartChatResult, metadata: SmartChatMetadata): SmartChatResult {
+  return {
+    ...result,
+    provider: metadata.provider,
+    model: metadata.model,
+  };
+}
+
+function buildSummarySuggestions(title: string): string[] {
+  return [`${title}를 타임라인으로도 요약해줘.`, `${title}의 핵심 키워드를 다시 정리해줘.`];
+}
+
+function buildQuizSuggestions(): string[] {
+  return ['이 퀴즈의 해설도 보여줘.', '문항 수를 줄여서 다시 만들어줘.'];
+}
+
+export async function runSmartChat(
+  input: SmartChatRequest,
+  env?: RuntimeBindings,
+): Promise<SmartChatResult> {
+  const message = input.message.trim();
+  const lectureId = input.lecture_id?.trim() ?? null;
+  const courseId = input.course_id?.trim() ?? null;
+  const normalizedInput: SmartChatRequest = {
+    ...input,
+    message,
+    lecture_id: lectureId ?? undefined,
+    course_id: courseId ?? undefined,
+  };
+
+  const intentExecution = await runAIIntentWithExecution(
+    {
+      message,
+      lecture_id: lectureId ?? undefined,
+      context: input.context,
+    },
+    undefined,
+    env,
+  );
+
+  const route = normalizeRoute(intentExecution.result.intent);
+  const baseFallback = buildSmartChatOverview(normalizedInput);
+  const sharedResult = attachMetadata(
+    {
+      ...baseFallback,
+      message,
+      lecture_id: lectureId,
+      course_id: courseId,
+      route,
+      intent: intentExecution.result,
+    },
+    {
+      provider: intentExecution.provider,
+      model: intentExecution.model,
+    },
+  );
+
+  if (route === 'summary' && lectureId) {
+    const summaryExecution = await runAISummaryWithEngine(
+      {
+        lecture_id: lectureId,
+        style: 'brief',
+        language: input.language ?? 'ko',
+      },
+      undefined,
+      env,
+    );
+
+    if (summaryExecution) {
+      return attachMetadata(
+        {
+          message,
+          lecture_id: lectureId,
+          course_id: courseId,
+          route,
+          intent: intentExecution.result,
+          answer: summaryExecution.result.content,
+          references: summaryExecution.result.references,
+          suggestions: buildSummarySuggestions(summaryExecution.result.title),
+          summary: summaryExecution.result,
+        },
+        {
+          provider: summaryExecution.provider,
+          model: summaryExecution.model,
+        },
+      );
+    }
+  }
+
+  if (route === 'quiz' && lectureId) {
+    const quizExecution = await runAIQuizWithEngine(
+      {
+        lecture_id: lectureId,
+        count: 4,
+        difficulty: 'medium',
+      },
+      undefined,
+      env,
+    );
+
+    if (quizExecution) {
+      return attachMetadata(
+        {
+          message,
+          lecture_id: lectureId,
+          course_id: courseId,
+          route,
+          intent: intentExecution.result,
+          answer: `${quizExecution.result.title}가 생성되었습니다.`,
+          references: quizExecution.result.questions.map((question) => question.reference).slice(0, 4),
+          suggestions: buildQuizSuggestions(),
+          quiz: quizExecution.result,
+        },
+        {
+          provider: quizExecution.provider,
+          model: quizExecution.model,
+        },
+      );
+    }
+  }
+
+  if (route === 'answer') {
+    const answerExecution = await runAIAnswerWithExecution(
+      {
+        question: message,
+        lecture_id: lectureId ?? undefined,
+        limit: 4,
+      },
+      undefined,
+      env,
+    );
+
+    return attachMetadata(
+      {
+        message,
+        lecture_id: lectureId,
+        course_id: courseId,
+        route,
+        intent: intentExecution.result,
+        answer: answerExecution.result.answer,
+        references: answerExecution.result.references,
+        suggestions: answerExecution.result.suggestions,
+      },
+      {
+        provider: answerExecution.provider,
+        model: answerExecution.model,
+      },
+    );
+  }
+
+  return sharedResult;
+}

--- a/backend/src/routes/smart.ts
+++ b/backend/src/routes/smart.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
-import { buildSmartChatOverview, getCourseDetail, getLectureDetail, type SmartChatRequest } from '@myway/shared';
+import { getCourseDetail, getLectureDetail, type SmartChatRequest } from '@myway/shared';
 import { getAuthenticatedUser } from '../lib/auth';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
+import { runSmartChat } from '../lib/smart-chat';
 
 const smart = new Hono();
 
@@ -32,7 +33,7 @@ smart.post('/chat', async (c) => {
     return jsonFailure('COURSE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  const result = buildSmartChatOverview({
+  const result = await runSmartChat({
     message,
     lecture_id: lectureId,
     course_id: courseId,

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -16,7 +16,7 @@
     "MYWAY_MEDIA_PROCESSOR_TOKEN": "local-media-processor-token",
     "MYWAY_MEDIA_CALLBACK_SECRET": "local-media-callback-secret",
     "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
-    "MYWAY_OLLAMA_MODEL": "llama3.1",
+    "MYWAY_OLLAMA_MODEL": "llama3.1:8b",
     "MYWAY_GEMINI_API_KEY": "replace-with-local-gemini-key",
     "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
     "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
@@ -34,7 +34,7 @@
         "MYWAY_MEDIA_PROCESSOR_TOKEN": "local-media-processor-token",
         "MYWAY_MEDIA_CALLBACK_SECRET": "local-media-callback-secret",
         "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
-        "MYWAY_OLLAMA_MODEL": "llama3.1",
+        "MYWAY_OLLAMA_MODEL": "llama3.1:8b",
         "MYWAY_GEMINI_API_KEY": "replace-with-local-gemini-key",
         "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
         "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"

--- a/docs/dev-logs/2026-04-10-ollama-smart-chat-integration.md
+++ b/docs/dev-logs/2026-04-10-ollama-smart-chat-integration.md
@@ -1,0 +1,21 @@
+# Ollama smart chat integration
+
+## 왜 바꿨는가
+- 이슈 #98의 챗봇 경로는 아직 shared demo 흐름에 머물러 있어서, 실제 Ollama 기반 intent 분류와 요약/퀴즈/답변 경로가 필요했다.
+- intent와 answer의 실행 메타데이터를 함께 돌려야 smart chat 응답의 provider/model도 표준화할 수 있었다.
+
+## 무엇을 바꿨는가
+- `backend/src/lib/ai-engine-runners.ts`에 intent/answer 실행 메타데이터를 담는 실행 래퍼를 추가했다.
+- Ollama 응답이 길어질 때 demo fallback으로 빠지지 않도록 timeout 기준을 60초로 늘렸다.
+- `backend/src/lib/smart-chat.ts`를 새로 만들어 smart chat을 Ollama 기반 intent 분류 후 summary, quiz, answer 엔진으로 라우팅하게 바꿨다.
+- `backend/src/routes/smart.ts`는 새 smart chat 헬퍼를 호출하도록 단순화했다.
+- `SmartChatResult`에 provider/model 메타데이터를 선택 필드로 추가하고, AI layer 문서를 갱신했다.
+- 퀴즈 프롬프트는 응답 시간이 더 길어서 `OLLAMA_QUIZ_TIMEOUT_MS`를 별도로 두고 quiz route만 더 오래 기다리게 했다.
+
+## 어떻게 검증했는가
+- `npm run verify`
+- 로컬 `runAIIntentWithExecution`에서 `provider=ollama`, `model=llama3.1:8b`가 내려오는 것을 확인했다.
+- 로컬 `runAISummaryWithEngine`에서 `provider=ollama`, `model=llama3.1:8b`가 내려오는 것을 확인했다.
+- 로컬 `runAIQuizWithEngine`에서 `provider=ollama`, `model=llama3.1:8b`가 내려오는 것을 확인했다.
+- 로컬 `runSmartChat`에서 `route=summary`, `provider=ollama`, `model=llama3.1:8b`가 내려오는 것을 확인했다.
+- 로컬 `runSmartChat` 퀴즈 요청에서도 `route=quiz`, `provider=ollama`, `model=llama3.1:8b`가 내려오는 것을 확인했다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-10-ollama-smart-chat-integration.md`
 - `2026-04-10-gemini-fallback-summary-quiz.md`
 - `2026-04-10-media-pipeline-failure-retry.md`
 - `2026-04-10-media-pipeline-refresh-and-history.md`

--- a/docs/project/14-ai-layer.md
+++ b/docs/project/14-ai-layer.md
@@ -89,8 +89,8 @@
 - `POST /api/v1/ai/answer`로 질문 응답과 근거 참조를 함께 돌려준다.
 - `POST /api/v1/ai/summary`로 강의 요약을 생성한다.
 - `POST /api/v1/ai/quiz`로 강의 기반 퀴즈를 생성한다.
+- `POST /api/v1/smart/chat`는 Ollama 기반 intent 분류 결과를 바탕으로 요약, 퀴즈, 답변을 실제 엔진 경로로 연결하고, 나머지 라우트는 shared fallback으로 유지한다.
 - `POST /api/v1/ai/summary`와 `POST /api/v1/ai/quiz`는 가능한 경우 Ollama 엔진 결과를 먼저 시도하고, 실패 시 Gemini JSON 응답을 한 번 더 시도한 뒤 shared fallback을 사용한다.
 - `GET /api/v1/ai/insights`로 AI 사용량과 역할별 인사이트를 조회한다.
 - `GET /api/v1/ai/providers`로 provider 계층과 fallback 순서를 조회한다.
-- `POST /api/v1/smart/chat`로 의도 분류와 응답 라우팅을 한 번에 처리한다.
 - 공통 로직은 `packages/shared/src/ai.ts`에서 관리한다.

--- a/packages/shared/src/types/ai/chat.ts
+++ b/packages/shared/src/types/ai/chat.ts
@@ -1,4 +1,5 @@
 import type { MediaSummaryStyle, SimilarChunk } from '../lms';
+import type { AIProviderName } from '../../ai/ai-provider';
 import type { AIIntent } from './intent';
 
 export type AIChunkSource = 'lecture' | 'transcript' | 'note';
@@ -118,4 +119,6 @@ export type SmartChatResult = {
   suggestions: string[];
   summary?: AISummaryResult | null;
   quiz?: AIQuizResult | null;
+  provider?: AIProviderName;
+  model?: string;
 };


### PR DESCRIPTION
# 변경 요약
Ollama 기반 smart chat 라우팅을 실제 summary, quiz, answer 엔진으로 연결하고, 느린 Ollama 응답에 맞춰 timeout을 조정했습니다.

## 배경
이슈 #98의 목표는 demo fallback이 아니라 실제 Ollama 경로로 intent 분류와 요약/퀴즈 응답을 제공하는 것입니다.

## 변경 내용
- `backend/src/lib/smart-chat.ts`를 추가해 smart chat 오케스트레이션을 분리했습니다.
- `backend/src/lib/ai-engine-runners.ts`에서 intent/answer 메타데이터와 quiz timeout을 조정했습니다.
- `backend/src/routes/smart.ts`, `backend/wrangler.jsonc`, `packages/shared/src/types/ai/chat.ts`를 함께 갱신했습니다.
- `docs/project/14-ai-layer.md`와 `docs/dev-logs/`에 변경 내용을 남겼습니다.

## 연결 이슈
- Closes #98
- Fixes #98

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
