### PR TITLE
chore: bind media d1 database

### DIFF
--- a/backend/src/lib/runtime-env.ts
+++ b/backend/src/lib/runtime-env.ts
@@ -29,13 +29,14 @@ export type R2BucketLike = {
   >;
 };
 
-type RuntimeStringKey = Exclude<keyof RuntimeBindings, 'AI' | 'ASSETS' | 'DB'>;
+type RuntimeStringKey = Exclude<keyof RuntimeBindings, 'AI' | 'ASSETS' | 'DB' | 'MEDIA_DB'>;
 
 export type RuntimeBindings = {
   APP_ENV?: 'development' | 'staging' | 'production';
   API_ORIGIN?: string;
   AI?: WorkersAI;
   DB?: D1Database;
+  MEDIA_DB?: D1Database;
   ASSETS?: R2BucketLike;
   MYWAY_AI_PUBLIC_MODE?: 'dev' | 'free_test';
   MYWAY_AI_REQUIRE_AUTH?: string;

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -7,6 +7,11 @@
       "binding": "DB",
       "database_name": "myway-class-quota",
       "database_id": "3ef1768f-347d-4e82-93ea-2c346f52630a"
+    },
+    {
+      "binding": "MEDIA_DB",
+      "database_name": "myway-class-data",
+      "database_id": "519993d1-b497-401d-a072-c7d777bc0ddb"
     }
   ],
   "r2_buckets": [

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -6,7 +6,7 @@
     {
       "binding": "DB",
       "database_name": "myway-class-quota",
-      "database_id": "REPLACE_WITH_D1_DATABASE_ID"
+      "database_id": "3ef1768f-347d-4e82-93ea-2c346f52630a"
     }
   ],
   "r2_buckets": [

--- a/docs/dev-logs/2026-04-11-d1-media-binding.md
+++ b/docs/dev-logs/2026-04-11-d1-media-binding.md
@@ -1,0 +1,9 @@
+# 2026-04-11 D1 media binding
+
+- Cloudflare D1 `myway-class-data`를 생성했다.
+- `backend/wrangler.jsonc`에 `MEDIA_DB` 바인딩을 추가했다.
+- `backend/src/lib/runtime-env.ts`에 `MEDIA_DB` 타입을 추가했다.
+- 아직 실제 transcript/note/extraction 저장소 레이어는 연결 전이다.
+
+## 검증
+- `wrangler d1 list`에서 `myway-class-data` 확인

--- a/docs/dev-logs/2026-04-11-d1-quota-binding.md
+++ b/docs/dev-logs/2026-04-11-d1-quota-binding.md
@@ -1,0 +1,8 @@
+# 2026-04-11 D1 quota binding
+
+- Cloudflare D1 `myway-class-quota`를 생성했다.
+- `backend/wrangler.jsonc`의 `DB` 바인딩에 실제 `database_id`를 연결했다.
+- 다음 단계로 migration을 적용해 quota 테이블을 생성한다.
+
+## 검증
+- D1 목록에서 `myway-class-quota` 확인

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-11-d1-media-binding.md`
 - `2026-04-11-d1-quota-binding.md`
 - `2026-04-10-lecture-draft-api-worktree-compare.md`
 - `2026-04-10-shortform-preview-modal-close-fix.md`

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-11-d1-quota-binding.md`
 - `2026-04-10-lecture-draft-api-worktree-compare.md`
 - `2026-04-10-shortform-preview-modal-close-fix.md`
 - `2026-04-10-lecture-studio-ui-ux.md`


### PR DESCRIPTION
# 변경 요약
`MEDIA_DB`를 추가해 강의 전사/요약/오디오 추출 메타데이터를 R2/RAM이 아닌 D1에 저장할 준비를 마쳤습니다.

## 배경
긴 영상 사전 처리와 공개 테스트 분리를 위해, transcript / note / extraction / pipeline 데이터를 영속 저장할 전용 DB가 필요했습니다.

## 변경 내용
- `backend/wrangler.jsonc`에 `MEDIA_DB` 바인딩 추가
- `backend/src/lib/runtime-env.ts`에 `MEDIA_DB` 타입 반영
- `docs/dev-logs/2026-04-11-d1-media-binding.md`에 변경 요약 기록
- 영상 파일은 R2, quota는 `DB`, 메타데이터는 `MEDIA_DB`로 분리

## 연결 이슈
- Closes #127
- Fixes #127

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다