### PR TITLE
feat: update admin automation provider guidance

### DIFF
--- a/docs/dev-logs/2026-04-10-admin-automation-provider-runtime-policy.md
+++ b/docs/dev-logs/2026-04-10-admin-automation-provider-runtime-policy.md
@@ -1,0 +1,8 @@
+# 2026-04-10 관리자 자동화 provider runtime policy 갱신
+
+- issue #125는 관리자 자동화 화면의 provider 안내 문구가 예전 fallback 설명에 머물러 있어서, 현재 runtime policy 기준으로 정리할 필요가 있었다.
+- `packages/shared/src/ai/ai-provider.ts`의 provider 설명과 단계 설명을 dev / staging / production 정책에 맞게 바꿨다.
+- `frontend/src/features/lms/pages/AdminAutomationPage.tsx`에 runtime policy 요약 카드를 추가해서 운영 모드, AI 로그인, STT, 미디어 업로드 상태를 한눈에 보이게 했다.
+
+## 검증
+- `npm run verify` 통과

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-10-admin-automation-provider-runtime-policy.md`
 - `2026-04-10-quota-rate-limit-ui-notice.md`
 - `2026-04-10-free-tier-docs-secret-d1.md`
 - `2026-04-10-free-tier-public-test-policy-summary.md`

--- a/frontend/src/features/lms/pages/AdminAutomationPage.tsx
+++ b/frontend/src/features/lms/pages/AdminAutomationPage.tsx
@@ -72,6 +72,11 @@ type AdminAutomationPageProps = {
 
 export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProps) {
   const providerPlans = providerCatalog?.plans.slice(0, 4) ?? [];
+  const runtimePolicy = providerCatalog?.runtime_policy;
+  const runtimeModeLabel = runtimePolicy?.public_mode === 'free_test' ? '공개 테스트' : '개발';
+  const authLabel = runtimePolicy?.require_auth ? '로그인 필수' : '로그인 선택';
+  const sttLabel = runtimePolicy?.enable_stt ? 'STT 활성' : 'STT 비활성';
+  const uploadLabel = runtimePolicy?.enable_media_upload ? '업로드 허용' : '업로드 차단';
 
   return (
     <div className="space-y-5">
@@ -124,8 +129,29 @@ export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProp
           AI provider 계층
         </h3>
         <p className="mt-2 text-[12px] leading-6 text-slate-500">
-          현재는 demo 엔진으로 기본 동작을 유지하고, 앞으로는 Ollama, Gemini, Cloudflare AI 순으로 기능별 fallback을 적용합니다.
+          현재 화면은 runtime policy 기준으로 보여주며, dev는 Ollama, staging/production은 Gemini 중심, STT는 Cloudflare 우선으로 안내합니다.
         </p>
+
+        {runtimePolicy ? (
+          <div className="mt-4 grid gap-2 md:grid-cols-4">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">운영 모드</div>
+              <div className="mt-1 text-[13px] font-semibold text-slate-900">{runtimeModeLabel}</div>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">AI 접근</div>
+              <div className="mt-1 text-[13px] font-semibold text-slate-900">{authLabel}</div>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">STT</div>
+              <div className="mt-1 text-[13px] font-semibold text-slate-900">{sttLabel}</div>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">미디어 업로드</div>
+              <div className="mt-1 text-[13px] font-semibold text-slate-900">{uploadLabel}</div>
+            </div>
+          </div>
+        ) : null}
 
         <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
           {providerPlans.map((plan) => (
@@ -133,7 +159,7 @@ export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProp
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <div className="text-[13px] font-semibold text-slate-900">{plan.feature}</div>
-                  <div className="mt-1 text-[12px] text-slate-500">{plan.current_provider}가 현재 우선 제공자예요.</div>
+                  <div className="mt-1 text-[12px] text-slate-500">{plan.current_provider}가 현재 runtime policy 기준의 우선 제공자예요.</div>
                 </div>
                 <span className="rounded-full bg-indigo-100 px-2.5 py-1 text-[11px] font-semibold text-indigo-600">
                   {plan.steps[0]?.status ?? 'planned'}

--- a/packages/shared/src/ai/ai-provider.ts
+++ b/packages/shared/src/ai/ai-provider.ts
@@ -35,8 +35,25 @@ export type AIProviderPlan = {
   steps: AIProviderStep[];
 };
 
+export type AIRuntimePolicy = {
+  public_mode: 'dev' | 'free_test';
+  require_auth: boolean;
+  enable_stt: boolean;
+  enable_media_upload: boolean;
+  daily_limits: {
+    total?: number;
+    smart?: number;
+    summary?: number;
+    quiz?: number;
+    stt?: number;
+    answer?: number;
+    gemini?: number;
+  };
+};
+
 export type AIProviderCatalog = {
   generated_at: string;
+  runtime_policy?: AIRuntimePolicy;
   providers: AIProviderDescriptor[];
   plans: AIProviderPlan[];
 };
@@ -45,28 +62,28 @@ const PROVIDER_DESCRIPTORS: AIProviderDescriptor[] = [
   {
     name: 'demo',
     label: 'Demo Engine',
-    description: '현재 앱의 기본 동작을 보장하는 내장 데모 엔진입니다.',
+    description: '항상 동작하는 내장 안전망으로, 정책이나 네트워크가 막혀도 기본 동작을 보장합니다.',
     status: 'available',
     capabilities: ['intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations', 'stt', 'embedding'],
   },
   {
     name: 'ollama',
     label: 'Ollama',
-    description: '로컬 또는 자가 호스팅 환경에서 무료로 사용할 수 있는 모델 계층입니다.',
+    description: 'dev 로컬 개발 환경에서 사용하는 모델 계층입니다.',
     status: 'available',
     capabilities: ['intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations', 'embedding'],
   },
   {
     name: 'gemini',
     label: 'Gemini',
-    description: '무료 API 쿼터 기반으로 생성, 분류, 요약 보강에 활용할 수 있는 외부 모델 계층입니다.',
+    description: 'staging/production에서 텍스트 생성과 분류, 요약을 담당하는 외부 모델 계층입니다.',
     status: 'available',
     capabilities: ['intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations', 'stt'],
   },
   {
     name: 'cloudflare',
     label: 'Cloudflare AI',
-    description: 'Workers AI와 연계해 배포 환경에서 안정적으로 붙일 수 있는 인프라 계층입니다.',
+    description: '공개 테스트에서 STT 우선 경로로 쓰는 Workers AI 계층입니다.',
     status: 'planned',
     capabilities: ['stt', 'embedding', 'intent', 'search', 'answer', 'summary', 'quiz', 'smart', 'insights', 'recommendations'],
   },
@@ -88,16 +105,24 @@ const FEATURE_CHAIN: Record<AIProviderCapability, AIProviderName[]> = {
 function buildSteps(chain: AIProviderName[]): AIProviderStep[] {
   return chain.map((provider, index) => {
     const descriptor = PROVIDER_DESCRIPTORS.find((item) => item.name === provider);
+    const firstProvider = chain[0];
+    const reason =
+      index === 0
+        ? firstProvider === 'ollama'
+          ? 'dev 로컬 기본 경로'
+          : firstProvider === 'gemini'
+            ? 'staging/production 텍스트 기본 경로'
+            : firstProvider === 'cloudflare'
+              ? '공개 테스트 STT 우선 경로'
+              : '이 기능의 기본 경로'
+        : index === chain.length - 1
+          ? '최후의 안전망'
+          : '기본 경로가 실패할 때의 대체 경로';
 
     return {
       provider,
       status: descriptor?.status ?? 'planned',
-      reason:
-        index === 0
-          ? '이 기능의 기본 경로'
-          : index === chain.length - 1
-            ? '최후의 안전망'
-            : '기본 경로가 실패할 때의 대체 경로',
+      reason,
     };
   });
 }


### PR DESCRIPTION
# 변경 요약
관리자 자동화 화면에서 provider 설명을 현재 runtime policy 기준으로 갱신했습니다.

## 배경
dev / staging / production의 실제 provider 정책과 화면 문구가 어긋나지 않게 하려는 작업입니다.

## 변경 내용
- `packages/shared/src/ai/ai-provider.ts`의 provider 설명과 단계 이유를 runtime policy에 맞게 정리했습니다.
- `frontend/src/features/lms/pages/AdminAutomationPage.tsx`에 runtime policy 요약 카드를 추가하고 안내 문구를 갱신했습니다.
- `docs/dev-logs/2026-04-10-admin-automation-provider-runtime-policy.md`를 추가하고 `docs/dev-logs/README.md`를 갱신했습니다.

## 연결 이슈
- Closes #125

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다