### PR TITLE
feat: add AI runtime policy bindings

### DIFF
--- a/backend/migrations/0001_ai_controls.sql
+++ b/backend/migrations/0001_ai_controls.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS ai_daily_usage (
+  usage_date TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  feature TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (usage_date, user_id, feature)
+);
+
+CREATE TABLE IF NOT EXISTS ai_total_usage (
+  usage_date TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (usage_date, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_global_usage (
+  usage_date TEXT NOT NULL,
+  feature TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (usage_date, feature)
+);
+
+CREATE TABLE IF NOT EXISTS ai_rate_limits (
+  bucket_key TEXT PRIMARY KEY,
+  bucket_type TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/src/lib/ai-adapter.ts
+++ b/backend/src/lib/ai-adapter.ts
@@ -14,7 +14,7 @@ import {
   type AISummaryResult,
 } from '@myway/shared';
 import { type AIEngineExecution, runAIAnswerWithEngine, runAIIntentWithEngine, runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine';
-import { getAIProviderSelection } from './ai-provider';
+import { getAIProviderSelectionForRuntime } from './ai-provider';
 import type { RuntimeBindings } from './runtime-env';
 
 export type AIAdapterResultMap = {
@@ -36,7 +36,7 @@ type AIAdapterInputMap = {
 };
 
 function resolveProvider(feature: AIProviderCapability, preferredProvider?: AIProviderName): AIProviderName {
-  return getAIProviderSelection(feature, preferredProvider).current_provider;
+  return getAIProviderSelectionForRuntime(feature, undefined, preferredProvider).current_provider;
 }
 
 export async function runAIIntent(

--- a/backend/src/lib/ai-controls.ts
+++ b/backend/src/lib/ai-controls.ts
@@ -1,0 +1,325 @@
+import type { AuthUser } from '@myway/shared';
+import { getAuthenticatedUser } from './auth';
+import { jsonFailure } from './http';
+import { getAIRuntimePolicy, type RuntimeBindings } from './runtime-env';
+
+export type AiControlFeature = 'intent' | 'search' | 'answer' | 'summary' | 'quiz' | 'smart' | 'stt';
+
+export type AiControlContext = {
+  user: AuthUser | null;
+  policy: ReturnType<typeof getAIRuntimePolicy>;
+};
+
+const AI_CONTROL_SCHEMA = `
+CREATE TABLE IF NOT EXISTS ai_daily_usage (
+  usage_date TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  feature TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (usage_date, user_id, feature)
+);
+
+CREATE TABLE IF NOT EXISTS ai_total_usage (
+  usage_date TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (usage_date, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_global_usage (
+  usage_date TEXT NOT NULL,
+  feature TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (usage_date, feature)
+);
+
+CREATE TABLE IF NOT EXISTS ai_rate_limits (
+  bucket_key TEXT PRIMARY KEY,
+  bucket_type TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`;
+
+const RATE_LIMITS = {
+  perMinute: 10,
+  perHour: 100,
+} as const;
+
+let schemaReady: Promise<void> | null = null;
+
+function getTodayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getMinuteWindowKey(date = new Date()): string {
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  return `${date.toISOString().slice(0, 10)}T${hours}:${minutes}Z`;
+}
+
+function getHourWindowKey(date = new Date()): string {
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  return `${date.toISOString().slice(0, 10)}T${hours}Z`;
+}
+
+function getClientIp(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  const cfIp = request.headers.get('cf-connecting-ip')?.trim();
+  return forwarded || cfIp || 'unknown';
+}
+
+function getQuotaLimit(policy: AiControlContext['policy'], feature: AiControlFeature): number | undefined {
+  switch (feature) {
+    case 'intent':
+    case 'smart':
+      return policy.daily_limits.smart;
+    case 'summary':
+      return policy.daily_limits.summary;
+    case 'quiz':
+      return policy.daily_limits.quiz;
+    case 'answer':
+      return policy.daily_limits.answer;
+    case 'stt':
+      return policy.daily_limits.stt;
+    case 'search':
+      return undefined;
+  }
+}
+
+function shouldCountTotal(feature: AiControlFeature): boolean {
+  return feature !== 'search';
+}
+
+function shouldCountGemini(feature: AiControlFeature): boolean {
+  return feature !== 'search' && feature !== 'stt';
+}
+
+async function ensureSchema(db: NonNullable<RuntimeBindings['DB']>): Promise<void> {
+  if (!schemaReady) {
+    schemaReady = db
+      .exec(AI_CONTROL_SCHEMA)
+      .then(() => undefined)
+      .catch((error) => {
+        schemaReady = null;
+        throw error;
+      });
+  }
+
+  return schemaReady;
+}
+
+async function bumpBoundedCounter(
+  db: NonNullable<RuntimeBindings['DB']>,
+  query: string,
+  selectQuery: string,
+  bindings: (string | number)[],
+  limit: number,
+): Promise<{ allowed: boolean; count: number }> {
+  const result = await db.prepare(query).bind(...bindings, limit).run();
+  const changed = Number(result.meta?.changes ?? 0);
+  if (changed <= 0) {
+    return { allowed: false, count: limit };
+  }
+
+  const row = await db.prepare(selectQuery).bind(...bindings).first<{ count: number }>();
+  return { allowed: true, count: row?.count ?? 0 };
+}
+
+async function bumpDailyUsage(
+  db: NonNullable<RuntimeBindings['DB']>,
+  userId: string,
+  feature: AiControlFeature,
+  limit: number,
+): Promise<{ allowed: boolean; remaining: number }> {
+  const date = getTodayKey();
+  const result = await bumpBoundedCounter(
+    db,
+    `
+INSERT INTO ai_daily_usage (usage_date, user_id, feature, count)
+VALUES (?, ?, ?, 1)
+ON CONFLICT(usage_date, user_id, feature)
+DO UPDATE SET count = count + 1, updated_at = CURRENT_TIMESTAMP
+WHERE count < ?;
+`,
+    `
+SELECT count FROM ai_daily_usage
+WHERE usage_date = ? AND user_id = ? AND feature = ?;
+`,
+    [date, userId, feature],
+    limit,
+  );
+
+  if (!result.allowed) {
+    return { allowed: false, remaining: 0 };
+  }
+
+  return { allowed: true, remaining: Math.max(0, limit - result.count) };
+}
+
+async function bumpDailyTotal(
+  db: NonNullable<RuntimeBindings['DB']>,
+  userId: string,
+  limit: number,
+): Promise<{ allowed: boolean; remaining: number }> {
+  const date = getTodayKey();
+  const result = await bumpBoundedCounter(
+    db,
+    `
+INSERT INTO ai_total_usage (usage_date, user_id, count)
+VALUES (?, ?, 1)
+ON CONFLICT(usage_date, user_id)
+DO UPDATE SET count = count + 1, updated_at = CURRENT_TIMESTAMP
+WHERE count < ?;
+`,
+    `
+SELECT count FROM ai_total_usage
+WHERE usage_date = ? AND user_id = ?;
+`,
+    [date, userId],
+    limit,
+  );
+
+  if (!result.allowed) {
+    return { allowed: false, remaining: 0 };
+  }
+
+  return { allowed: true, remaining: Math.max(0, limit - result.count) };
+}
+
+async function bumpGlobalQuota(
+  db: NonNullable<RuntimeBindings['DB']>,
+  feature: string,
+  limit: number,
+): Promise<{ allowed: boolean; remaining: number }> {
+  const date = getTodayKey();
+  const result = await bumpBoundedCounter(
+    db,
+    `
+INSERT INTO ai_global_usage (usage_date, feature, count)
+VALUES (?, ?, 1)
+ON CONFLICT(usage_date, feature)
+DO UPDATE SET count = count + 1, updated_at = CURRENT_TIMESTAMP
+WHERE count < ?;
+`,
+    `
+SELECT count FROM ai_global_usage
+WHERE usage_date = ? AND feature = ?;
+`,
+    [date, feature],
+    limit,
+  );
+
+  if (!result.allowed) {
+    return { allowed: false, remaining: 0 };
+  }
+
+  return { allowed: true, remaining: Math.max(0, limit - result.count) };
+}
+
+async function bumpRateLimit(
+  db: NonNullable<RuntimeBindings['DB']>,
+  bucketKey: string,
+  bucketType: string,
+  limit: number,
+): Promise<{ allowed: boolean; remaining: number }> {
+  const result = await bumpBoundedCounter(
+    db,
+    `
+INSERT INTO ai_rate_limits (bucket_key, bucket_type, count)
+VALUES (?, ?, 1)
+ON CONFLICT(bucket_key)
+DO UPDATE SET count = count + 1, updated_at = CURRENT_TIMESTAMP
+WHERE count < ?;
+`,
+    `
+SELECT count FROM ai_rate_limits
+WHERE bucket_key = ?;
+`,
+    [bucketKey, bucketType],
+    limit,
+  );
+
+  if (!result.allowed) {
+    return { allowed: false, remaining: 0 };
+  }
+
+  return { allowed: true, remaining: Math.max(0, limit - result.count) };
+}
+
+export async function guardAiRequest(
+  request: Request,
+  env: RuntimeBindings | undefined,
+  feature: AiControlFeature,
+): Promise<AiControlContext | Response> {
+  const policy = getAIRuntimePolicy(env);
+  const user = getAuthenticatedUser(request);
+
+  if (policy.require_auth && !user) {
+    return jsonFailure('AI_AUTH_REQUIRED', 'AI 기능은 로그인 후 사용할 수 있습니다.', 401);
+  }
+
+  if (feature === 'stt' && !policy.enable_stt) {
+    return jsonFailure('STT_DISABLED', '현재 환경에서는 STT 기능이 비활성화되어 있습니다.', 403);
+  }
+
+  if (policy.public_mode === 'dev') {
+    return { user, policy };
+  }
+
+  const db = env?.DB;
+  if (!db) {
+    return jsonFailure('AI_QUOTA_STORAGE_REQUIRED', '공개 테스트 quota 저장소가 필요합니다.', 503);
+  }
+
+  await ensureSchema(db);
+
+  const ip = getClientIp(request);
+  const minuteWindow = getMinuteWindowKey();
+  const hourWindow = getHourWindowKey();
+
+  const minuteLimit = await bumpRateLimit(db, `minute:${feature}:${ip}:${minuteWindow}`, 'minute', RATE_LIMITS.perMinute);
+  if (!minuteLimit.allowed) {
+    return jsonFailure('RATE_LIMIT_EXCEEDED', '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.', 429);
+  }
+
+  const hourLimit = await bumpRateLimit(db, `hour:${feature}:${ip}:${hourWindow}`, 'hour', RATE_LIMITS.perHour);
+  if (!hourLimit.allowed) {
+    return jsonFailure('RATE_LIMIT_EXCEEDED', '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.', 429);
+  }
+
+  if (feature === 'search') {
+    return { user, policy };
+  }
+
+  const quotaLimit = getQuotaLimit(policy, feature);
+  if (!quotaLimit) {
+    return { user, policy };
+  }
+
+  const actorId = user?.id ?? 'anonymous';
+
+  const dailyUsage = await bumpDailyUsage(db, actorId, feature, quotaLimit);
+  if (!dailyUsage.allowed) {
+    return jsonFailure('AI_QUOTA_EXCEEDED', '일일 사용 한도를 초과했습니다.', 429);
+  }
+
+  if (policy.daily_limits.total && shouldCountTotal(feature)) {
+    const totalUsage = await bumpDailyTotal(db, actorId, policy.daily_limits.total);
+    if (!totalUsage.allowed) {
+      return jsonFailure('AI_TOTAL_QUOTA_EXCEEDED', '일일 AI 총 사용 한도를 초과했습니다.', 429);
+    }
+  }
+
+  if (policy.daily_limits.gemini && shouldCountGemini(feature)) {
+    const geminiUsage = await bumpGlobalQuota(db, 'gemini', policy.daily_limits.gemini);
+    if (!geminiUsage.allowed) {
+      return jsonFailure('AI_GEMINI_QUOTA_EXCEEDED', 'Gemini 일일 사용 한도를 초과했습니다.', 429);
+    }
+  }
+
+  return { user, policy };
+}

--- a/backend/src/lib/ai-engine-runners.ts
+++ b/backend/src/lib/ai-engine-runners.ts
@@ -9,7 +9,7 @@ import type {
   AISummaryResult,
   AIProviderName,
 } from '@myway/shared';
-import { getAIProviderSelection } from './ai-provider';
+import { getAIProviderSelectionForRuntime } from './ai-provider';
 import { runGeminiJsonPrompt, runOllamaChat } from './providers';
 import type { RuntimeBindings } from './runtime-env';
 import {
@@ -50,7 +50,7 @@ async function runStructuredJsonFallback(
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
 ): Promise<string | null> {
-  const providerPlan = getAIProviderSelection(feature, preferredProvider);
+  const providerPlan = getAIProviderSelectionForRuntime(feature, env, preferredProvider);
 
   for (const provider of providerPlan.fallback_chain) {
     if (provider === 'ollama') {
@@ -84,7 +84,8 @@ async function runOllamaStructuredIntent(
 ): Promise<AIEngineExecution<AIIntentResult>> {
   const fallback = getIntentFallback(input);
 
-  if (!isRemoteFeatureEnabled('intent', preferredProvider)) {
+  const providerPlan = getAIProviderSelectionForRuntime('intent', env, preferredProvider);
+  if (providerPlan.current_provider === 'demo') {
     return {
       result: fallback,
       provider: 'demo',
@@ -92,11 +93,32 @@ async function runOllamaStructuredIntent(
     };
   }
 
-  const response = await runOllamaChat(buildIntentPrompt(input, fallback), env, {
-    model: getOllamaModel(env),
-    temperature: 0.1,
-    timeoutMs: OLLAMA_TIMEOUT_MS,
-  });
+  const messages = buildIntentPrompt(input, fallback);
+  let response: string | null = null;
+  let responseProvider: AIProviderName | null = null;
+
+  for (const provider of providerPlan.fallback_chain) {
+    if (provider === 'ollama') {
+      response = await runOllamaChat(messages, env, {
+        model: getOllamaModel(env),
+        temperature: 0.1,
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      responseProvider = response ? 'ollama' : null;
+    }
+
+    if (!response && provider === 'gemini') {
+      response = await runGeminiJsonPrompt(messages, env, {
+        model: getGeminiModel(env),
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      responseProvider = response ? 'gemini' : responseProvider;
+    }
+
+    if (response) {
+      break;
+    }
+  }
 
   const parsed = parseJsonObject(response ?? '');
   if (!parsed) {
@@ -117,8 +139,8 @@ async function runOllamaStructuredIntent(
       reason: pickString(parsed.reason, fallback.reason),
       needs_clarification: typeof parsed.needs_clarification === 'boolean' ? parsed.needs_clarification : fallback.needs_clarification,
     },
-    provider: 'ollama',
-    model: getOllamaModel(env),
+    provider: responseProvider ?? 'demo',
+    model: responseProvider === 'gemini' ? getGeminiModel(env) : getOllamaModel(env),
   };
 }
 
@@ -129,7 +151,8 @@ async function runOllamaStructuredAnswer(
 ): Promise<AIEngineExecution<AIAnswerResult>> {
   const fallback = getAnswerFallback(input);
 
-  if (!isRemoteFeatureEnabled('answer', preferredProvider)) {
+  const providerPlan = getAIProviderSelectionForRuntime('answer', env, preferredProvider);
+  if (providerPlan.current_provider === 'demo') {
     return {
       result: fallback,
       provider: 'demo',
@@ -137,11 +160,32 @@ async function runOllamaStructuredAnswer(
     };
   }
 
-  const response = await runOllamaChat(buildAnswerPrompt(input, fallback), env, {
-    model: getOllamaModel(env),
-    temperature: 0.2,
-    timeoutMs: OLLAMA_TIMEOUT_MS,
-  });
+  const messages = buildAnswerPrompt(input, fallback);
+  let response: string | null = null;
+  let responseProvider: AIProviderName | null = null;
+
+  for (const provider of providerPlan.fallback_chain) {
+    if (provider === 'ollama') {
+      response = await runOllamaChat(messages, env, {
+        model: getOllamaModel(env),
+        temperature: 0.2,
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      responseProvider = response ? 'ollama' : null;
+    }
+
+    if (!response && provider === 'gemini') {
+      response = await runGeminiJsonPrompt(messages, env, {
+        model: getGeminiModel(env),
+        timeoutMs: OLLAMA_TIMEOUT_MS,
+      });
+      responseProvider = response ? 'gemini' : responseProvider;
+    }
+
+    if (response) {
+      break;
+    }
+  }
 
   const parsed = parseJsonObject(response ?? '');
   if (!parsed) {
@@ -167,8 +211,8 @@ async function runOllamaStructuredAnswer(
       answer,
       suggestions: toStringArray(parsed.suggestions).slice(0, 2).concat(fallback.suggestions).slice(0, 2),
     },
-    provider: 'ollama',
-    model: getOllamaModel(env),
+    provider: responseProvider ?? 'demo',
+    model: responseProvider === 'gemini' ? getGeminiModel(env) : getOllamaModel(env),
   };
 }
 
@@ -215,7 +259,7 @@ export async function runAISummaryWithEngine(
   }
 
   const source = getLectureSourceText(input.lecture_id);
-  if (!source || !isRemoteFeatureEnabled('summary', preferredProvider) || input.style === 'timeline') {
+  if (!source || !isRemoteFeatureEnabled('summary', env, preferredProvider) || input.style === 'timeline') {
     return {
       result: fallback,
       provider: 'demo',
@@ -224,7 +268,7 @@ export async function runAISummaryWithEngine(
   }
 
   const messages = buildSummaryPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input.style, input.language);
-  const providerPlan = getAIProviderSelection('summary', preferredProvider);
+  const providerPlan = getAIProviderSelectionForRuntime('summary', env, preferredProvider);
   let response: string | null = null;
   let responseProvider: AIProviderName | null = null;
 
@@ -305,7 +349,7 @@ export async function runAIQuizWithEngine(
   }
 
   const source = getLectureSourceText(input.lecture_id);
-  if (!source || !isRemoteFeatureEnabled('quiz', preferredProvider)) {
+  if (!source || !isRemoteFeatureEnabled('quiz', env, preferredProvider)) {
     return {
       result: fallback,
       provider: 'demo',
@@ -314,7 +358,7 @@ export async function runAIQuizWithEngine(
   }
 
   const messages = buildQuizPrompt(source.lectureTitle, source.courseTitle, truncate(source.sourceText, 6000), input);
-  const providerPlan = getAIProviderSelection('quiz', preferredProvider);
+  const providerPlan = getAIProviderSelectionForRuntime('quiz', env, preferredProvider);
   let response: string | null = null;
   let responseProvider: AIProviderName | null = null;
 

--- a/backend/src/lib/ai-engine-utils.ts
+++ b/backend/src/lib/ai-engine-utils.ts
@@ -19,7 +19,7 @@ import {
   type AISummaryResult,
   type AIProviderName,
 } from '@myway/shared';
-import { getAIProviderSelection } from './ai-provider';
+import { getAIProviderSelectionForRuntime } from './ai-provider';
 import type { RuntimeBindings } from './runtime-env';
 
 export type JsonObject = Record<string, unknown>;
@@ -187,8 +187,8 @@ export function getGeminiModel(env?: RuntimeBindings): string {
   return env?.MYWAY_GEMINI_MODEL ?? env?.GEMINI_MODEL ?? 'gemini-2.0-flash';
 }
 
-export function isRemoteFeatureEnabled(feature: 'intent' | 'answer' | 'summary' | 'quiz', preferredProvider?: AIProviderName): boolean {
-  const provider = getAIProviderSelection(feature, preferredProvider);
+export function isRemoteFeatureEnabled(feature: 'intent' | 'answer' | 'summary' | 'quiz', env?: RuntimeBindings, preferredProvider?: AIProviderName): boolean {
+  const provider = getAIProviderSelectionForRuntime(feature, env, preferredProvider);
   return provider.current_provider === 'ollama' || provider.current_provider === 'gemini';
 }
 

--- a/backend/src/lib/ai-provider.ts
+++ b/backend/src/lib/ai-provider.ts
@@ -1,4 +1,5 @@
 import { getAIProviderCatalog, getAIProviderPlan, type AIProviderCapability, type AIProviderName } from '@myway/shared';
+import { getAIRuntimePolicy, type RuntimeBindings } from './runtime-env';
 
 export type AIProviderSelection = {
   feature: AIProviderCapability;
@@ -8,14 +9,14 @@ export type AIProviderSelection = {
 };
 
 const DEFAULT_FALLBACK_ORDER: Record<AIProviderCapability, AIProviderName[]> = {
-  intent: ['ollama', 'gemini', 'cloudflare', 'demo'],
-  search: ['ollama', 'gemini', 'cloudflare', 'demo'],
-  answer: ['ollama', 'gemini', 'cloudflare', 'demo'],
-  summary: ['ollama', 'gemini', 'cloudflare', 'demo'],
-  quiz: ['ollama', 'gemini', 'cloudflare', 'demo'],
-  smart: ['ollama', 'gemini', 'cloudflare', 'demo'],
-  insights: ['ollama', 'gemini', 'cloudflare', 'demo'],
-  recommendations: ['ollama', 'gemini', 'cloudflare', 'demo'],
+  intent: ['ollama', 'gemini', 'demo'],
+  search: ['demo'],
+  answer: ['ollama', 'gemini', 'demo'],
+  summary: ['ollama', 'gemini', 'demo'],
+  quiz: ['ollama', 'gemini', 'demo'],
+  smart: ['ollama', 'gemini', 'demo'],
+  insights: ['ollama', 'gemini', 'demo'],
+  recommendations: ['ollama', 'gemini', 'demo'],
   stt: ['cloudflare', 'gemini', 'demo'],
   embedding: ['cloudflare', 'ollama', 'demo'],
 };
@@ -35,6 +36,33 @@ export function getAIProviderSelection(feature: AIProviderCapability, preferredP
     feature: plan.feature,
     current_provider: preferredProvider ?? plan.current_provider,
     recommended_chain: plan.recommended_chain,
+    fallback_chain,
+  };
+}
+
+export function getAIProviderSelectionForRuntime(
+  feature: AIProviderCapability,
+  env?: RuntimeBindings,
+  preferredProvider?: AIProviderName,
+): AIProviderSelection {
+  const policy = getAIRuntimePolicy(env);
+  const baseChain: AIProviderName[] =
+    feature === 'search'
+      ? ['demo']
+      : policy.public_mode === 'dev'
+        ? ['ollama', 'gemini', 'demo']
+        : ['gemini', 'demo'];
+
+  const normalizedPreferred = preferredProvider && baseChain.includes(preferredProvider) ? preferredProvider : undefined;
+  const fallback_chain = uniqueProviders([
+    ...(normalizedPreferred ? [normalizedPreferred] : []),
+    ...baseChain,
+  ]);
+
+  return {
+    feature,
+    current_provider: normalizedPreferred ?? baseChain[0],
+    recommended_chain: baseChain,
     fallback_chain,
   };
 }

--- a/backend/src/lib/runtime-env.ts
+++ b/backend/src/lib/runtime-env.ts
@@ -47,6 +47,7 @@ export type RuntimeBindings = {
   MYWAY_AI_DAILY_LIMIT_STT?: string;
   MYWAY_AI_DAILY_LIMIT_ANSWER?: string;
   MYWAY_AI_DAILY_LIMIT_GEMINI?: string;
+  MYWAY_AI_DAILY_LIMIT_TOTAL?: string;
   MYWAY_OLLAMA_BASE_URL?: string;
   OLLAMA_BASE_URL?: string;
   MYWAY_OLLAMA_MODEL?: string;
@@ -138,6 +139,7 @@ export function getAIRuntimePolicy(env?: RuntimeBindings): {
   enable_stt: boolean;
   enable_media_upload: boolean;
   daily_limits: {
+    total?: number;
     smart?: number;
     summary?: number;
     quiz?: number;
@@ -167,6 +169,7 @@ export function getAIRuntimePolicy(env?: RuntimeBindings): {
       stt: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_STT),
       answer: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_ANSWER),
       gemini: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_GEMINI),
+      total: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_TOTAL),
     },
   };
 }

--- a/backend/src/lib/runtime-env.ts
+++ b/backend/src/lib/runtime-env.ts
@@ -1,3 +1,5 @@
+import type { D1Database } from '@cloudflare/workers-types';
+
 export type WorkersAI = {
   run: <TInput extends Record<string, unknown>, TOutput = unknown>(model: string, input: TInput) => Promise<TOutput>;
 };
@@ -27,13 +29,24 @@ export type R2BucketLike = {
   >;
 };
 
-type RuntimeStringKey = Exclude<keyof RuntimeBindings, 'AI' | 'ASSETS'>;
+type RuntimeStringKey = Exclude<keyof RuntimeBindings, 'AI' | 'ASSETS' | 'DB'>;
 
 export type RuntimeBindings = {
   APP_ENV?: 'development' | 'staging' | 'production';
   API_ORIGIN?: string;
   AI?: WorkersAI;
+  DB?: D1Database;
   ASSETS?: R2BucketLike;
+  MYWAY_AI_PUBLIC_MODE?: 'dev' | 'free_test';
+  MYWAY_AI_REQUIRE_AUTH?: string;
+  MYWAY_AI_ENABLE_STT?: string;
+  MYWAY_AI_ENABLE_MEDIA_UPLOAD?: string;
+  MYWAY_AI_DAILY_LIMIT_SMART?: string;
+  MYWAY_AI_DAILY_LIMIT_SUMMARY?: string;
+  MYWAY_AI_DAILY_LIMIT_QUIZ?: string;
+  MYWAY_AI_DAILY_LIMIT_STT?: string;
+  MYWAY_AI_DAILY_LIMIT_ANSWER?: string;
+  MYWAY_AI_DAILY_LIMIT_GEMINI?: string;
   MYWAY_OLLAMA_BASE_URL?: string;
   OLLAMA_BASE_URL?: string;
   MYWAY_OLLAMA_MODEL?: string;
@@ -116,5 +129,44 @@ export function getMediaProcessorRuntimeSettings(env?: RuntimeBindings): {
     url: getRuntimeValue(env, 'MYWAY_MEDIA_PROCESSOR_URL', getRuntimeValue(env, 'MEDIA_PROCESSOR_URL')),
     token: getRuntimeValue(env, 'MYWAY_MEDIA_PROCESSOR_TOKEN', getRuntimeValue(env, 'MEDIA_PROCESSOR_TOKEN')),
     callback_secret: getRuntimeValue(env, 'MYWAY_MEDIA_CALLBACK_SECRET', getRuntimeValue(env, 'MEDIA_CALLBACK_SECRET')),
+  };
+}
+
+export function getAIRuntimePolicy(env?: RuntimeBindings): {
+  public_mode: 'dev' | 'free_test';
+  require_auth: boolean;
+  enable_stt: boolean;
+  enable_media_upload: boolean;
+  daily_limits: {
+    smart?: number;
+    summary?: number;
+    quiz?: number;
+    stt?: number;
+    answer?: number;
+    gemini?: number;
+  };
+} {
+  const parseLimit = (value: string | undefined): number | undefined => {
+    if (!value) {
+      return undefined;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  };
+
+  return {
+    public_mode: env?.MYWAY_AI_PUBLIC_MODE ?? 'dev',
+    require_auth: (env?.MYWAY_AI_REQUIRE_AUTH ?? 'false') === 'true',
+    enable_stt: (env?.MYWAY_AI_ENABLE_STT ?? 'true') === 'true',
+    enable_media_upload: (env?.MYWAY_AI_ENABLE_MEDIA_UPLOAD ?? 'true') === 'true',
+    daily_limits: {
+      smart: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_SMART),
+      summary: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_SUMMARY),
+      quiz: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_QUIZ),
+      stt: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_STT),
+      answer: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_ANSWER),
+      gemini: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_GEMINI),
+    },
   };
 }

--- a/backend/src/lib/stt-adapter.ts
+++ b/backend/src/lib/stt-adapter.ts
@@ -3,6 +3,8 @@ import { getSTTProviderSelection } from './stt-provider';
 import { runCloudflareTranscription } from './providers';
 import type { RuntimeBindings } from './runtime-env';
 
+export const PUBLIC_STT_MAX_DURATION_MS = 180_000;
+
 export type STTAdapterResult =
   | {
       ok: true;
@@ -17,7 +19,7 @@ export type STTAdapterResult =
     }
   | {
       ok: false;
-      reason: 'lecture_not_found' | 'transcript_failed';
+      reason: 'lecture_not_found' | 'transcript_failed' | 'input_too_large';
   };
 
 export async function runTranscriptGeneration(
@@ -26,6 +28,13 @@ export async function runTranscriptGeneration(
   preferredProvider?: 'demo' | 'cloudflare' | 'gemini',
   env?: RuntimeBindings,
 ): Promise<STTAdapterResult> {
+  if (typeof input.duration_ms === 'number' && input.duration_ms > PUBLIC_STT_MAX_DURATION_MS) {
+    return {
+      ok: false,
+      reason: 'input_too_large',
+    };
+  }
+
   const provider = getSTTProviderSelection('transcribe', preferredProvider);
 
   if (provider.current_provider === 'cloudflare' && input.audio_url) {
@@ -38,6 +47,13 @@ export async function runTranscriptGeneration(
     );
 
     if (cloudflareResult) {
+      if (typeof cloudflareResult.duration_ms === 'number' && cloudflareResult.duration_ms > PUBLIC_STT_MAX_DURATION_MS) {
+        return {
+          ok: false,
+          reason: 'input_too_large',
+        };
+      }
+
       const result = createLectureTranscript(userId, {
         ...input,
         text: cloudflareResult.text,

--- a/backend/src/routes/ai-providers.ts
+++ b/backend/src/routes/ai-providers.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { getAIProviderOverview } from '../lib/ai-provider';
 import { getAuthenticatedUser } from '../lib/auth';
 import { jsonFailure, jsonSuccess } from '../lib/http';
+import { getAIRuntimePolicy, type RuntimeBindings } from '../lib/runtime-env';
 
 const aiProviders = new Hono();
 
@@ -11,9 +12,14 @@ aiProviders.get('/', (c) => {
     return jsonFailure('UNAUTHENTICATED', '로그인이 필요합니다.', 401);
   }
 
+  const env = c.env as RuntimeBindings | undefined;
+  const policy = getAIRuntimePolicy(env);
+
   return jsonSuccess(
     {
       ...getAIProviderOverview(),
+      runtime_policy: policy,
+      active_provider: policy.public_mode === 'dev' ? 'ollama' : 'gemini',
       requested_by: user.role,
     },
     'AI provider 구성을 조회했습니다.',

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -11,10 +11,10 @@ import {
   type AISummaryRequest,
 } from '@myway/shared';
 import { runAIAnswer, runAIIntent, runAIQuiz, runAISearch, runAISummary } from '../lib/ai-adapter';
-import { getAIProviderSelection } from '../lib/ai-provider';
-import { getAuthenticatedUser } from '../lib/auth';
+import { getAIProviderSelectionForRuntime } from '../lib/ai-provider';
+import { guardAiRequest } from '../lib/ai-controls';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
-import type { RuntimeBindings } from '../lib/runtime-env';
+import { getGeminiRuntimeSettings, type RuntimeBindings } from '../lib/runtime-env';
 
 const ai = new Hono();
 
@@ -60,7 +60,15 @@ function buildResponseMetadata(feature: 'intent' | 'search' | 'answer' | 'summar
     return { provider: 'demo', model: 'demo-search-v1' };
   }
 
-  return { provider: getAIProviderSelection(feature).current_provider, model: getOllamaModel(env) };
+  const provider = getAIProviderSelectionForRuntime(feature, env).current_provider;
+  const model =
+    provider === 'gemini'
+      ? getGeminiRuntimeSettings(env).model ?? 'gemini-2.0-flash'
+      : provider === 'ollama'
+        ? getOllamaModel(env)
+        : `demo-${feature}-v1`;
+
+  return { provider, model };
 }
 
 function recordUsageLog(input: {
@@ -87,7 +95,12 @@ function recordUsageLog(input: {
 }
 
 ai.post('/intent', async (c) => {
-  const user = getAuthenticatedUser(c.req.raw);
+  const access = await guardAiRequest(c.req.raw, c.env as RuntimeBindings | undefined, 'intent');
+  if (access instanceof Response) {
+    return access;
+  }
+
+  const { user } = access;
   const body = await readJsonBody<AIIntentRequest>(c.req.raw);
   const message = body?.message?.trim();
 
@@ -135,7 +148,12 @@ ai.post('/intent', async (c) => {
 });
 
 ai.post('/search', async (c) => {
-  const user = getAuthenticatedUser(c.req.raw);
+  const access = await guardAiRequest(c.req.raw, c.env as RuntimeBindings | undefined, 'search');
+  if (access instanceof Response) {
+    return access;
+  }
+
+  const { user } = access;
   const body = await readJsonBody<AISearchRequest>(c.req.raw);
   const query = body?.query?.trim();
 
@@ -172,7 +190,12 @@ ai.post('/search', async (c) => {
 });
 
 ai.post('/answer', async (c) => {
-  const user = getAuthenticatedUser(c.req.raw);
+  const access = await guardAiRequest(c.req.raw, c.env as RuntimeBindings | undefined, 'answer');
+  if (access instanceof Response) {
+    return access;
+  }
+
+  const { user } = access;
   const body = await readJsonBody<AIAnswerRequest>(c.req.raw);
   const question = body?.question?.trim();
 
@@ -224,7 +247,12 @@ ai.post('/answer', async (c) => {
 });
 
 ai.post('/summary', async (c) => {
-  const user = getAuthenticatedUser(c.req.raw);
+  const access = await guardAiRequest(c.req.raw, c.env as RuntimeBindings | undefined, 'summary');
+  if (access instanceof Response) {
+    return access;
+  }
+
+  const { user } = access;
   const body = await readJsonBody<AISummaryRequest>(c.req.raw);
   const lectureId = body?.lecture_id?.trim();
 
@@ -270,7 +298,12 @@ ai.post('/summary', async (c) => {
 });
 
 ai.post('/quiz', async (c) => {
-  const user = getAuthenticatedUser(c.req.raw);
+  const access = await guardAiRequest(c.req.raw, c.env as RuntimeBindings | undefined, 'quiz');
+  if (access instanceof Response) {
+    return access;
+  }
+
+  const { user } = access;
   const body = await readJsonBody<AIQuizRequest>(c.req.raw);
   const lectureId = body?.lecture_id?.trim();
 

--- a/backend/src/routes/media.ts
+++ b/backend/src/routes/media.ts
@@ -19,7 +19,8 @@ import { completeMediaExtractionJob, createMediaExtractionJob } from '../lib/med
 import { normalizeMediaCallbackPayload, verifyMediaCallbackSecret } from '../lib/media-processor';
 import { buildExtractionCallbackResponse, buildExtractionResponse } from '../lib/media-response';
 import { getSTTProviderOverview } from '../lib/stt-provider';
-import { runTranscriptGeneration } from '../lib/stt-adapter';
+import { PUBLIC_STT_MAX_DURATION_MS, runTranscriptGeneration } from '../lib/stt-adapter';
+import { guardAiRequest } from '../lib/ai-controls';
 import type { RuntimeBindings } from '../lib/runtime-env';
 
 const media = new Hono();
@@ -77,6 +78,11 @@ media.post('/transcribe', async (c) => {
     return jsonFailure('UNAUTHENTICATED', '로그인이 필요합니다.', 401);
   }
 
+  const access = await guardAiRequest(c.req.raw, c.env as RuntimeBindings | undefined, 'stt');
+  if (access instanceof Response) {
+    return access;
+  }
+
   const body = await readJsonBody<TranscriptCreateRequest>(c.req.raw);
   const lectureId = body?.lecture_id?.trim();
 
@@ -86,6 +92,10 @@ media.post('/transcribe', async (c) => {
 
   if (!ensureLectureExists(lectureId, user.id)) {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
+  }
+
+  if (typeof body?.duration_ms === 'number' && body.duration_ms > PUBLIC_STT_MAX_DURATION_MS) {
+    return jsonFailure('STT_INPUT_TOO_LONG', '오디오 길이는 3분 이하만 허용됩니다.', 413);
   }
 
   const result = await runTranscriptGeneration(user.id, {
@@ -99,6 +109,10 @@ media.post('/transcribe', async (c) => {
   }, undefined, c.env as RuntimeBindings | undefined);
 
   if (!result.ok) {
+    if (result.reason === 'input_too_large') {
+      return jsonFailure('STT_INPUT_TOO_LONG', '오디오 길이는 3분 이하만 허용됩니다.', 413);
+    }
+
     return jsonFailure('TRANSCRIPT_FAILED', '트랜스크립트를 생성할 수 없습니다.', 400);
   }
 

--- a/backend/src/routes/smart.ts
+++ b/backend/src/routes/smart.ts
@@ -1,8 +1,9 @@
 import { Hono } from 'hono';
 import { getCourseDetail, getLectureDetail, type SmartChatRequest } from '@myway/shared';
-import { getAuthenticatedUser } from '../lib/auth';
+import { guardAiRequest } from '../lib/ai-controls';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
 import { runSmartChat } from '../lib/smart-chat';
+import type { RuntimeBindings } from '../lib/runtime-env';
 
 const smart = new Hono();
 
@@ -11,10 +12,12 @@ function ensureLectureExists(lectureId: string): boolean {
 }
 
 smart.post('/chat', async (c) => {
-  const user = getAuthenticatedUser(c.req.raw);
-  if (!user) {
-    return jsonFailure('UNAUTHENTICATED', '로그인이 필요합니다.', 401);
+  const access = await guardAiRequest(c.req.raw, c.env as RuntimeBindings | undefined, 'smart');
+  if (access instanceof Response) {
+    return access;
   }
+  const user = access.user;
+  const userId = user?.id ?? 'guest';
 
   const body = await readJsonBody<SmartChatRequest>(c.req.raw);
   const message = body?.message?.trim();
@@ -29,7 +32,7 @@ smart.post('/chat', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  if (courseId && !getCourseDetail(courseId, user.id)) {
+  if (courseId && !getCourseDetail(courseId, userId)) {
     return jsonFailure('COURSE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -37,11 +37,10 @@
         "MYWAY_AI_DAILY_LIMIT_QUIZ": "999",
         "MYWAY_AI_DAILY_LIMIT_STT": "999",
         "MYWAY_AI_DAILY_LIMIT_ANSWER": "999",
+        "MYWAY_AI_DAILY_LIMIT_TOTAL": "999",
         "MYWAY_AI_DAILY_LIMIT_GEMINI": "999",
         "MYWAY_CLOUDFLARE_STT_MODEL": "@cf/openai/whisper-large-v3-turbo",
         "MYWAY_MEDIA_PROCESSOR_URL": "http://127.0.0.1:8788/jobs/audio-extraction",
-        "MYWAY_MEDIA_PROCESSOR_TOKEN": "local-media-processor-token",
-        "MYWAY_MEDIA_CALLBACK_SECRET": "local-media-callback-secret",
         "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
         "MYWAY_OLLAMA_MODEL": "llama3.1:8b"
       }
@@ -59,11 +58,10 @@
         "MYWAY_AI_DAILY_LIMIT_QUIZ": "20",
         "MYWAY_AI_DAILY_LIMIT_STT": "10",
         "MYWAY_AI_DAILY_LIMIT_ANSWER": "40",
+        "MYWAY_AI_DAILY_LIMIT_TOTAL": "50",
         "MYWAY_AI_DAILY_LIMIT_GEMINI": "120",
         "MYWAY_CLOUDFLARE_STT_MODEL": "@cf/openai/whisper-large-v3-turbo",
         "MYWAY_MEDIA_PROCESSOR_URL": "https://media-processor.staging.mywayclass.com/jobs/audio-extraction",
-        "MYWAY_MEDIA_PROCESSOR_TOKEN": "replace-with-staging-token",
-        "MYWAY_MEDIA_CALLBACK_SECRET": "replace-with-staging-secret",
         "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
         "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
       }
@@ -81,11 +79,10 @@
         "MYWAY_AI_DAILY_LIMIT_QUIZ": "20",
         "MYWAY_AI_DAILY_LIMIT_STT": "10",
         "MYWAY_AI_DAILY_LIMIT_ANSWER": "40",
+        "MYWAY_AI_DAILY_LIMIT_TOTAL": "50",
         "MYWAY_AI_DAILY_LIMIT_GEMINI": "120",
         "MYWAY_CLOUDFLARE_STT_MODEL": "@cf/openai/whisper-large-v3-turbo",
         "MYWAY_MEDIA_PROCESSOR_URL": "https://media-processor.mywayclass.com/jobs/audio-extraction",
-        "MYWAY_MEDIA_PROCESSOR_TOKEN": "replace-with-production-token",
-        "MYWAY_MEDIA_CALLBACK_SECRET": "replace-with-production-secret",
         "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
         "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
       }

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -3,21 +3,20 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-04-06",
   "d1_databases": [
-    // Bind the Cloudflare D1 database here as `DB`.
+    {
+      "binding": "DB",
+      "database_name": "myway-class-quota",
+      "database_id": "REPLACE_WITH_D1_DATABASE_ID"
+    }
   ],
   "r2_buckets": [
-    // Bind the Cloudflare R2 bucket here as `ASSETS`.
+    {
+      "binding": "ASSETS",
+      "bucket_name": "myway-class-assets"
+    }
   ],
   "vars": {
-    "APP_ENV": "development",
-    "API_ORIGIN": "http://localhost:5173",
     "MYWAY_CLOUDFLARE_STT_MODEL": "@cf/openai/whisper-large-v3-turbo",
-    "MYWAY_MEDIA_PROCESSOR_URL": "http://127.0.0.1:8788/jobs/audio-extraction",
-    "MYWAY_MEDIA_PROCESSOR_TOKEN": "local-media-processor-token",
-    "MYWAY_MEDIA_CALLBACK_SECRET": "local-media-callback-secret",
-    "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
-    "MYWAY_OLLAMA_MODEL": "llama3.1:8b",
-    "MYWAY_GEMINI_API_KEY": "replace-with-local-gemini-key",
     "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
     "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
   },
@@ -29,28 +28,42 @@
       "vars": {
         "APP_ENV": "development",
         "API_ORIGIN": "http://localhost:5173",
+        "MYWAY_AI_PUBLIC_MODE": "dev",
+        "MYWAY_AI_REQUIRE_AUTH": "false",
+        "MYWAY_AI_ENABLE_STT": "true",
+        "MYWAY_AI_ENABLE_MEDIA_UPLOAD": "true",
+        "MYWAY_AI_DAILY_LIMIT_SMART": "999",
+        "MYWAY_AI_DAILY_LIMIT_SUMMARY": "999",
+        "MYWAY_AI_DAILY_LIMIT_QUIZ": "999",
+        "MYWAY_AI_DAILY_LIMIT_STT": "999",
+        "MYWAY_AI_DAILY_LIMIT_ANSWER": "999",
+        "MYWAY_AI_DAILY_LIMIT_GEMINI": "999",
         "MYWAY_CLOUDFLARE_STT_MODEL": "@cf/openai/whisper-large-v3-turbo",
         "MYWAY_MEDIA_PROCESSOR_URL": "http://127.0.0.1:8788/jobs/audio-extraction",
         "MYWAY_MEDIA_PROCESSOR_TOKEN": "local-media-processor-token",
         "MYWAY_MEDIA_CALLBACK_SECRET": "local-media-callback-secret",
         "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
-        "MYWAY_OLLAMA_MODEL": "llama3.1:8b",
-        "MYWAY_GEMINI_API_KEY": "replace-with-local-gemini-key",
-        "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
-        "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
+        "MYWAY_OLLAMA_MODEL": "llama3.1:8b"
       }
     },
     "staging": {
       "vars": {
         "APP_ENV": "staging",
         "API_ORIGIN": "https://staging.mywayclass.pages.dev",
+        "MYWAY_AI_PUBLIC_MODE": "free_test",
+        "MYWAY_AI_REQUIRE_AUTH": "true",
+        "MYWAY_AI_ENABLE_STT": "true",
+        "MYWAY_AI_ENABLE_MEDIA_UPLOAD": "false",
+        "MYWAY_AI_DAILY_LIMIT_SMART": "25",
+        "MYWAY_AI_DAILY_LIMIT_SUMMARY": "30",
+        "MYWAY_AI_DAILY_LIMIT_QUIZ": "20",
+        "MYWAY_AI_DAILY_LIMIT_STT": "10",
+        "MYWAY_AI_DAILY_LIMIT_ANSWER": "40",
+        "MYWAY_AI_DAILY_LIMIT_GEMINI": "120",
         "MYWAY_CLOUDFLARE_STT_MODEL": "@cf/openai/whisper-large-v3-turbo",
         "MYWAY_MEDIA_PROCESSOR_URL": "https://media-processor.staging.mywayclass.com/jobs/audio-extraction",
         "MYWAY_MEDIA_PROCESSOR_TOKEN": "replace-with-staging-token",
         "MYWAY_MEDIA_CALLBACK_SECRET": "replace-with-staging-secret",
-        "MYWAY_OLLAMA_BASE_URL": "https://ollama.staging.mywayclass.com",
-        "MYWAY_OLLAMA_MODEL": "llama3.1",
-        "MYWAY_GEMINI_API_KEY": "replace-with-staging-gemini-key",
         "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
         "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
       }
@@ -59,13 +72,20 @@
       "vars": {
         "APP_ENV": "production",
         "API_ORIGIN": "https://mywayclass.pages.dev",
+        "MYWAY_AI_PUBLIC_MODE": "free_test",
+        "MYWAY_AI_REQUIRE_AUTH": "true",
+        "MYWAY_AI_ENABLE_STT": "true",
+        "MYWAY_AI_ENABLE_MEDIA_UPLOAD": "false",
+        "MYWAY_AI_DAILY_LIMIT_SMART": "25",
+        "MYWAY_AI_DAILY_LIMIT_SUMMARY": "30",
+        "MYWAY_AI_DAILY_LIMIT_QUIZ": "20",
+        "MYWAY_AI_DAILY_LIMIT_STT": "10",
+        "MYWAY_AI_DAILY_LIMIT_ANSWER": "40",
+        "MYWAY_AI_DAILY_LIMIT_GEMINI": "120",
         "MYWAY_CLOUDFLARE_STT_MODEL": "@cf/openai/whisper-large-v3-turbo",
         "MYWAY_MEDIA_PROCESSOR_URL": "https://media-processor.mywayclass.com/jobs/audio-extraction",
         "MYWAY_MEDIA_PROCESSOR_TOKEN": "replace-with-production-token",
         "MYWAY_MEDIA_CALLBACK_SECRET": "replace-with-production-secret",
-        "MYWAY_OLLAMA_BASE_URL": "https://ollama.mywayclass.com",
-        "MYWAY_OLLAMA_MODEL": "llama3.1",
-        "MYWAY_GEMINI_API_KEY": "replace-with-production-gemini-key",
         "MYWAY_GEMINI_MODEL": "gemini-2.0-flash",
         "MYWAY_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta"
       }

--- a/docs/dev-logs/2026-04-10-ai-free-tier-p0-controls.md
+++ b/docs/dev-logs/2026-04-10-ai-free-tier-p0-controls.md
@@ -1,0 +1,17 @@
+# 2026-04-10 AI 무료 티어 P0 보호 강화
+
+## 변경 이유
+- 공개 테스트에서 민감정보가 `wrangler.jsonc`에 남아 있던 부분을 제거해야 했음.
+- `dev`/`staging`/`production`의 provider 정책을 실제 라우트에서 강제할 필요가 있었음.
+- 무료 티어 공개 테스트에서 `AI/STT` 로그인, 일일 quota, 단기 rate limit, STT 길이 제한이 필요했음.
+
+## 변경 내용
+- `MYWAY_MEDIA_PROCESSOR_TOKEN`, `MYWAY_MEDIA_CALLBACK_SECRET`를 `wrangler.jsonc` vars에서 제거함.
+- `MYWAY_AI_DAILY_LIMIT_TOTAL`을 추가하고, free_test 환경에 총량 quota를 넣음.
+- `AI` 라우트와 `smart/chat`에 로그인 + rate limit + quota guard를 붙임.
+- `dev`는 Ollama, `staging/production`은 Gemini 중심으로 강제되도록 provider 선택을 runtime 정책 기반으로 바꿈.
+- `transcribe` 경로에 3분 하드 리밋을 추가함.
+- D1 quota 테이블 마이그레이션 파일을 추가함.
+
+## 검증
+- `npm run verify` 통과

--- a/docs/dev-logs/2026-04-10-ai-runtime-policy-and-binding-setup.md
+++ b/docs/dev-logs/2026-04-10-ai-runtime-policy-and-binding-setup.md
@@ -1,0 +1,14 @@
+# AI runtime policy and binding setup
+
+## 왜 바꿨는가
+- 무료 티어 공개 테스트를 위해 `dev`와 `staging`/`production`의 provider 정책을 분리할 공통 설정이 필요했다.
+- quota와 공개 테스트 정책이 다음 단계에서 안정적으로 붙을 수 있도록 runtime bindings를 먼저 정리해야 했다.
+
+## 무엇을 바꿨는가
+- `backend/wrangler.jsonc`에서 D1 `DB`와 R2 `ASSETS` 바인딩을 추가하고, `MYWAY_GEMINI_API_KEY`를 vars에서 제거했다.
+- `dev`는 Ollama 허용, `staging`/`production`은 free_test 정책 변수와 일일 한도 값을 가지도록 정리했다.
+- `backend/src/lib/runtime-env.ts`에 `DB` 타입과 AI 공개 정책/일일 quota 설정 타입 및 헬퍼를 추가했다.
+
+## 어떻게 검증했는가
+- `git diff`로 wrangler 설정과 runtime bindings 변경 범위를 확인했다.
+- 이후 quota/provider 작업이 바로 이어질 수 있도록 환경 변수 이름과 기본값을 정리했다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-10-ai-runtime-policy-and-binding-setup.md`
 - `2026-04-10-ollama-smart-chat-integration.md`
 - `2026-04-10-gemini-fallback-summary-quiz.md`
 - `2026-04-10-media-pipeline-failure-retry.md`

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-10-ai-free-tier-p0-controls.md`
 - `2026-04-10-ai-runtime-policy-and-binding-setup.md`
 - `2026-04-10-ollama-smart-chat-integration.md`
 - `2026-04-10-gemini-fallback-summary-quiz.md`


### PR DESCRIPTION
# 변경 요약
무료 티어 공개 테스트를 위한 AI 런타임 정책과 Cloudflare 바인딩 구성을 정리했습니다.

## 배경
staging/production에서 Ollama를 전제로 두던 구성을 정리하고, 이후 quota와 provider 정책이 붙을 수 있는 공통 기반이 필요했습니다.

## 변경 내용
- `backend/wrangler.jsonc`에서 D1 `DB`와 R2 `ASSETS` 바인딩을 추가했습니다.
- `MYWAY_GEMINI_API_KEY`를 vars에서 제거하고, env별 공개 테스트 정책 변수와 일일 한도를 추가했습니다.
- `backend/src/lib/runtime-env.ts`에 DB 타입과 AI 공개 정책 헬퍼를 추가했습니다.
- `docs/dev-logs/`에 변경 요약을 남겼습니다.

## 연결 이슈
- Closes #114
- Fixes #114

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
