### PR TITLE
refactor: make provider catalog runtime aware

### DIFF
--- a/docs/dev-logs/2026-04-10-provider-catalog-runtime-aware-fallback.md
+++ b/docs/dev-logs/2026-04-10-provider-catalog-runtime-aware-fallback.md
@@ -1,0 +1,8 @@
+# 2026-04-10 provider catalog runtime-aware fallback
+
+- issue #126는 provider catalog가 API 실패 시 정적 fallback으로 내려가서 실제 runtime policy와 설명이 어긋날 수 있다는 문제를 다룬다.
+- `packages/shared/src/ai/ai-provider.ts`에서 provider catalog와 plan 생성이 runtime policy를 받아 동적으로 조합되도록 바꿨다.
+- `frontend/src/lib/api-dashboard.ts`는 성공 응답을 캐시하고, 실패 시 마지막으로 확인한 runtime policy 기준으로 provider catalog를 다시 만들어 보여주도록 정리했다.
+
+## 검증
+- `npm run verify` 통과

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-10-provider-catalog-runtime-aware-fallback.md`
 - `2026-04-10-admin-automation-provider-runtime-policy.md`
 - `2026-04-10-quota-rate-limit-ui-notice.md`
 - `2026-04-10-free-tier-docs-secret-d1.md`

--- a/frontend/src/lib/api-dashboard.ts
+++ b/frontend/src/lib/api-dashboard.ts
@@ -16,6 +16,25 @@ import {
 } from '@myway/shared';
 import { getFallbackUserId, getStoredAuth, request } from './api-core';
 
+const AI_PROVIDER_CATALOG_STORAGE_KEY = 'mywayclass.ai.providers';
+
+function readCachedAIProviderCatalog(): AIProviderCatalog | null {
+  try {
+    const value = localStorage.getItem(AI_PROVIDER_CATALOG_STORAGE_KEY);
+    return value ? (JSON.parse(value) as AIProviderCatalog) : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeCachedAIProviderCatalog(catalog: AIProviderCatalog): void {
+  try {
+    localStorage.setItem(AI_PROVIDER_CATALOG_STORAGE_KEY, JSON.stringify(catalog));
+  } catch {
+    // Ignore storage failures and fall back to the in-memory response path.
+  }
+}
+
 export async function loadDashboard(sessionToken?: string | null): Promise<Dashboard | null> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
 
@@ -89,8 +108,17 @@ export async function loadAIProviders(sessionToken?: string | null): Promise<AIP
   }
 
   const response = await request<AIProviderCatalog>('/api/v1/ai/providers', undefined, token);
+  if (response?.success && response.data) {
+    storeCachedAIProviderCatalog(response.data);
+    return response.data;
+  }
 
-  return response?.success && response.data ? response.data : getAIProviderCatalog();
+  const cachedCatalog = readCachedAIProviderCatalog();
+  if (cachedCatalog) {
+    return getAIProviderCatalog(cachedCatalog.runtime_policy);
+  }
+
+  return getAIProviderCatalog();
 }
 
 export async function saveAISettings(

--- a/packages/shared/src/ai/ai-provider.ts
+++ b/packages/shared/src/ai/ai-provider.ts
@@ -89,7 +89,7 @@ const PROVIDER_DESCRIPTORS: AIProviderDescriptor[] = [
   },
 ];
 
-const FEATURE_CHAIN: Record<AIProviderCapability, AIProviderName[]> = {
+const STATIC_FEATURE_CHAIN: Record<AIProviderCapability, AIProviderName[]> = {
   intent: ['ollama', 'gemini', 'cloudflare', 'demo'],
   search: ['ollama', 'gemini', 'cloudflare', 'demo'],
   answer: ['ollama', 'gemini', 'cloudflare', 'demo'],
@@ -101,6 +101,26 @@ const FEATURE_CHAIN: Record<AIProviderCapability, AIProviderName[]> = {
   stt: ['cloudflare', 'gemini', 'demo'],
   embedding: ['cloudflare', 'ollama', 'demo'],
 };
+
+function buildRuntimeFeatureChain(feature: AIProviderCapability, runtimePolicy?: AIRuntimePolicy): AIProviderName[] {
+  if (!runtimePolicy) {
+    return STATIC_FEATURE_CHAIN[feature];
+  }
+
+  if (feature === 'search') {
+    return ['demo'];
+  }
+
+  if (feature === 'stt') {
+    return runtimePolicy.public_mode === 'dev' ? ['cloudflare', 'gemini', 'demo'] : ['cloudflare', 'gemini', 'demo'];
+  }
+
+  if (runtimePolicy.public_mode === 'dev') {
+    return ['ollama', 'gemini', 'demo'];
+  }
+
+  return ['gemini', 'demo'];
+}
 
 function buildSteps(chain: AIProviderName[]): AIProviderStep[] {
   return chain.map((provider, index) => {
@@ -127,21 +147,29 @@ function buildSteps(chain: AIProviderName[]): AIProviderStep[] {
   });
 }
 
-export function getAIProviderCatalog(): AIProviderCatalog {
-  return {
-    generated_at: new Date().toISOString(),
-    providers: PROVIDER_DESCRIPTORS,
-    plans: Object.entries(FEATURE_CHAIN).map(([feature, chain]) => ({
-      feature: feature as AIProviderCapability,
+export function getAIProviderCatalog(runtimePolicy?: AIRuntimePolicy): AIProviderCatalog {
+  const plans = Object.keys(STATIC_FEATURE_CHAIN).map((feature) => {
+    const featureKey = feature as AIProviderCapability;
+    const chain = buildRuntimeFeatureChain(featureKey, runtimePolicy);
+
+    return {
+      feature: featureKey,
       current_provider: chain[0],
       recommended_chain: chain,
       steps: buildSteps(chain),
-    })),
+    };
+  });
+
+  return {
+    generated_at: new Date().toISOString(),
+    runtime_policy: runtimePolicy,
+    providers: PROVIDER_DESCRIPTORS,
+    plans,
   };
 }
 
-export function getAIProviderPlan(feature: AIProviderCapability): AIProviderPlan {
-  const chain = FEATURE_CHAIN[feature];
+export function getAIProviderPlan(feature: AIProviderCapability, runtimePolicy?: AIRuntimePolicy): AIProviderPlan {
+  const chain = buildRuntimeFeatureChain(feature, runtimePolicy);
   return {
     feature,
     current_provider: chain[0],


### PR DESCRIPTION
# 변경 요약
provider catalog의 API 실패 fallback을 runtime policy 기준으로 정리했습니다.

## 배경
정적 fallback만 쓰면 dev / staging / production의 실제 provider 설명과 어긋날 수 있어서, 마지막에 확인한 runtime policy를 그대로 반영하도록 바꿨습니다.

## 변경 내용
- `packages/shared/src/ai/ai-provider.ts`에서 provider catalog와 plan 생성을 runtime policy 기반으로 구성하도록 바꿨습니다.
- `frontend/src/lib/api-dashboard.ts`에서 성공 응답을 캐시하고, 실패 시 cached runtime policy 기준으로 provider catalog를 다시 만들어 보여주도록 정리했습니다.
- `docs/dev-logs/2026-04-10-provider-catalog-runtime-aware-fallback.md`를 추가하고 `docs/dev-logs/README.md`를 갱신했습니다.

## 연결 이슈
- Closes #126

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다