### PR TITLE
feat: persist media pipeline data in D1

### DIFF
--- a/backend/migrations/0002_media_store.sql
+++ b/backend/migrations/0002_media_store.sql
@@ -1,0 +1,79 @@
+CREATE TABLE IF NOT EXISTS lecture_transcripts (
+  id TEXT PRIMARY KEY,
+  lecture_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  language TEXT NOT NULL,
+  full_text TEXT NOT NULL,
+  segments_json TEXT NOT NULL,
+  word_count INTEGER NOT NULL,
+  duration_ms INTEGER NOT NULL,
+  stt_provider TEXT NOT NULL,
+  stt_model TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_lecture_transcripts_lecture_id_created_at
+  ON lecture_transcripts(lecture_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS lecture_notes (
+  id TEXT PRIMARY KEY,
+  lecture_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  note_type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  key_concepts_json TEXT NOT NULL,
+  keywords_json TEXT NOT NULL,
+  timestamps_json TEXT,
+  language TEXT NOT NULL,
+  ai_model TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_lecture_notes_lecture_id_created_at
+  ON lecture_notes(lecture_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS audio_extractions (
+  id TEXT PRIMARY KEY,
+  lecture_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  source_type TEXT NOT NULL,
+  source_url TEXT NOT NULL,
+  source_video_key TEXT,
+  source_video_name TEXT,
+  source_content_type TEXT,
+  source_size_bytes INTEGER,
+  language TEXT,
+  requested_stt_provider TEXT,
+  requested_stt_model TEXT,
+  processing_job_id TEXT,
+  processing_error TEXT,
+  audio_url TEXT,
+  audio_format TEXT NOT NULL,
+  audio_duration_ms INTEGER NOT NULL,
+  sample_rate INTEGER NOT NULL,
+  channels INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  transcript_id TEXT,
+  stt_status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  processed_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_audio_extractions_lecture_id_created_at
+  ON audio_extractions(lecture_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audio_extractions_job
+  ON audio_extractions(processing_job_id);
+
+CREATE TABLE IF NOT EXISTS lecture_pipelines (
+  lecture_id TEXT PRIMARY KEY,
+  transcript_status TEXT NOT NULL,
+  summary_status TEXT NOT NULL,
+  audio_status TEXT NOT NULL,
+  transcript_id TEXT,
+  note_id TEXT,
+  extraction_id TEXT,
+  updated_at TEXT NOT NULL
+);

--- a/backend/src/lib/ai-adapter.ts
+++ b/backend/src/lib/ai-adapter.ts
@@ -16,6 +16,7 @@ import {
 import { type AIEngineExecution, runAIAnswerWithEngine, runAIIntentWithEngine, runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine';
 import { getAIProviderSelectionForRuntime } from './ai-provider';
 import type { RuntimeBindings } from './runtime-env';
+import type { MediaRepository } from '@myway/shared';
 
 export type AIAdapterResultMap = {
   intent: AIIntentResult;
@@ -43,41 +44,49 @@ export async function runAIIntent(
   input: AIIntentRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIIntentResult> {
   resolveProvider('intent', preferredProvider);
-  return runAIIntentWithEngine(input, preferredProvider, env);
+  return runAIIntentWithEngine(input, preferredProvider, env, repository);
 }
 
-export function runAISearch(input: AISearchRequest, preferredProvider?: AIProviderName): AISearchResult {
+export async function runAISearch(
+  input: AISearchRequest,
+  preferredProvider?: AIProviderName,
+  repository?: MediaRepository,
+): Promise<AISearchResult> {
   void resolveProvider('search', preferredProvider);
-  return searchAIContent(input);
+  return await searchAIContent(input, repository);
 }
 
 export async function runAIAnswer(
   input: AIAnswerRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIAnswerResult> {
   resolveProvider('answer', preferredProvider);
-  return runAIAnswerWithEngine(input, preferredProvider, env);
+  return runAIAnswerWithEngine(input, preferredProvider, env, repository);
 }
 
 export async function runAISummary(
   input: AISummaryRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIEngineExecution<AISummaryResult> | null> {
   resolveProvider('summary', preferredProvider);
-  return runAISummaryWithEngine(input, preferredProvider, env);
+  return runAISummaryWithEngine(input, preferredProvider, env, repository);
 }
 
 export async function runAIQuiz(
   input: AIQuizRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIEngineExecution<AIQuizResult> | null> {
   resolveProvider('quiz', preferredProvider);
-  return runAIQuizWithEngine(input, preferredProvider, env);
+  return runAIQuizWithEngine(input, preferredProvider, env, repository);
 }
 
 export async function runAIFeature<TFeature extends AIAdapterFeature>(
@@ -85,18 +94,19 @@ export async function runAIFeature<TFeature extends AIAdapterFeature>(
   input: AIAdapterInputMap[TFeature],
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIAdapterResultMap[TFeature]> {
   switch (feature) {
     case 'intent':
-      return (await runAIIntent(input as AIIntentRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
+      return (await runAIIntent(input as AIIntentRequest, preferredProvider, env, repository)) as AIAdapterResultMap[TFeature];
     case 'search':
-      return runAISearch(input as AISearchRequest, preferredProvider) as AIAdapterResultMap[TFeature];
+      return (await runAISearch(input as AISearchRequest, preferredProvider, repository)) as AIAdapterResultMap[TFeature];
     case 'answer':
-      return (await runAIAnswer(input as AIAnswerRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
+      return (await runAIAnswer(input as AIAnswerRequest, preferredProvider, env, repository)) as AIAdapterResultMap[TFeature];
     case 'summary':
-      return (await runAISummary(input as AISummaryRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
+      return (await runAISummary(input as AISummaryRequest, preferredProvider, env, repository)) as AIAdapterResultMap[TFeature];
     case 'quiz':
-      return (await runAIQuiz(input as AIQuizRequest, preferredProvider, env)) as AIAdapterResultMap[TFeature];
+      return (await runAIQuiz(input as AIQuizRequest, preferredProvider, env, repository)) as AIAdapterResultMap[TFeature];
     default:
       throw new Error(`Unsupported AI feature: ${String(feature)}`);
   }

--- a/backend/src/lib/ai-engine-runners.ts
+++ b/backend/src/lib/ai-engine-runners.ts
@@ -8,6 +8,7 @@ import type {
   AISummaryRequest,
   AISummaryResult,
   AIProviderName,
+  MediaRepository,
 } from '@myway/shared';
 import { getAIProviderSelectionForRuntime } from './ai-provider';
 import { runGeminiJsonPrompt, runOllamaChat } from './providers';
@@ -81,6 +82,7 @@ async function runOllamaStructuredIntent(
   input: AIIntentRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIEngineExecution<AIIntentResult>> {
   const fallback = getIntentFallback(input);
 
@@ -148,8 +150,9 @@ async function runOllamaStructuredAnswer(
   input: AIAnswerRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIEngineExecution<AIAnswerResult>> {
-  const fallback = getAnswerFallback(input);
+  const fallback = await getAnswerFallback(input, repository);
 
   const providerPlan = getAIProviderSelectionForRuntime('answer', env, preferredProvider);
   if (providerPlan.current_provider === 'demo') {
@@ -220,45 +223,50 @@ export async function runAIIntentWithExecution(
   input: AIIntentRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIEngineExecution<AIIntentResult>> {
-  return runOllamaStructuredIntent(input, preferredProvider, env);
+  return runOllamaStructuredIntent(input, preferredProvider, env, repository);
 }
 
 export async function runAIIntentWithEngine(
   input: AIIntentRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIIntentResult> {
-  return (await runAIIntentWithExecution(input, preferredProvider, env)).result;
+  return (await runAIIntentWithExecution(input, preferredProvider, env, repository)).result;
 }
 
 export async function runAIAnswerWithExecution(
   input: AIAnswerRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIEngineExecution<AIAnswerResult>> {
-  return runOllamaStructuredAnswer(input, preferredProvider, env);
+  return runOllamaStructuredAnswer(input, preferredProvider, env, repository);
 }
 
 export async function runAIAnswerWithEngine(
   input: AIAnswerRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIAnswerResult> {
-  return (await runAIAnswerWithExecution(input, preferredProvider, env)).result;
+  return (await runAIAnswerWithExecution(input, preferredProvider, env, repository)).result;
 }
 
 export async function runAISummaryWithEngine(
   input: AISummaryRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIEngineExecution<AISummaryResult> | null> {
-  const fallback = getSummaryFallback(input);
+  const fallback = await getSummaryFallback(input, repository);
   if (!fallback) {
     return null;
   }
 
-  const source = getLectureSourceText(input.lecture_id);
+  const source = await getLectureSourceText(input.lecture_id, repository);
   if (!source || !isRemoteFeatureEnabled('summary', env, preferredProvider) || input.style === 'timeline') {
     return {
       result: fallback,
@@ -342,13 +350,14 @@ export async function runAIQuizWithEngine(
   input: AIQuizRequest,
   preferredProvider?: AIProviderName,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<AIEngineExecution<AIQuizResult> | null> {
-  const fallback = getQuizFallback(input);
+  const fallback = await getQuizFallback(input, repository);
   if (!fallback) {
     return null;
   }
 
-  const source = getLectureSourceText(input.lecture_id);
+  const source = await getLectureSourceText(input.lecture_id, repository);
   if (!source || !isRemoteFeatureEnabled('quiz', env, preferredProvider)) {
     return {
       result: fallback,

--- a/backend/src/lib/ai-engine-utils.ts
+++ b/backend/src/lib/ai-engine-utils.ts
@@ -6,6 +6,7 @@ import {
   getLectureDetail,
   getLectureTranscript,
   listLectureNotes,
+  type MediaRepository,
   type AIAction,
   type AIIntent,
   type AIIntentRequest,
@@ -162,14 +163,17 @@ export function normalizeQuizQuestion(
   };
 }
 
-export function getLectureSourceText(lectureId: string): { lectureTitle: string; courseTitle: string; sourceText: string } | null {
+export async function getLectureSourceText(
+  lectureId: string,
+  repository?: MediaRepository,
+): Promise<{ lectureTitle: string; courseTitle: string; sourceText: string } | null> {
   const lecture = getLectureDetail(lectureId);
   if (!lecture) {
     return null;
   }
 
-  const transcript = getLectureTranscript(lecture.id);
-  const note = listLectureNotes(lecture.id)[0];
+  const transcript = await getLectureTranscript(lecture.id, repository);
+  const note = (await listLectureNotes(lecture.id, repository))[0];
   const sourceText = normalizeText(note?.content ?? transcript?.full_text ?? lecture.content_text);
 
   return {
@@ -196,14 +200,23 @@ export function getIntentFallback(input: AIIntentRequest): AIIntentResult {
   return classifyAIIntent(input);
 }
 
-export function getAnswerFallback(input: AIAnswerRequest): AIAnswerResult {
-  return answerAIQuestion(input);
+export async function getAnswerFallback(
+  input: AIAnswerRequest,
+  repository?: MediaRepository,
+): Promise<AIAnswerResult> {
+  return await answerAIQuestion(input, repository);
 }
 
-export function getSummaryFallback(input: AISummaryRequest): AISummaryResult | null {
-  return createAISummary(input);
+export async function getSummaryFallback(
+  input: AISummaryRequest,
+  repository?: MediaRepository,
+): Promise<AISummaryResult | null> {
+  return await createAISummary(input, repository);
 }
 
-export function getQuizFallback(input: AIQuizRequest): AIQuizResult | null {
-  return generateAIQuiz(input);
+export async function getQuizFallback(
+  input: AIQuizRequest,
+  repository?: MediaRepository,
+): Promise<AIQuizResult | null> {
+  return await generateAIQuiz(input, repository);
 }

--- a/backend/src/lib/media-pipeline.ts
+++ b/backend/src/lib/media-pipeline.ts
@@ -6,6 +6,7 @@ import {
   type AudioExtractionCallbackRequest,
   type AudioExtractionRequest,
   type LecturePipeline,
+  type MediaRepository,
 } from '@myway/shared';
 import { dispatchMediaProcessorJob } from './media-processor';
 import { runTranscriptGeneration, type STTAdapterResult } from './stt-adapter';
@@ -48,6 +49,7 @@ export async function createMediaExtractionJob(
   input: AudioExtractionRequest,
   requestUrl: string,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<MediaExtractionRequestResult> {
   let transcriptResult: STTAdapterResult | null = null;
 
@@ -63,6 +65,7 @@ export async function createMediaExtractionJob(
       },
       'cloudflare',
       env,
+      repository,
     );
 
     if (!transcriptResult.ok) {
@@ -74,7 +77,7 @@ export async function createMediaExtractionJob(
     }
   }
 
-  const extractionResult = createAudioExtraction(userId, {
+  const extractionResult = await createAudioExtraction(userId, {
     lecture_id: input.lecture_id,
     video_url: input.video_url?.trim(),
     video_asset_key: input.video_asset_key?.trim(),
@@ -85,7 +88,7 @@ export async function createMediaExtractionJob(
     language: input.language ?? 'ko',
     stt_provider: input.stt_provider?.trim(),
     stt_model: input.stt_model?.trim(),
-  });
+  }, repository);
 
   if (!extractionResult) {
     return {
@@ -114,12 +117,12 @@ export async function createMediaExtractionJob(
   );
 
   if (!dispatchResult.ok) {
-    updateAudioExtraction({
+    await updateAudioExtraction({
       extraction_id: extractionResult.extraction.id,
       lecture_id: extractionResult.extraction.lecture_id,
       status: 'FAILED',
       error_message: dispatchResult.message,
-    });
+    }, repository);
 
     return {
       ok: false,
@@ -128,12 +131,12 @@ export async function createMediaExtractionJob(
     };
   }
 
-  const updated = updateAudioExtraction({
+  const updated = await updateAudioExtraction({
     extraction_id: extractionResult.extraction.id,
     lecture_id: extractionResult.extraction.lecture_id,
     status: dispatchResult.status,
     processing_job_id: dispatchResult.job_id ?? undefined,
-  });
+  }, repository);
 
   return {
     ok: true,
@@ -148,8 +151,9 @@ export async function completeMediaExtractionJob(
   userId: string,
   payload: AudioExtractionCallbackRequest,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<MediaExtractionCallbackResult> {
-  const extraction = getAudioExtraction(payload.extraction_id);
+  const extraction = await getAudioExtraction(payload.extraction_id, repository);
   if (!extraction || extraction.lecture_id !== payload.lecture_id) {
     return {
       ok: false,
@@ -159,7 +163,7 @@ export async function completeMediaExtractionJob(
   }
 
   if (payload.status === 'FAILED') {
-    const failed = updateAudioExtraction(payload);
+    const failed = await updateAudioExtraction(payload, repository);
     if (!failed) {
       return {
         ok: false,
@@ -195,14 +199,15 @@ export async function completeMediaExtractionJob(
     },
     'cloudflare',
     env,
+    repository,
   );
 
   if (!transcriptResult.ok) {
-    const failed = updateAudioExtraction({
+    const failed = await updateAudioExtraction({
       ...payload,
       status: 'FAILED',
       error_message: '오디오 전사를 생성할 수 없습니다.',
-    });
+    }, repository);
 
     return {
       ok: false,
@@ -211,12 +216,12 @@ export async function completeMediaExtractionJob(
     };
   }
 
-  const completed = updateAudioExtraction({
+  const completed = await updateAudioExtraction({
     ...payload,
     status: 'COMPLETED',
     transcript_id: transcriptResult.transcript_id,
     stt_status: 'COMPLETED',
-  });
+  }, repository);
 
   if (!completed) {
     return {

--- a/backend/src/lib/media-repository.ts
+++ b/backend/src/lib/media-repository.ts
@@ -1,0 +1,568 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import {
+  type AudioExtraction,
+  type AudioExtractionCallbackRequest,
+  type AudioExtractionRequest,
+  type LectureNote,
+  type LecturePipeline,
+  type LectureTranscript,
+  type MediaSummaryRequest,
+  type TranscriptCreateRequest,
+  type MediaRepository,
+} from '@myway/shared';
+import {
+  extractKeyConcepts,
+  extractKeywords,
+  findLecture,
+  normalizeText,
+  splitIntoSegments,
+  summarizeByStyle,
+  buildTimelineMarkers,
+  now,
+} from '@myway/shared/lms/media/helpers';
+
+type TranscriptRow = {
+  id: string;
+  lecture_id: string;
+  user_id: string;
+  language: string;
+  full_text: string;
+  segments_json: string;
+  word_count: number;
+  duration_ms: number;
+  stt_provider: string;
+  stt_model: string;
+  created_at: string;
+};
+
+type NoteRow = {
+  id: string;
+  lecture_id: string;
+  user_id: string;
+  note_type: LectureNote['note_type'];
+  title: string;
+  content: string;
+  key_concepts_json: string;
+  keywords_json: string;
+  timestamps_json: string | null;
+  language: string;
+  ai_model: string;
+  created_at: string;
+};
+
+type ExtractionRow = {
+  id: string;
+  lecture_id: string;
+  user_id: string;
+  source_type: AudioExtraction['source_type'];
+  source_url: string;
+  source_video_key: string | null;
+  source_video_name: string | null;
+  source_content_type: string | null;
+  source_size_bytes: number | null;
+  language: string | null;
+  requested_stt_provider: string | null;
+  requested_stt_model: string | null;
+  processing_job_id: string | null;
+  processing_error: string | null;
+  audio_url: string | null;
+  audio_format: string;
+  audio_duration_ms: number;
+  sample_rate: number;
+  channels: number;
+  status: AudioExtraction['status'];
+  transcript_id: string | null;
+  stt_status: AudioExtraction['stt_status'];
+  created_at: string;
+  processed_at: string | null;
+  updated_at: string;
+};
+
+type PipelineRow = {
+  lecture_id: string;
+  transcript_status: LecturePipeline['transcript_status'];
+  summary_status: LecturePipeline['summary_status'];
+  audio_status: LecturePipeline['audio_status'];
+  transcript_id: string | null;
+  note_id: string | null;
+  extraction_id: string | null;
+  updated_at: string;
+};
+
+function createId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().replaceAll('-', '').slice(0, 12)}`;
+}
+
+function parseJsonArray<T>(value: string | null | undefined, fallback: T[] = []): T[] {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? (parsed as T[]) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function mapTranscriptRow(row: TranscriptRow): LectureTranscript {
+  return {
+    id: row.id,
+    lecture_id: row.lecture_id,
+    user_id: row.user_id,
+    language: row.language,
+    full_text: row.full_text,
+    segments: parseJsonArray(row.segments_json),
+    word_count: row.word_count,
+    duration_ms: row.duration_ms,
+    stt_provider: row.stt_provider,
+    stt_model: row.stt_model,
+    created_at: row.created_at,
+  };
+}
+
+function mapNoteRow(row: NoteRow): LectureNote {
+  return {
+    id: row.id,
+    lecture_id: row.lecture_id,
+    user_id: row.user_id,
+    note_type: row.note_type,
+    title: row.title,
+    content: row.content,
+    key_concepts: parseJsonArray(row.key_concepts_json),
+    keywords: parseJsonArray(row.keywords_json),
+    timestamps: row.timestamps_json ? parseJsonArray(row.timestamps_json) : null,
+    language: row.language,
+    ai_model: row.ai_model,
+    created_at: row.created_at,
+  };
+}
+
+function mapExtractionRow(row: ExtractionRow): AudioExtraction {
+  return {
+    id: row.id,
+    lecture_id: row.lecture_id,
+    user_id: row.user_id,
+    source_type: row.source_type,
+    source_url: row.source_url,
+    source_video_key: row.source_video_key ?? undefined,
+    source_video_name: row.source_video_name ?? undefined,
+    source_content_type: row.source_content_type ?? undefined,
+    source_size_bytes: row.source_size_bytes ?? undefined,
+    language: row.language ?? undefined,
+    requested_stt_provider: row.requested_stt_provider ?? undefined,
+    requested_stt_model: row.requested_stt_model ?? undefined,
+    processing_job_id: row.processing_job_id,
+    processing_error: row.processing_error,
+    audio_url: row.audio_url,
+    audio_format: row.audio_format,
+    audio_duration_ms: row.audio_duration_ms,
+    sample_rate: row.sample_rate,
+    channels: row.channels,
+    status: row.status,
+    transcript_id: row.transcript_id,
+    stt_status: row.stt_status,
+    created_at: row.created_at,
+    processed_at: row.processed_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function mapPipelineRow(row: PipelineRow): LecturePipeline {
+  return {
+    lecture_id: row.lecture_id,
+    transcript_status: row.transcript_status,
+    summary_status: row.summary_status,
+    audio_status: row.audio_status,
+    transcript_id: row.transcript_id,
+    note_id: row.note_id,
+    extraction_id: row.extraction_id,
+    updated_at: row.updated_at,
+  };
+}
+
+function inferAudioFormat(source: string | undefined): string {
+  if (!source) {
+    return 'pending';
+  }
+
+  const normalized = source.split('?')[0]?.split('#')[0] ?? '';
+  const extension = normalized.includes('.') ? normalized.split('.').pop()?.toLowerCase() : '';
+  if (!extension) {
+    return 'wav';
+  }
+
+  if (['mp3', 'wav', 'm4a', 'aac', 'ogg', 'flac', 'webm'].includes(extension)) {
+    return extension;
+  }
+
+  return 'wav';
+}
+
+export function createMediaRepository(db: D1Database): MediaRepository {
+  const repository: MediaRepository = {
+    async getLectureTranscript(lectureId: string): Promise<LectureTranscript | undefined> {
+      const row = await db
+        .prepare('SELECT * FROM lecture_transcripts WHERE lecture_id = ? ORDER BY created_at DESC LIMIT 1')
+        .bind(lectureId)
+        .first<TranscriptRow>();
+      return row ? mapTranscriptRow(row) : undefined;
+    },
+    async listLectureTranscripts(lectureId: string): Promise<LectureTranscript[]> {
+      const rows = await db
+        .prepare('SELECT * FROM lecture_transcripts WHERE lecture_id = ? ORDER BY created_at DESC')
+        .bind(lectureId)
+        .all<TranscriptRow>();
+      return rows.results.map(mapTranscriptRow);
+    },
+    async createLectureTranscript(
+      userId: string,
+      input: TranscriptCreateRequest,
+    ): Promise<{ transcript: LectureTranscript; pipeline: LecturePipeline } | null> {
+      const lecture = findLecture(input.lecture_id);
+      if (!lecture) {
+        return null;
+      }
+
+      const fullText = normalizeText(input.text || lecture.content_text || '');
+      if (!fullText) {
+        return null;
+      }
+
+      const fallbackDurationMs = Math.max(lecture.duration_minutes * 60_000, fullText.length * 40, 180_000);
+      const segments = input.segments?.length
+        ? input.segments.map((segment, index) => ({
+            index,
+            start_ms: Math.max(0, Math.round(segment.start_ms)),
+            end_ms: Math.max(Math.round(segment.start_ms), Math.round(segment.end_ms)),
+            text: normalizeText(segment.text),
+          }))
+        : splitIntoSegments(fullText, input.duration_ms ?? fallbackDurationMs);
+      const durationMs =
+        input.duration_ms ??
+        (segments.length > 0 ? segments[segments.length - 1]?.end_ms ?? fallbackDurationMs : fallbackDurationMs);
+      const wordCount = input.word_count ?? fullText.split(/\s+/).filter(Boolean).length;
+      const transcript: LectureTranscript = {
+        id: createId('trs'),
+        lecture_id: lecture.id,
+        user_id: userId,
+        language: input.language ?? 'ko',
+        full_text: fullText,
+        segments,
+        word_count: wordCount,
+        duration_ms: durationMs,
+        stt_provider: input.stt_provider ?? (input.text ? 'text-derived-stt' : 'demo-stt'),
+        stt_model: input.stt_model ?? 'pseudo-stt-v1',
+        created_at: now(),
+      };
+
+      await db.prepare(
+        'INSERT INTO lecture_transcripts (id, lecture_id, user_id, language, full_text, segments_json, word_count, duration_ms, stt_provider, stt_model, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+        .bind(
+          transcript.id,
+          transcript.lecture_id,
+          transcript.user_id,
+          transcript.language,
+          transcript.full_text,
+          JSON.stringify(transcript.segments),
+          transcript.word_count,
+          transcript.duration_ms,
+          transcript.stt_provider,
+          transcript.stt_model,
+          transcript.created_at,
+        )
+        .run();
+
+      const pipeline = await repository.upsertPipeline({
+        lecture_id: lecture.id,
+        transcript_status: 'COMPLETED',
+        transcript_id: transcript.id,
+      });
+
+      return { transcript, pipeline };
+    },
+    async listLectureNotes(lectureId: string): Promise<LectureNote[]> {
+      const rows = await db
+        .prepare('SELECT * FROM lecture_notes WHERE lecture_id = ? ORDER BY created_at DESC')
+        .bind(lectureId)
+        .all<NoteRow>();
+      return rows.results.map(mapNoteRow);
+    },
+    async createLectureSummaryNote(
+      userId: string,
+      input: MediaSummaryRequest,
+    ): Promise<{ note: LectureNote; pipeline: LecturePipeline; keyConcepts: string[]; keywords: string[] } | null> {
+      const lecture = findLecture(input.lecture_id);
+      if (!lecture) {
+        return null;
+      }
+
+      const transcript = await repository.getLectureTranscript(lecture.id);
+      const sourceText = transcript?.full_text ?? lecture.content_text;
+      const style = input.style ?? 'brief';
+      const keyConcepts = extractKeyConcepts(sourceText, style === 'detailed' ? 5 : 3);
+      const keywords = extractKeywords(sourceText, 5);
+      const summaryContent = summarizeByStyle(sourceText, style);
+      const timestamps =
+        style === 'timeline'
+          ? buildTimelineMarkers(transcript?.segments ?? splitIntoSegments(sourceText, Math.max(lecture.duration_minutes * 60_000, 180_000)))
+          : null;
+
+      let noteType: LectureNote['note_type'] = 'ai_summary';
+      let titleSuffix = '핵심 요약';
+      if (style === 'detailed') {
+        noteType = 'ai_detailed';
+        titleSuffix = '상세 요약';
+      } else if (style === 'timeline') {
+        noteType = 'ai_timeline';
+        titleSuffix = '타임라인 요약';
+      }
+
+      const note: LectureNote = {
+        id: createId('note'),
+        lecture_id: lecture.id,
+        user_id: userId,
+        note_type: noteType,
+        title: `${lecture.title} - ${titleSuffix}`,
+        content: summaryContent,
+        key_concepts: keyConcepts,
+        keywords,
+        timestamps,
+        language: input.language ?? 'ko',
+        ai_model: 'demo-summary-v1',
+        created_at: now(),
+      };
+
+      await db.prepare(
+        'INSERT INTO lecture_notes (id, lecture_id, user_id, note_type, title, content, key_concepts_json, keywords_json, timestamps_json, language, ai_model, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+        .bind(
+          note.id,
+          note.lecture_id,
+          note.user_id,
+          note.note_type,
+          note.title,
+          note.content,
+          JSON.stringify(note.key_concepts),
+          JSON.stringify(note.keywords),
+          note.timestamps ? JSON.stringify(note.timestamps) : null,
+          note.language,
+          note.ai_model,
+          note.created_at,
+        )
+        .run();
+
+      const pipeline = await repository.upsertPipeline({
+        lecture_id: lecture.id,
+        summary_status: 'COMPLETED',
+        note_id: note.id,
+      });
+
+      return { note, pipeline, keyConcepts, keywords };
+    },
+    async listAudioExtractions(lectureId: string): Promise<AudioExtraction[]> {
+      const rows = await db
+        .prepare('SELECT * FROM audio_extractions WHERE lecture_id = ? ORDER BY created_at DESC')
+        .bind(lectureId)
+        .all<ExtractionRow>();
+      return rows.results.map(mapExtractionRow);
+    },
+    async getAudioExtraction(extractionId: string): Promise<AudioExtraction | undefined> {
+      const row = await db.prepare('SELECT * FROM audio_extractions WHERE id = ? LIMIT 1').bind(extractionId).first<ExtractionRow>();
+      return row ? mapExtractionRow(row) : undefined;
+    },
+    async createAudioExtraction(
+      userId: string,
+      input: AudioExtractionRequest,
+    ): Promise<{ extraction: AudioExtraction; pipeline: LecturePipeline } | null> {
+      const lecture = findLecture(input.lecture_id);
+      if (!lecture) {
+        return null;
+      }
+
+      const existingTranscript = await repository.getLectureTranscript(lecture.id);
+      const extraction: AudioExtraction = {
+        id: createId('aud'),
+        lecture_id: lecture.id,
+        user_id: userId,
+        source_type: 'video',
+        source_url: input.video_url ?? '/static/media/demo-lecture.mp4',
+        source_video_key: input.video_asset_key,
+        source_video_name: input.source_file_name,
+        source_content_type: input.source_content_type,
+        source_size_bytes: input.source_size_bytes,
+        language: input.language ?? 'ko',
+        requested_stt_provider: input.stt_provider,
+        requested_stt_model: input.stt_model,
+        processing_job_id: null,
+        processing_error: null,
+        audio_url: input.audio_url ?? null,
+        audio_format: input.audio_url ? inferAudioFormat(input.audio_url) : 'pending',
+        audio_duration_ms: Math.max(lecture.duration_minutes * 60_000, 30_000),
+        sample_rate: 16_000,
+        channels: 1,
+        status: input.audio_url ? 'COMPLETED' : 'PROCESSING',
+        transcript_id: existingTranscript?.id ?? null,
+        stt_status: existingTranscript ? 'COMPLETED' : input.audio_url ? 'PROCESSING' : 'PENDING',
+        created_at: now(),
+        processed_at: input.audio_url ? now() : null,
+        updated_at: now(),
+      };
+
+      await db.prepare(
+        'INSERT INTO audio_extractions (id, lecture_id, user_id, source_type, source_url, source_video_key, source_video_name, source_content_type, source_size_bytes, language, requested_stt_provider, requested_stt_model, processing_job_id, processing_error, audio_url, audio_format, audio_duration_ms, sample_rate, channels, status, transcript_id, stt_status, created_at, processed_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+        .bind(
+          extraction.id,
+          extraction.lecture_id,
+          extraction.user_id,
+          extraction.source_type,
+          extraction.source_url,
+          extraction.source_video_key ?? null,
+          extraction.source_video_name ?? null,
+          extraction.source_content_type ?? null,
+          extraction.source_size_bytes ?? null,
+          extraction.language ?? null,
+          extraction.requested_stt_provider ?? null,
+          extraction.requested_stt_model ?? null,
+          extraction.processing_job_id ?? null,
+          extraction.processing_error ?? null,
+          extraction.audio_url ?? null,
+          extraction.audio_format,
+          extraction.audio_duration_ms,
+          extraction.sample_rate,
+          extraction.channels,
+          extraction.status,
+          extraction.transcript_id ?? null,
+          extraction.stt_status,
+          extraction.created_at,
+          extraction.processed_at ?? null,
+          extraction.updated_at,
+        )
+        .run();
+
+      const pipeline = await repository.upsertPipeline({
+        lecture_id: lecture.id,
+        audio_status: extraction.status,
+        extraction_id: extraction.id,
+      });
+
+      return { extraction, pipeline };
+    },
+    async updateAudioExtraction(
+      input: AudioExtractionCallbackRequest & {
+        transcript_id?: string | null;
+        stt_status?: AudioExtraction['stt_status'];
+      },
+    ): Promise<{ extraction: AudioExtraction; pipeline: LecturePipeline } | null> {
+      const current = await repository.getAudioExtraction(input.extraction_id);
+      if (!current || current.lecture_id !== input.lecture_id) {
+        return null;
+      }
+
+      const nextStatus = input.status;
+      const next: AudioExtraction = {
+        ...current,
+        processing_job_id: input.processing_job_id ?? current.processing_job_id ?? null,
+        processing_error: input.error_message ?? (nextStatus === 'FAILED' ? '오디오 추출에 실패했습니다.' : null),
+        audio_url: input.audio_url ?? current.audio_url ?? null,
+        audio_format: input.audio_format ?? (input.audio_url ? inferAudioFormat(input.audio_url) : current.audio_format),
+        audio_duration_ms: input.audio_duration_ms ?? current.audio_duration_ms,
+        sample_rate: input.sample_rate ?? current.sample_rate,
+        channels: input.channels ?? current.channels,
+        status: nextStatus,
+        transcript_id: input.transcript_id ?? current.transcript_id,
+        stt_status:
+          input.stt_status ??
+          (nextStatus === 'FAILED'
+            ? 'FAILED'
+            : input.transcript_id
+              ? 'COMPLETED'
+              : current.stt_status),
+        processed_at: nextStatus === 'COMPLETED' ? now() : current.processed_at ?? null,
+        updated_at: now(),
+      };
+
+      await db.prepare(
+        'UPDATE audio_extractions SET processing_job_id = ?, processing_error = ?, audio_url = ?, audio_format = ?, audio_duration_ms = ?, sample_rate = ?, channels = ?, status = ?, transcript_id = ?, stt_status = ?, processed_at = ?, updated_at = ? WHERE id = ?',
+      )
+        .bind(
+          next.processing_job_id ?? null,
+          next.processing_error ?? null,
+          next.audio_url ?? null,
+          next.audio_format,
+          next.audio_duration_ms,
+          next.sample_rate,
+          next.channels,
+          next.status,
+          next.transcript_id ?? null,
+          next.stt_status,
+          next.processed_at ?? null,
+          next.updated_at,
+          next.id,
+        )
+        .run();
+
+      const pipeline = await repository.upsertPipeline({
+        lecture_id: next.lecture_id,
+        audio_status: next.status,
+        extraction_id: next.id,
+        transcript_status: next.transcript_id ? 'COMPLETED' : next.stt_status,
+        transcript_id: next.transcript_id,
+      });
+
+      return { extraction: next, pipeline };
+    },
+    async getLecturePipeline(lectureId: string): Promise<LecturePipeline> {
+      const row = await db.prepare('SELECT * FROM lecture_pipelines WHERE lecture_id = ? LIMIT 1').bind(lectureId).first<PipelineRow>();
+      if (row) {
+        return mapPipelineRow(row);
+      }
+
+      const transcript = await repository.getLectureTranscript(lectureId);
+      const notes = await repository.listLectureNotes(lectureId);
+      const extractions = await repository.listAudioExtractions(lectureId);
+      const latestExtraction = extractions[0];
+
+      return {
+        lecture_id: lectureId,
+        transcript_status: transcript ? 'COMPLETED' : 'PENDING',
+        summary_status: notes.length > 0 ? 'COMPLETED' : 'PENDING',
+        audio_status: latestExtraction?.status ?? 'PENDING',
+        transcript_id: transcript?.id ?? null,
+        note_id: notes[0]?.id ?? null,
+        extraction_id: latestExtraction?.id ?? null,
+        updated_at: now(),
+      };
+    },
+    async upsertPipeline(partial: Partial<LecturePipeline> & { lecture_id: string }): Promise<LecturePipeline> {
+      const current = await repository.getLecturePipeline(partial.lecture_id);
+      const next: LecturePipeline = {
+        ...current,
+        ...partial,
+        updated_at: now(),
+      };
+
+      await db.prepare(
+        'INSERT INTO lecture_pipelines (lecture_id, transcript_status, summary_status, audio_status, transcript_id, note_id, extraction_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(lecture_id) DO UPDATE SET transcript_status = excluded.transcript_status, summary_status = excluded.summary_status, audio_status = excluded.audio_status, transcript_id = excluded.transcript_id, note_id = excluded.note_id, extraction_id = excluded.extraction_id, updated_at = excluded.updated_at',
+      )
+        .bind(
+          next.lecture_id,
+          next.transcript_status,
+          next.summary_status,
+          next.audio_status,
+          next.transcript_id ?? null,
+          next.note_id ?? null,
+          next.extraction_id ?? null,
+          next.updated_at,
+        )
+        .run();
+
+      return next;
+    },
+  };
+
+  return repository;
+}

--- a/backend/src/lib/runtime-env.ts
+++ b/backend/src/lib/runtime-env.ts
@@ -29,13 +29,14 @@ export type R2BucketLike = {
   >;
 };
 
-type RuntimeStringKey = Exclude<keyof RuntimeBindings, 'AI' | 'ASSETS' | 'DB'>;
+type RuntimeStringKey = Exclude<keyof RuntimeBindings, 'AI' | 'ASSETS' | 'DB' | 'MEDIA_DB'>;
 
 export type RuntimeBindings = {
   APP_ENV?: 'development' | 'staging' | 'production';
   API_ORIGIN?: string;
   AI?: WorkersAI;
   DB?: D1Database;
+  MEDIA_DB?: D1Database;
   ASSETS?: R2BucketLike;
   MYWAY_AI_PUBLIC_MODE?: 'dev' | 'free_test';
   MYWAY_AI_REQUIRE_AUTH?: string;

--- a/backend/src/lib/smart-chat.ts
+++ b/backend/src/lib/smart-chat.ts
@@ -4,6 +4,7 @@ import {
   type SmartChatRequest,
   type SmartChatResult,
   type SmartChatRoute,
+  type MediaRepository,
 } from '@myway/shared';
 import { runAIAnswerWithExecution, runAIIntentWithExecution, runAIQuizWithEngine, runAISummaryWithEngine } from './ai-engine-runners';
 import type { RuntimeBindings } from './runtime-env';
@@ -42,6 +43,7 @@ function buildQuizSuggestions(): string[] {
 export async function runSmartChat(
   input: SmartChatRequest,
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<SmartChatResult> {
   const message = input.message.trim();
   const lectureId = input.lecture_id?.trim() ?? null;
@@ -64,7 +66,7 @@ export async function runSmartChat(
   );
 
   const route = normalizeRoute(intentExecution.result.intent);
-  const baseFallback = buildSmartChatOverview(normalizedInput);
+  const baseFallback = await buildSmartChatOverview(normalizedInput);
   const sharedResult = attachMetadata(
     {
       ...baseFallback,
@@ -89,6 +91,7 @@ export async function runSmartChat(
       },
       undefined,
       env,
+      repository,
     );
 
     if (summaryExecution) {
@@ -121,6 +124,7 @@ export async function runSmartChat(
       },
       undefined,
       env,
+      repository,
     );
 
     if (quizExecution) {
@@ -153,6 +157,7 @@ export async function runSmartChat(
       },
       undefined,
       env,
+      repository,
     );
 
     return attachMetadata(

--- a/backend/src/lib/stt-adapter.ts
+++ b/backend/src/lib/stt-adapter.ts
@@ -1,4 +1,4 @@
-import { createLectureTranscript, type TranscriptCreateRequest, type LecturePipeline } from '@myway/shared';
+import { createLectureTranscript, type TranscriptCreateRequest, type LecturePipeline, type MediaRepository } from '@myway/shared';
 import { getSTTProviderSelection } from './stt-provider';
 import { runCloudflareTranscription } from './providers';
 import type { RuntimeBindings } from './runtime-env';
@@ -27,6 +27,7 @@ export async function runTranscriptGeneration(
   input: TranscriptCreateRequest,
   preferredProvider?: 'demo' | 'cloudflare' | 'gemini',
   env?: RuntimeBindings,
+  repository?: MediaRepository,
 ): Promise<STTAdapterResult> {
   if (typeof input.duration_ms === 'number' && input.duration_ms > PUBLIC_STT_MAX_DURATION_MS) {
     return {
@@ -54,7 +55,7 @@ export async function runTranscriptGeneration(
         };
       }
 
-      const result = createLectureTranscript(userId, {
+      const result = await createLectureTranscript(userId, {
         ...input,
         text: cloudflareResult.text,
         duration_ms: input.duration_ms ?? cloudflareResult.duration_ms,
@@ -63,7 +64,7 @@ export async function runTranscriptGeneration(
         stt_model: cloudflareResult.model,
         segments: cloudflareResult.segments,
         word_count: cloudflareResult.word_count,
-      });
+      }, repository);
 
       if (!result) {
         return {
@@ -86,11 +87,11 @@ export async function runTranscriptGeneration(
     }
   }
 
-  const result = createLectureTranscript(userId, {
+  const result = await createLectureTranscript(userId, {
     ...input,
     stt_provider: provider.current_provider,
     stt_model: input.stt_model ?? 'pseudo-stt-v1',
-  });
+  }, repository);
 
   if (!result) {
     return {

--- a/backend/src/routes/ai-rag.ts
+++ b/backend/src/routes/ai-rag.ts
@@ -1,8 +1,14 @@
 import { Hono } from 'hono';
 import { getCourseLectures, getLectureDetail, type AIRagRequest, buildAIRAGOverview } from '@myway/shared';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
+import { createMediaRepository } from '../lib/media-repository';
+import type { RuntimeBindings } from '../lib/runtime-env';
 
 const rag = new Hono();
+
+function getMediaRepository(env: RuntimeBindings | undefined) {
+  return env?.MEDIA_DB ? createMediaRepository(env.MEDIA_DB) : undefined;
+}
 
 function ensureCourseExists(courseId: string): boolean {
   return getCourseLectures(courseId).length > 0;
@@ -27,14 +33,14 @@ rag.post('/', async (c) => {
   }
 
   return jsonSuccess(
-    buildAIRAGOverview({
+    await buildAIRAGOverview({
       query,
       lecture_id: lectureId,
       course_id: courseId,
       limit: body?.limit,
       context: body?.context,
       preferred_provider: body?.preferred_provider,
-    }),
+    }, getMediaRepository(c.env as RuntimeBindings | undefined)),
     'RAG 파이프라인이 생성되었습니다.',
   );
 });

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -14,6 +14,7 @@ import { runAIAnswer, runAIIntent, runAIQuiz, runAISearch, runAISummary } from '
 import { getAIProviderSelectionForRuntime } from '../lib/ai-provider';
 import { guardAiRequest } from '../lib/ai-controls';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
+import { createMediaRepository } from '../lib/media-repository';
 import { getGeminiRuntimeSettings, type RuntimeBindings } from '../lib/runtime-env';
 
 const ai = new Hono();
@@ -41,6 +42,10 @@ function getLectureSnapshot(lectureId?: string): AISnapshot {
     lecture_id: lecture.id,
     course_id: lecture.course_id,
   };
+}
+
+function getMediaRepository(env: RuntimeBindings | undefined) {
+  return env?.MEDIA_DB ? createMediaRepository(env.MEDIA_DB) : undefined;
 }
 
 function estimateTokens(text: string): number {
@@ -118,6 +123,7 @@ ai.post('/intent', async (c) => {
     },
     undefined,
     env,
+    getMediaRepository(env),
   );
 
   if (user) {
@@ -168,11 +174,11 @@ ai.post('/search', async (c) => {
 
   const env = c.env as RuntimeBindings | undefined;
   const metadata = buildResponseMetadata('search', env);
-  const result = runAISearch({
+  const result = await runAISearch({
     query,
     lecture_id: lectureId,
     limit: body?.limit,
-  });
+  }, undefined, getMediaRepository(env));
 
   if (user) {
     recordUsageLog({
@@ -219,6 +225,7 @@ ai.post('/answer', async (c) => {
     },
     undefined,
     env,
+    getMediaRepository(env),
   );
 
   if (user) {
@@ -273,6 +280,7 @@ ai.post('/summary', async (c) => {
     },
     undefined,
     env,
+    getMediaRepository(env),
   );
 
   if (!execution) {
@@ -324,6 +332,7 @@ ai.post('/quiz', async (c) => {
     },
     undefined,
     env,
+    getMediaRepository(env),
   );
 
   if (!execution) {

--- a/backend/src/routes/media.ts
+++ b/backend/src/routes/media.ts
@@ -16,6 +16,7 @@ import { getAuthenticatedUser, hasRole } from '../lib/auth';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
 import { readLectureVideoAsset, uploadLectureVideoAsset } from '../lib/media-assets';
 import { completeMediaExtractionJob, createMediaExtractionJob } from '../lib/media-pipeline';
+import { createMediaRepository } from '../lib/media-repository';
 import { normalizeMediaCallbackPayload, verifyMediaCallbackSecret } from '../lib/media-processor';
 import { buildExtractionCallbackResponse, buildExtractionResponse } from '../lib/media-response';
 import { getSTTProviderOverview } from '../lib/stt-provider';
@@ -27,6 +28,10 @@ const media = new Hono();
 
 function ensureLectureExists(lectureId: string, userId: string): boolean {
   return Boolean(getLectureDetail(lectureId, userId));
+}
+
+function getMediaRepository(env: RuntimeBindings | undefined) {
+  return env?.MEDIA_DB ? createMediaRepository(env.MEDIA_DB) : undefined;
 }
 
 media.post('/upload-video', async (c) => {
@@ -106,7 +111,7 @@ media.post('/transcribe', async (c) => {
     language: body?.language ?? 'ko',
     stt_provider: body?.stt_provider?.trim(),
     stt_model: body?.stt_model?.trim(),
-  }, undefined, c.env as RuntimeBindings | undefined);
+  }, undefined, c.env as RuntimeBindings | undefined, getMediaRepository(c.env as RuntimeBindings | undefined));
 
   if (!result.ok) {
     if (result.reason === 'input_too_large') {
@@ -167,11 +172,11 @@ media.post('/summarize', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  const result = createLectureSummaryNote(user.id, {
+  const result = await createLectureSummaryNote(user.id, {
     lecture_id: lectureId,
     style: body?.style ?? 'brief',
     language: body?.language ?? 'ko',
-  });
+  }, getMediaRepository(c.env as RuntimeBindings | undefined));
 
   if (!result) {
     return jsonFailure('SUMMARY_FAILED', '요약을 생성할 수 없습니다.', 400);
@@ -219,7 +224,7 @@ media.post('/extract-audio', async (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  const result = await createMediaExtractionJob(user.id, body, c.req.url, c.env as RuntimeBindings | undefined);
+  const result = await createMediaExtractionJob(user.id, body, c.req.url, c.env as RuntimeBindings | undefined, getMediaRepository(c.env as RuntimeBindings | undefined));
   if (!result.ok) {
     const status =
       result.reason === 'processor_not_configured'
@@ -248,7 +253,7 @@ media.post('/extract-audio/callback', async (c) => {
     return jsonFailure('CALLBACK_INVALID', 'callback payload가 올바르지 않습니다.', 400);
   }
 
-  const result = await completeMediaExtractionJob('media-processor', payload, c.env as RuntimeBindings | undefined);
+  const result = await completeMediaExtractionJob('media-processor', payload, c.env as RuntimeBindings | undefined, getMediaRepository(c.env as RuntimeBindings | undefined));
   if (!result.ok) {
     const status =
       result.reason === 'extraction_not_found'
@@ -265,7 +270,7 @@ media.post('/extract-audio/callback', async (c) => {
   );
 });
 
-media.get('/transcript/:lectureId', (c) => {
+media.get('/transcript/:lectureId', async (c) => {
   const user = getAuthenticatedUser(c.req.raw);
   const lectureId = c.req.param('lectureId');
 
@@ -273,10 +278,10 @@ media.get('/transcript/:lectureId', (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  return jsonSuccess(listLectureTranscripts(lectureId)[0] ?? null);
+  return jsonSuccess((await listLectureTranscripts(lectureId, getMediaRepository(c.env as RuntimeBindings | undefined)))[0] ?? null);
 });
 
-media.get('/notes/:lectureId', (c) => {
+media.get('/notes/:lectureId', async (c) => {
   const user = getAuthenticatedUser(c.req.raw);
   const lectureId = c.req.param('lectureId');
 
@@ -284,10 +289,10 @@ media.get('/notes/:lectureId', (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  return jsonSuccess(listLectureNotes(lectureId));
+  return jsonSuccess(await listLectureNotes(lectureId, getMediaRepository(c.env as RuntimeBindings | undefined)));
 });
 
-media.get('/audio-extractions/:lectureId', (c) => {
+media.get('/audio-extractions/:lectureId', async (c) => {
   const user = getAuthenticatedUser(c.req.raw);
   const lectureId = c.req.param('lectureId');
 
@@ -295,10 +300,10 @@ media.get('/audio-extractions/:lectureId', (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  return jsonSuccess(listAudioExtractions(lectureId));
+  return jsonSuccess(await listAudioExtractions(lectureId, getMediaRepository(c.env as RuntimeBindings | undefined)));
 });
 
-media.get('/pipeline/:lectureId', (c) => {
+media.get('/pipeline/:lectureId', async (c) => {
   const user = getAuthenticatedUser(c.req.raw);
   const lectureId = c.req.param('lectureId');
 
@@ -306,7 +311,7 @@ media.get('/pipeline/:lectureId', (c) => {
     return jsonFailure('LECTURE_NOT_FOUND', '강의를 찾을 수 없습니다.', 404);
   }
 
-  return jsonSuccess(buildPipelineOverview(lectureId));
+  return jsonSuccess(await buildPipelineOverview(lectureId, getMediaRepository(c.env as RuntimeBindings | undefined)));
 });
 
 export default media;

--- a/backend/src/routes/smart.ts
+++ b/backend/src/routes/smart.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { getCourseDetail, getLectureDetail, type SmartChatRequest } from '@myway/shared';
 import { guardAiRequest } from '../lib/ai-controls';
 import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
+import { createMediaRepository } from '../lib/media-repository';
 import { runSmartChat } from '../lib/smart-chat';
 import type { RuntimeBindings } from '../lib/runtime-env';
 
@@ -9,6 +10,10 @@ const smart = new Hono();
 
 function ensureLectureExists(lectureId: string): boolean {
   return Boolean(getLectureDetail(lectureId));
+}
+
+function getMediaRepository(env: RuntimeBindings | undefined) {
+  return env?.MEDIA_DB ? createMediaRepository(env.MEDIA_DB) : undefined;
 }
 
 smart.post('/chat', async (c) => {
@@ -42,7 +47,7 @@ smart.post('/chat', async (c) => {
     course_id: courseId,
     context: body?.context,
     language: body?.language ?? 'ko',
-  });
+  }, c.env as RuntimeBindings | undefined, getMediaRepository(c.env as RuntimeBindings | undefined));
 
   return jsonSuccess(result, '스마트 AI 응답을 생성했습니다.');
 });

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -7,6 +7,11 @@
       "binding": "DB",
       "database_name": "myway-class-quota",
       "database_id": "3ef1768f-347d-4e82-93ea-2c346f52630a"
+    },
+    {
+      "binding": "MEDIA_DB",
+      "database_name": "myway-class-data",
+      "database_id": "519993d1-b497-401d-a072-c7d777bc0ddb"
     }
   ],
   "r2_buckets": [

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -6,7 +6,7 @@
     {
       "binding": "DB",
       "database_name": "myway-class-quota",
-      "database_id": "REPLACE_WITH_D1_DATABASE_ID"
+      "database_id": "3ef1768f-347d-4e82-93ea-2c346f52630a"
     }
   ],
   "r2_buckets": [

--- a/docs/dev-logs/2026-04-11-d1-media-binding.md
+++ b/docs/dev-logs/2026-04-11-d1-media-binding.md
@@ -1,0 +1,9 @@
+# 2026-04-11 D1 media binding
+
+- Cloudflare D1 `myway-class-data`를 생성했다.
+- `backend/wrangler.jsonc`에 `MEDIA_DB` 바인딩을 추가했다.
+- `backend/src/lib/runtime-env.ts`에 `MEDIA_DB` 타입을 추가했다.
+- 아직 실제 transcript/note/extraction 저장소 레이어는 연결 전이다.
+
+## 검증
+- `wrangler d1 list`에서 `myway-class-data` 확인

--- a/docs/dev-logs/2026-04-11-d1-quota-binding.md
+++ b/docs/dev-logs/2026-04-11-d1-quota-binding.md
@@ -1,0 +1,8 @@
+# 2026-04-11 D1 quota binding
+
+- Cloudflare D1 `myway-class-quota`를 생성했다.
+- `backend/wrangler.jsonc`의 `DB` 바인딩에 실제 `database_id`를 연결했다.
+- 다음 단계로 migration을 적용해 quota 테이블을 생성한다.
+
+## 검증
+- D1 목록에서 `myway-class-quota` 확인

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-11-d1-media-binding.md`
 - `2026-04-11-d1-quota-binding.md`
 - `2026-04-10-lecture-draft-api-worktree-compare.md`
 - `2026-04-10-shortform-preview-modal-close-fix.md`

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-11-d1-quota-binding.md`
 - `2026-04-10-lecture-draft-api-worktree-compare.md`
 - `2026-04-10-shortform-preview-modal-close-fix.md`
 - `2026-04-10-lecture-studio-ui-ux.md`

--- a/frontend/src/lib/ai-rag.ts
+++ b/frontend/src/lib/ai-rag.ts
@@ -42,7 +42,7 @@ export async function loadAIRAGOverview(
   const token = sessionToken ?? readStoredAuth()?.session_token ?? null;
 
   if (!token) {
-    return buildAIRAGOverview(input);
+    return await buildAIRAGOverview(input);
   }
 
   const response = await request<AIRagResult>(
@@ -54,5 +54,5 @@ export async function loadAIRAGOverview(
     token,
   );
 
-  return response?.success && response.data ? response.data : buildAIRAGOverview(input);
+  return response?.success && response.data ? response.data : await buildAIRAGOverview(input);
 }

--- a/packages/shared/src/ai/ai-learning.ts
+++ b/packages/shared/src/ai/ai-learning.ts
@@ -1,5 +1,5 @@
 import { getLectureDetail } from '../lms/learning';
-import { collectLectureReferences } from './ai-intent';
+import { collectLectureReferences } from './intent/corpus';
 import { getLectureTranscript, listLectureNotes } from '../lms/media';
 import type {
   AIQuizQuestion,
@@ -9,6 +9,7 @@ import type {
   AISummaryResult,
   MediaSummaryStyle,
 } from '../types';
+import { memoryMediaRepository, type MediaRepository } from '../lms/media/store';
 
 function normalizeText(text: string): string {
   return text.replaceAll(/\s+/g, ' ').trim();
@@ -54,8 +55,8 @@ function buildSummaryContent(text: string, style: MediaSummaryStyle): string {
   return sentences.slice(0, 2).join(' ');
 }
 
-function buildSummaryReferences(lectureId: string) {
-  return collectLectureReferences(lectureId).slice(0, 2);
+async function buildSummaryReferences(lectureId: string, repository: MediaRepository = memoryMediaRepository) {
+  return (await collectLectureReferences(lectureId, repository)).slice(0, 2);
 }
 
 function buildQuizChoices(concepts: string[], lectureTitle: string): string[] {
@@ -109,7 +110,7 @@ function buildQuizQuestion(
   courseTitle: string,
   sourceText: string,
   concepts: string[],
-  quizReferences: ReturnType<typeof buildSummaryReferences>,
+  quizReferences: Awaited<ReturnType<typeof buildSummaryReferences>>,
   index: number,
 ): AIQuizQuestion {
   const concept = concepts[index % Math.max(1, concepts.length)] ?? lectureTitle;
@@ -129,14 +130,17 @@ function buildQuizQuestion(
   };
 }
 
-export function createAISummary(input: AISummaryRequest): AISummaryResult | null {
+export async function createAISummary(
+  input: AISummaryRequest,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AISummaryResult | null> {
   const lecture = getLectureDetail(input.lecture_id);
   if (!lecture) {
     return null;
   }
 
-  const transcript = getLectureTranscript(lecture.id);
-  const note = listLectureNotes(lecture.id)[0];
+  const transcript = await getLectureTranscript(lecture.id, repository);
+  const note = (await listLectureNotes(lecture.id, repository))[0];
   const sourceText = note?.content ?? transcript?.full_text ?? lecture.content_text;
   const style = input.style ?? 'brief';
   const titleSuffix =
@@ -157,18 +161,21 @@ export function createAISummary(input: AISummaryRequest): AISummaryResult | null
     language: input.language ?? 'ko',
     content: buildSummaryContent(sourceText, style),
     key_points: keyPoints,
-    references: buildSummaryReferences(lecture.id),
+    references: await buildSummaryReferences(lecture.id, repository),
   };
 }
 
-export function generateAIQuiz(input: AIQuizRequest): AIQuizResult | null {
+export async function generateAIQuiz(
+  input: AIQuizRequest,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIQuizResult | null> {
   const lecture = getLectureDetail(input.lecture_id);
   if (!lecture) {
     return null;
   }
 
-  const transcript = getLectureTranscript(lecture.id);
-  const note = listLectureNotes(lecture.id)[0];
+  const transcript = await getLectureTranscript(lecture.id, repository);
+  const note = (await listLectureNotes(lecture.id, repository))[0];
   const sourceText = note?.content ?? transcript?.full_text ?? lecture.content_text;
   const concepts = collectQuizConcepts(sourceText, lecture.title, lecture.course_title);
   let count = input.count ?? 4;
@@ -178,7 +185,7 @@ export function generateAIQuiz(input: AIQuizRequest): AIQuizResult | null {
     count = input.count ?? 3;
   }
   count = Math.max(1, Math.min(5, count));
-  const quizReferences = buildSummaryReferences(lecture.id);
+  const quizReferences = await buildSummaryReferences(lecture.id, repository);
   const questions: AIQuizQuestion[] = Array.from({ length: count }, (_, index) =>
     buildQuizQuestion(
       lecture.id,

--- a/packages/shared/src/ai/intent/corpus.ts
+++ b/packages/shared/src/ai/intent/corpus.ts
@@ -1,7 +1,7 @@
 import { demoLectures } from '../../data/demo-data';
 import { getLectureDetail } from '../../lms/learning';
-import { getLectureTranscript, listLectureNotes } from '../../lms/media';
-import type { AIChunkSource, AIReference, AISearchHit } from '../../types';
+import { getLectureTranscript, listLectureNotes, type MediaRepository, memoryMediaRepository } from '../../lms/media';
+import type { AIChunkSource, AIReference, AISearchHit, AIRagChunk, AIRagRequest } from '../../types';
 import { buildChunkText as buildChunkTextFromText, scoreChunk as scoreChunkFromText } from './helpers';
 
 function listTargetLectureIds(lectureId?: string): string[] {
@@ -18,6 +18,14 @@ export function buildChunkText(text: string, maxChunks = 3): string[] {
 
 export function scoreChunk(queryTokens: string[], candidateText: string, title: string): number {
   return scoreChunkFromText(queryTokens, candidateText, title);
+}
+
+function countTokens(text: string): number {
+  return text
+    .toLowerCase()
+    .split(/[^a-zA-Z0-9가-힣]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0).length;
 }
 
 export function createReference(
@@ -42,7 +50,10 @@ export function createReference(
   };
 }
 
-export function collectLectureReferences(lectureId: string): AIReference[] {
+export async function collectLectureReferences(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIReference[]> {
   const lecture = getLectureDetail(lectureId);
   if (!lecture) {
     return [];
@@ -65,7 +76,7 @@ export function collectLectureReferences(lectureId: string): AIReference[] {
     );
   });
 
-  const transcript = getLectureTranscript(lecture.id);
+  const transcript = await getLectureTranscript(lecture.id, repository);
   transcript?.segments.slice(0, 2).forEach((segment, index) => {
     references.push(
       createReference(
@@ -80,7 +91,7 @@ export function collectLectureReferences(lectureId: string): AIReference[] {
     );
   });
 
-  const note = listLectureNotes(lecture.id)[0];
+  const note = (await listLectureNotes(lecture.id, repository))[0];
   if (note) {
     const noteChunks = buildChunkText(`${note.title}. ${note.content}`, 2);
     noteChunks.slice(0, 2).forEach((chunk, index) => {
@@ -101,6 +112,153 @@ export function collectLectureReferences(lectureId: string): AIReference[] {
   return references;
 }
 
-export function buildSearchCandidates(lectureId?: string): AISearchHit[] {
-  return listTargetLectureIds(lectureId).flatMap((id) => collectLectureReferences(id));
+export async function buildSearchCandidates(
+  lectureId?: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AISearchHit[]> {
+  return Promise.all(listTargetLectureIds(lectureId).map((id) => collectLectureReferences(id, repository))).then((items) => items.flat());
+}
+
+export async function buildCorpusForLecture(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIRagChunk[]> {
+  const lecture = getLectureDetail(lectureId);
+  if (!lecture) {
+    return [];
+  }
+
+  const transcript = await getLectureTranscript(lectureId, repository);
+  const note = (await listLectureNotes(lectureId, repository))[0];
+  const chunks: AIRagChunk[] = [];
+
+  const lectureChunks = buildChunkText(`${lecture.title}. ${lecture.content_text}`, 2);
+  lectureChunks.forEach((chunk, index) => {
+    chunks.push({
+      id: `lecture_${lecture.id}_${String(index + 1).padStart(2, '0')}`,
+      lecture_id: lecture.id,
+      source_type: 'lecture',
+      source_id: lecture.id,
+      title: `${lecture.course_title} · ${lecture.title} · 강의 본문`,
+      content: chunk.slice(0, 240),
+      excerpt: chunk.slice(0, 240),
+      similarity: 0,
+      chunk_index: index,
+      source_scope: 'lecture',
+      token_count: countTokens(chunk),
+    });
+  });
+
+  transcript?.segments.forEach((segment) => {
+    const content = segment.text.trim();
+    if (!content) {
+      return;
+    }
+
+    chunks.push({
+      id: `transcript_${transcript.id}_${String(segment.index + 1).padStart(2, '0')}`,
+      lecture_id: lecture.id,
+      source_type: 'transcript',
+      source_id: transcript.id,
+      title: `${lecture.title} · 트랜스크립트`,
+      content: content.slice(0, 240),
+      excerpt: content.slice(0, 240),
+      similarity: 0,
+      chunk_index: segment.index,
+      source_scope: 'transcript',
+      token_count: countTokens(content),
+      start_ms: segment.start_ms,
+      end_ms: segment.end_ms,
+    });
+  });
+
+  if (note) {
+    const noteChunks = buildChunkText(`${note.title}. ${note.content}`, 2);
+    noteChunks.forEach((chunk, index) => {
+      chunks.push({
+        id: `note_${note.id}_${String(index + 1).padStart(2, '0')}`,
+        lecture_id: lecture.id,
+        source_type: 'note',
+        source_id: note.id,
+        title: `${lecture.title} · 요약 노트`,
+        content: chunk.slice(0, 240),
+        excerpt: chunk.slice(0, 240),
+        similarity: 0,
+        chunk_index: index,
+        source_scope: 'note',
+        token_count: countTokens(chunk),
+      });
+    });
+  }
+
+  return chunks;
+}
+
+export async function buildCorpusForCourse(
+  courseId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIRagChunk[]> {
+  const lectures = demoLectures.filter((lecture) => lecture.course_id === courseId);
+  return Promise.all(lectures.map((lecture) => buildCorpusForLecture(lecture.id, repository))).then((items) => items.flat());
+}
+
+export async function buildCorpus(
+  input: AIRagRequest,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIRagChunk[]> {
+  if (input.lecture_id) {
+    return await buildCorpusForLecture(input.lecture_id, repository);
+  }
+
+  if (input.course_id) {
+    return await buildCorpusForCourse(input.course_id, repository);
+  }
+
+  return Promise.all(demoLectures.map((lecture) => buildCorpusForLecture(lecture.id, repository))).then((items) => items.flat());
+}
+
+function scoreCorpusChunk(query: string, chunk: AIRagChunk): number {
+  const queryTokens = query
+    .toLowerCase()
+    .split(/[^a-zA-Z0-9가-힣]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 1);
+
+  if (queryTokens.length === 0) {
+    if (chunk.source_scope === 'transcript') {
+      return 0.62;
+    }
+    if (chunk.source_scope === 'note') {
+      return 0.58;
+    }
+    return 0.55;
+  }
+
+  const haystackTokens = `${chunk.title} ${chunk.content}`
+    .toLowerCase()
+    .split(/[^a-zA-Z0-9가-힣]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 1);
+  const overlap = queryTokens.filter((token) => haystackTokens.includes(token)).length;
+  const coverage = overlap / Math.max(3, queryTokens.length);
+  const exactMatch = chunk.content.includes(query) ? 0.14 : 0;
+  const titleBoost = chunk.title.includes(query) ? 0.06 : 0;
+  let scopeBoost = 0;
+  if (chunk.source_scope === 'transcript') {
+    scopeBoost = 0.05;
+  } else if (chunk.source_scope === 'note') {
+    scopeBoost = 0.03;
+  }
+  return Math.min(0.99, coverage + exactMatch + titleBoost + scopeBoost);
+}
+
+export async function rankChunks(query: string, chunks: AIRagChunk[], limit: number): Promise<AIRagChunk[]> {
+  const rankedChunks = chunks
+    .map((chunk) => ({
+      ...chunk,
+      similarity: scoreCorpusChunk(query, chunk),
+    }))
+    .filter((chunk) => chunk.similarity > 0 || query.trim().length === 0);
+  rankedChunks.sort((left, right) => right.similarity - left.similarity || left.title.localeCompare(right.title));
+  return rankedChunks.slice(0, limit);
 }

--- a/packages/shared/src/ai/intent/pipeline.ts
+++ b/packages/shared/src/ai/intent/pipeline.ts
@@ -9,6 +9,7 @@ import type {
   AISearchRequest,
   AISearchResult,
 } from '../../types';
+import { memoryMediaRepository, type MediaRepository } from '../../lms/media';
 import {
   buildAnswerFromReference,
   buildIntentEntities,
@@ -70,34 +71,40 @@ export function classifyAIIntent(input: AIIntentRequest): AIIntentResult {
   };
 }
 
-export function searchAIContent(input: AISearchRequest): AISearchResult {
+export async function searchAIContent(
+  input: AISearchRequest,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AISearchResult> {
   const query = normalizeText(input.query);
   const limit = Math.max(1, Math.min(5, input.limit ?? 3));
-  const hits = scoreCandidates(query, buildSearchCandidates(input.lecture_id), limit);
+  const hits = scoreCandidates(query, await buildSearchCandidates(input.lecture_id, repository), limit);
 
   return buildSearchResult(query, input.lecture_id ?? null, hits);
 }
 
-export function answerAIQuestion(input: AIAnswerRequest): AIAnswerResult {
+export async function answerAIQuestion(
+  input: AIAnswerRequest,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIAnswerResult> {
   const intent = classifyAIIntent({
     message: input.question,
     lecture_id: input.lecture_id,
   });
-  const search = searchAIContent({
+  const search = await searchAIContent({
     query: input.question,
     lecture_id: input.lecture_id,
     limit: input.limit ?? 3,
-  });
+  }, repository);
   const references = search.hits;
   let summary = buildAnswerFromReference(references, input.lecture_id);
   const shouldSummarize = input.intent_hint === 'request_summary' || intent.intent === 'request_summary';
   if (shouldSummarize && input.lecture_id) {
     summary =
-      createAISummary({
+      (await createAISummary({
         lecture_id: input.lecture_id,
         style: 'brief',
         language: 'ko',
-      })?.content ?? summary;
+      }, repository))?.content ?? summary;
   }
 
   return {

--- a/packages/shared/src/ai/smart/helpers.ts
+++ b/packages/shared/src/ai/smart/helpers.ts
@@ -2,6 +2,7 @@ import { demoCourses } from '../../data/demo-data';
 import { getCourseLectures } from '../../lms/learning';
 import { createAISummary, generateAIQuiz } from '../ai-learning';
 import { collectLectureReferences } from '../intent/corpus';
+import { memoryMediaRepository, type MediaRepository } from '../../lms/media';
 import { normalizeText as normalizeIntentText, scoreChunk, tokenize } from '../intent/helpers';
 import type {
   AIReference,
@@ -22,18 +23,20 @@ function listCourseLectureIds(courseId: string): string[] {
   return getCourseLectures(courseId).map((lecture) => lecture.id);
 }
 
-function collectCourseReferences(courseId: string): AIReference[] {
-  return listCourseLectureIds(courseId).flatMap((lectureId) => collectLectureReferences(lectureId));
+async function collectCourseReferences(courseId: string, repository: MediaRepository = memoryMediaRepository): Promise<AIReference[]> {
+  return Promise.all(listCourseLectureIds(courseId).map((lectureId) => collectLectureReferences(lectureId, repository))).then((items) => items.flat());
 }
 
-function searchCourseReferences(query: string, courseId: string, limit: number): AIReference[] {
+async function searchCourseReferences(query: string, courseId: string, limit: number, repository: MediaRepository = memoryMediaRepository): Promise<AIReference[]> {
   const queryTokens = tokenize(query);
-  const hits = listCourseLectureIds(courseId).flatMap((lectureId) =>
-    collectLectureReferences(lectureId).map((reference) => ({
-      ...reference,
-      similarity: scoreChunk(queryTokens, reference.excerpt, reference.title),
-    })),
-  );
+  const hits = await Promise.all(
+    listCourseLectureIds(courseId).map(async (lectureId) =>
+      (await collectLectureReferences(lectureId, repository)).map((reference) => ({
+        ...reference,
+        similarity: scoreChunk(queryTokens, reference.excerpt, reference.title),
+      })),
+    ),
+  ).then((items) => items.flat());
 
   const uniqueHits = new Map<string, AIReference>();
   for (const hit of hits) {
@@ -68,16 +71,17 @@ function buildSummaryFromLectureSummaries(summaries: AISummaryResult[], courseTi
   return `${courseTitle}의 강의 흐름을 묶어 보면 다음과 같습니다.\n\n${lines.join('\n\n')}`;
 }
 
-function buildCourseSummary(courseId: string, language: 'ko' | 'en'): {
+async function buildCourseSummary(courseId: string, language: 'ko' | 'en', repository: MediaRepository = memoryMediaRepository): Promise<{
   summary: AISummaryResult | null;
   answer: string;
   references: AIReference[];
-} {
+}> {
   const lectureIds = listCourseLectureIds(courseId);
-  const summaries = lectureIds
-    .slice(0, 3)
-    .map((lectureId) => createAISummary({ lecture_id: lectureId, style: 'brief', language }))
-    .filter((item): item is AISummaryResult => Boolean(item));
+  const summaries = (await Promise.all(
+      lectureIds
+      .slice(0, 3)
+      .map((lectureId) => createAISummary({ lecture_id: lectureId, style: 'brief', language }, repository)),
+  )).filter((item): item is AISummaryResult => Boolean(item));
 
   if (summaries.length === 0) {
     return { summary: null, answer: '요약할 강의를 찾을 수 없습니다.', references: [] };
@@ -90,16 +94,16 @@ function buildCourseSummary(courseId: string, language: 'ko' | 'en'): {
   };
 }
 
-function buildCourseQuiz(courseId: string, count?: number): AIQuizResult | null {
+async function buildCourseQuiz(courseId: string, count?: number, repository: MediaRepository = memoryMediaRepository): Promise<AIQuizResult | null> {
   const lectureId = listCourseLectureIds(courseId)[0];
   if (!lectureId) {
     return null;
   }
 
-  return generateAIQuiz({
+  return await generateAIQuiz({
     lecture_id: lectureId,
     count,
-  });
+  }, repository);
 }
 
 function extractTranslationTarget(message: string, language?: 'ko' | 'en'): 'ko' | 'en' {

--- a/packages/shared/src/ai/smart/pipeline.ts
+++ b/packages/shared/src/ai/smart/pipeline.ts
@@ -1,6 +1,7 @@
 import { answerAIQuestion, classifyAIIntent } from '../intent/pipeline';
 import { collectLectureReferences } from '../intent/corpus';
 import { createAISummary, generateAIQuiz } from '../ai-learning';
+import { memoryMediaRepository, type MediaRepository } from '../../lms/media';
 import type {
   SmartChatRequest,
   SmartChatResult,
@@ -19,13 +20,13 @@ import {
   normalizeText,
 } from './helpers';
 
-function collectSmartReferences(lectureId: string | null, courseId: string | null) {
+async function collectSmartReferences(lectureId: string | null, courseId: string | null, repository: MediaRepository = memoryMediaRepository) {
   if (lectureId) {
-    return collectLectureReferences(lectureId);
+    return await collectLectureReferences(lectureId, repository);
   }
 
   if (courseId) {
-    return collectCourseReferences(courseId);
+    return await collectCourseReferences(courseId, repository);
   }
 
   return [];
@@ -43,7 +44,7 @@ function resolveSmartComparisonLabel(courseTitle: string, lectureId: string | nu
   return '전체 강의';
 }
 
-export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult {
+export async function buildSmartChatOverview(input: SmartChatRequest, repository: MediaRepository = memoryMediaRepository): Promise<SmartChatResult> {
   const message = normalizeText(input.message);
   const intent = classifyAIIntent({
     message,
@@ -64,14 +65,14 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
       route,
       intent,
       answer: '질문의 의도가 여러 가지로 해석됩니다. 요약, 질문응답, 검색, 번역, 비교 중 하나를 더 구체적으로 알려 주세요.',
-      references: collectSmartReferences(lectureId, courseId),
+      references: await collectSmartReferences(lectureId, courseId, repository),
       suggestions: ['이 강의를 3줄로 요약해줘.', '이 강의에서 핵심 근거를 찾아줘.', '이 두 개념을 비교해줘.'],
     };
   }
 
   if (route === 'summary') {
     if (lectureId) {
-      const summary = createAISummary({ lecture_id: lectureId, style: 'brief', language });
+      const summary = await createAISummary({ lecture_id: lectureId, style: 'brief', language }, repository);
       return {
         message,
         lecture_id: lectureId,
@@ -86,7 +87,7 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
     }
 
     if (courseId) {
-      const courseSummary = buildCourseSummary(courseId, language);
+      const courseSummary = await buildCourseSummary(courseId, language, repository);
       return {
         message,
         lecture_id: null,
@@ -103,7 +104,7 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
 
   if (route === 'quiz') {
     if (lectureId) {
-      const quiz = generateAIQuiz({ lecture_id: lectureId, count: 4 });
+      const quiz = await generateAIQuiz({ lecture_id: lectureId, count: 4 }, repository);
       return {
         message,
         lecture_id: lectureId,
@@ -111,14 +112,14 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
         route,
         intent,
         answer: quiz ? `${quiz.title}가 생성되었습니다.` : '퀴즈를 생성할 수 없습니다.',
-        references: lectureId ? collectLectureReferences(lectureId) : [],
+        references: lectureId ? await collectLectureReferences(lectureId, repository) : [],
         suggestions: ['이 퀴즈의 해설도 보여줘.', '문항 수를 줄여서 다시 만들어줘.'],
         quiz,
       };
     }
 
     if (courseId) {
-      const quiz = buildCourseQuiz(courseId, 4);
+      const quiz = await buildCourseQuiz(courseId, 4, repository);
       return {
         message,
         lecture_id: null,
@@ -126,7 +127,7 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
         route,
         intent,
         answer: quiz ? `${getCourseTitle(courseId)}의 첫 강의 기준 퀴즈를 생성했습니다.` : '퀴즈를 생성할 강의를 찾지 못했습니다.',
-        references: quiz ? collectCourseReferences(courseId).slice(0, 4) : [],
+        references: quiz ? (await collectCourseReferences(courseId, repository)).slice(0, 4) : [],
         suggestions: ['이 과목의 다른 강의로 퀴즈를 만들어줘.', '오답 해설도 같이 보여줘.'],
         quiz,
       };
@@ -139,12 +140,12 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
       : input.context?.[0] ?? message;
 
     const hits = courseId
-      ? searchCourseReferences(searchQuery, courseId, 4)
-      : answerAIQuestion({
+      ? await searchCourseReferences(searchQuery, courseId, 4, repository)
+      : (await answerAIQuestion({
           question: searchQuery,
           lecture_id: lectureId ?? undefined,
           limit: 4,
-        }).references;
+        }, repository)).references;
 
     let answerLabel = '전체 강의';
     if (courseId) {
@@ -153,11 +154,11 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
       answerLabel = '강의';
     }
     const searchAnswer = buildSearchAnswer(hits, searchQuery, answerLabel);
-    const directAnswer = answerAIQuestion({
+    const directAnswer = (await answerAIQuestion({
       question: message,
       lecture_id: lectureId ?? undefined,
       limit: 4,
-    }).answer;
+    }, repository)).answer;
     const answer = route === 'search' ? searchAnswer : directAnswer;
 
     return {
@@ -185,19 +186,19 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
       route,
       intent,
       answer,
-      references: collectSmartReferences(lectureId, courseId),
+      references: await collectSmartReferences(lectureId, courseId, repository),
       suggestions: ['다른 문장도 번역해줘.', '원문 기준으로 다시 풀어줘.'],
     };
   }
 
   if (route === 'compare') {
     const hits = courseId
-      ? searchCourseReferences(message, courseId, 2)
-      : answerAIQuestion({
+      ? await searchCourseReferences(message, courseId, 2, repository)
+      : (await answerAIQuestion({
           question: message,
           lecture_id: lectureId ?? undefined,
           limit: 2,
-        }).references;
+        }, repository)).references;
     const comparisonLabel = resolveSmartComparisonLabel(courseTitle, lectureId, courseId);
 
     return {
@@ -212,11 +213,11 @@ export function buildSmartChatOverview(input: SmartChatRequest): SmartChatResult
     };
   }
 
-  const fallback = answerAIQuestion({
+  const fallback = await answerAIQuestion({
     question: message,
     lecture_id: lectureId ?? undefined,
     limit: 3,
-  });
+  }, repository);
 
   return {
     message,

--- a/packages/shared/src/lms/media/audio.ts
+++ b/packages/shared/src/lms/media/audio.ts
@@ -1,127 +1,39 @@
-import { demoAudioExtractions } from '../../data/demo-data';
-import type { AudioExtraction, AudioExtractionCallbackRequest, AudioExtractionRequest } from '../../types';
-import { createId, findLecture, now, upsertPipeline } from './helpers';
-import { getLectureTranscript } from './transcript';
+import type {
+  AudioExtraction,
+  AudioExtractionCallbackRequest,
+  AudioExtractionRequest,
+  LecturePipeline,
+} from '../../types';
+import { memoryMediaRepository, type MediaRepository } from './store';
 
-function inferAudioFormat(source: string | undefined): string {
-  if (!source) {
-    return 'pending';
-  }
-
-  const normalized = source.split('?')[0]?.split('#')[0] ?? '';
-  const extension = normalized.includes('.') ? normalized.split('.').pop()?.toLowerCase() : '';
-
-  if (!extension) {
-    return 'wav';
-  }
-
-  if (['mp3', 'wav', 'm4a', 'aac', 'ogg', 'flac', 'webm'].includes(extension)) {
-    return extension;
-  }
-
-  return 'wav';
+export async function listAudioExtractions(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AudioExtraction[]> {
+  return await repository.listAudioExtractions(lectureId);
 }
 
-export function listAudioExtractions(lectureId: string): AudioExtraction[] {
-  return demoAudioExtractions
-    .filter((item) => item.lecture_id === lectureId)
-    .sort((a, b) => b.created_at.localeCompare(a.created_at));
+export async function getAudioExtraction(
+  extractionId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AudioExtraction | undefined> {
+  return await repository.getAudioExtraction(extractionId);
 }
 
-export function getAudioExtraction(extractionId: string): AudioExtraction | undefined {
-  return demoAudioExtractions.find((item) => item.id === extractionId);
-}
-
-export function createAudioExtraction(
+export async function createAudioExtraction(
   userId: string,
   input: AudioExtractionRequest,
-): { extraction: AudioExtraction; pipeline: ReturnType<typeof upsertPipeline> } | null {
-  const lecture = findLecture(input.lecture_id);
-  if (!lecture) {
-    return null;
-  }
-
-  const extraction: AudioExtraction = {
-    id: createId('aud', demoAudioExtractions.length),
-    lecture_id: lecture.id,
-    user_id: userId,
-    source_type: 'video',
-    source_url: input.video_url ?? '/static/media/demo-lecture.mp4',
-    source_video_key: input.video_asset_key,
-    source_video_name: input.source_file_name,
-    source_content_type: input.source_content_type,
-    source_size_bytes: input.source_size_bytes,
-    language: input.language ?? 'ko',
-    requested_stt_provider: input.stt_provider,
-    requested_stt_model: input.stt_model,
-    processing_job_id: null,
-    processing_error: null,
-    audio_url: input.audio_url ?? null,
-    audio_format: input.audio_url ? inferAudioFormat(input.audio_url) : 'pending',
-    audio_duration_ms: Math.max(lecture.duration_minutes * 60_000, 30_000),
-    sample_rate: 16_000,
-    channels: 1,
-    status: input.audio_url ? 'COMPLETED' : 'PROCESSING',
-    transcript_id: getLectureTranscript(lecture.id)?.id ?? null,
-    stt_status: getLectureTranscript(lecture.id) ? 'COMPLETED' : input.audio_url ? 'PROCESSING' : 'PENDING',
-    created_at: now(),
-    processed_at: input.audio_url ? now() : null,
-    updated_at: now(),
-  };
-
-  demoAudioExtractions.push(extraction);
-  const pipeline = upsertPipeline({
-    lecture_id: lecture.id,
-    audio_status: extraction.status,
-    extraction_id: extraction.id,
-  });
-
-  return { extraction, pipeline };
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<{ extraction: AudioExtraction; pipeline: LecturePipeline } | null> {
+  return await repository.createAudioExtraction(userId, input);
 }
 
-export function updateAudioExtraction(
+export async function updateAudioExtraction(
   input: AudioExtractionCallbackRequest & {
     transcript_id?: string | null;
     stt_status?: AudioExtraction['stt_status'];
   },
-): { extraction: AudioExtraction; pipeline: ReturnType<typeof upsertPipeline> } | null {
-  const targetIndex = demoAudioExtractions.findIndex((item) => item.id === input.extraction_id && item.lecture_id === input.lecture_id);
-  if (targetIndex < 0) {
-    return null;
-  }
-
-  const current = demoAudioExtractions[targetIndex];
-  const nextStatus = input.status;
-  const next: AudioExtraction = {
-    ...current,
-    processing_job_id: input.processing_job_id ?? current.processing_job_id ?? null,
-    processing_error: input.error_message ?? (nextStatus === 'FAILED' ? '오디오 추출에 실패했습니다.' : null),
-    audio_url: input.audio_url ?? current.audio_url ?? null,
-    audio_format: input.audio_format ?? (input.audio_url ? inferAudioFormat(input.audio_url) : current.audio_format),
-    audio_duration_ms: input.audio_duration_ms ?? current.audio_duration_ms,
-    sample_rate: input.sample_rate ?? current.sample_rate,
-    channels: input.channels ?? current.channels,
-    status: nextStatus,
-    transcript_id: input.transcript_id ?? current.transcript_id,
-    stt_status:
-      input.stt_status ??
-      (nextStatus === 'FAILED'
-        ? 'FAILED'
-        : input.transcript_id
-          ? 'COMPLETED'
-          : current.stt_status),
-    processed_at: nextStatus === 'COMPLETED' ? now() : current.processed_at ?? null,
-    updated_at: now(),
-  };
-
-  demoAudioExtractions[targetIndex] = next;
-  const pipeline = upsertPipeline({
-    lecture_id: next.lecture_id,
-    audio_status: next.status,
-    extraction_id: next.id,
-    transcript_status: next.transcript_id ? 'COMPLETED' : next.stt_status,
-    transcript_id: next.transcript_id,
-  });
-
-  return { extraction: next, pipeline };
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<{ extraction: AudioExtraction; pipeline: LecturePipeline } | null> {
+  return await repository.updateAudioExtraction(input);
 }

--- a/packages/shared/src/lms/media/index.ts
+++ b/packages/shared/src/lms/media/index.ts
@@ -2,3 +2,4 @@ export { getLectureTranscript, listLectureTranscripts, createLectureTranscript }
 export { listLectureNotes, createLectureSummaryNote } from './summary';
 export { listAudioExtractions, getAudioExtraction, createAudioExtraction, updateAudioExtraction } from './audio';
 export { getLecturePipeline, buildPipelineOverview } from './pipeline';
+export { memoryMediaRepository, type MediaRepository } from './store';

--- a/packages/shared/src/lms/media/pipeline.ts
+++ b/packages/shared/src/lms/media/pipeline.ts
@@ -1,34 +1,16 @@
-import { demoLecturePipelines } from '../../data/demo-data';
 import type { LecturePipeline } from '../../types';
-import { getLectureTranscript } from './transcript';
-import { listAudioExtractions } from './audio';
-import { listLectureNotes } from './summary';
-import { now } from './helpers';
+import { memoryMediaRepository, type MediaRepository } from './store';
 
-export function getLecturePipeline(lectureId: string): LecturePipeline {
-  const existing = demoLecturePipelines.find((item) => item.lecture_id === lectureId);
-
-  if (existing) {
-    return existing;
-  }
-
-  const transcript = getLectureTranscript(lectureId);
-  const notes = listLectureNotes(lectureId);
-  const extractions = listAudioExtractions(lectureId);
-  const latestExtraction = extractions[0];
-
-  return {
-    lecture_id: lectureId,
-    transcript_status: transcript ? 'COMPLETED' : 'PENDING',
-    summary_status: notes.length > 0 ? 'COMPLETED' : 'PENDING',
-    audio_status: latestExtraction?.status ?? 'PENDING',
-    transcript_id: transcript?.id ?? null,
-    note_id: notes[0]?.id ?? null,
-    extraction_id: latestExtraction?.id ?? null,
-    updated_at: now(),
-  };
+export async function getLecturePipeline(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<LecturePipeline> {
+  return await repository.getLecturePipeline(lectureId);
 }
 
-export function buildPipelineOverview(lectureId: string): LecturePipeline {
-  return getLecturePipeline(lectureId);
+export async function buildPipelineOverview(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<LecturePipeline> {
+  return await repository.getLecturePipeline(lectureId);
 }

--- a/packages/shared/src/lms/media/store.ts
+++ b/packages/shared/src/lms/media/store.ts
@@ -1,0 +1,394 @@
+import type {
+  AudioExtraction,
+  AudioExtractionCallbackRequest,
+  AudioExtractionRequest,
+  LectureNote,
+  LecturePipeline,
+  LectureTranscript,
+  MediaSummaryRequest,
+  TranscriptCreateRequest,
+} from '../../types';
+import {
+  demoAudioExtractions,
+  demoLectureNotes,
+  demoLecturePipelines,
+  demoLectureTranscripts,
+} from '../../data/demo-data';
+import { createId, findLecture, now, normalizeText, splitIntoSegments, upsertPipeline } from './helpers';
+
+export type MediaRepository = {
+  getLectureTranscript(lectureId: string): LectureTranscript | undefined | Promise<LectureTranscript | undefined>;
+  listLectureTranscripts(lectureId: string): LectureTranscript[] | Promise<LectureTranscript[]>;
+  createLectureTranscript(
+    userId: string,
+    input: TranscriptCreateRequest,
+  ): { transcript: LectureTranscript; pipeline: LecturePipeline } | null | Promise<{ transcript: LectureTranscript; pipeline: LecturePipeline } | null>;
+  listLectureNotes(lectureId: string): LectureNote[] | Promise<LectureNote[]>;
+  createLectureSummaryNote(
+    userId: string,
+    input: MediaSummaryRequest,
+  ): { note: LectureNote; pipeline: LecturePipeline; keyConcepts: string[]; keywords: string[] } | null | Promise<{
+    note: LectureNote;
+    pipeline: LecturePipeline;
+    keyConcepts: string[];
+    keywords: string[];
+  } | null>;
+  listAudioExtractions(lectureId: string): AudioExtraction[] | Promise<AudioExtraction[]>;
+  getAudioExtraction(extractionId: string): AudioExtraction | undefined | Promise<AudioExtraction | undefined>;
+  createAudioExtraction(
+    userId: string,
+    input: AudioExtractionRequest,
+  ): { extraction: AudioExtraction; pipeline: LecturePipeline } | null | Promise<{ extraction: AudioExtraction; pipeline: LecturePipeline } | null>;
+  updateAudioExtraction(
+    input: AudioExtractionCallbackRequest & {
+      transcript_id?: string | null;
+      stt_status?: AudioExtraction['stt_status'];
+    },
+  ): { extraction: AudioExtraction; pipeline: LecturePipeline } | null | Promise<{ extraction: AudioExtraction; pipeline: LecturePipeline } | null>;
+  getLecturePipeline(lectureId: string): LecturePipeline | Promise<LecturePipeline>;
+  upsertPipeline(partial: Partial<LecturePipeline> & { lecture_id: string }): LecturePipeline | Promise<LecturePipeline>;
+};
+
+function inferAudioFormat(source: string | undefined): string {
+  if (!source) {
+    return 'pending';
+  }
+
+  const normalized = source.split('?')[0]?.split('#')[0] ?? '';
+  const extension = normalized.includes('.') ? normalized.split('.').pop()?.toLowerCase() : '';
+
+  if (!extension) {
+    return 'wav';
+  }
+
+  if (['mp3', 'wav', 'm4a', 'aac', 'ogg', 'flac', 'webm'].includes(extension)) {
+    return extension;
+  }
+
+  return 'wav';
+}
+
+function getTranscriptIndex(lectureId: string): number {
+  return demoLectureTranscripts.findIndex((item) => item.lecture_id === lectureId);
+}
+
+function getNoteIndex(lectureId: string): number {
+  return demoLectureNotes.findIndex((item) => item.lecture_id === lectureId);
+}
+
+function getExtractionIndex(extractionId: string): number {
+  return demoAudioExtractions.findIndex((item) => item.id === extractionId);
+}
+
+function getPipelineIndex(lectureId: string): number {
+  return demoLecturePipelines.findIndex((item) => item.lecture_id === lectureId);
+}
+
+function upsertMemoryPipeline(partial: Partial<LecturePipeline> & { lecture_id: string }): LecturePipeline {
+  const existingIndex = getPipelineIndex(partial.lecture_id);
+  const base: LecturePipeline =
+    existingIndex >= 0
+      ? {
+          lecture_id: partial.lecture_id,
+          transcript_status: demoLecturePipelines[existingIndex]?.transcript_status ?? 'PENDING',
+          summary_status: demoLecturePipelines[existingIndex]?.summary_status ?? 'PENDING',
+          audio_status: demoLecturePipelines[existingIndex]?.audio_status ?? 'PENDING',
+          transcript_id: demoLecturePipelines[existingIndex]?.transcript_id ?? null,
+          note_id: demoLecturePipelines[existingIndex]?.note_id ?? null,
+          extraction_id: demoLecturePipelines[existingIndex]?.extraction_id ?? null,
+          updated_at: demoLecturePipelines[existingIndex]?.updated_at ?? now(),
+        }
+      : {
+          lecture_id: partial.lecture_id,
+          transcript_status: 'PENDING',
+          summary_status: 'PENDING',
+          audio_status: 'PENDING',
+          transcript_id: null,
+          note_id: null,
+          extraction_id: null,
+          updated_at: now(),
+        };
+
+  const next: LecturePipeline = {
+    ...base,
+    ...partial,
+    updated_at: now(),
+  };
+
+  if (existingIndex >= 0) {
+    demoLecturePipelines[existingIndex] = next;
+  } else {
+    demoLecturePipelines.push(next);
+  }
+
+  return next;
+}
+
+export const memoryMediaRepository: MediaRepository = {
+  getLectureTranscript(lectureId: string): LectureTranscript | undefined {
+    return demoLectureTranscripts.find((item) => item.lecture_id === lectureId);
+  },
+  listLectureTranscripts(lectureId: string): LectureTranscript[] {
+    return demoLectureTranscripts
+      .filter((item) => item.lecture_id === lectureId)
+      .sort((a, b) => b.created_at.localeCompare(a.created_at));
+  },
+  createLectureTranscript(
+    userId: string,
+    input: TranscriptCreateRequest,
+  ): { transcript: LectureTranscript; pipeline: LecturePipeline } | null {
+    const lecture = findLecture(input.lecture_id);
+    if (!lecture) {
+      return null;
+    }
+
+    const fullText = normalizeText(input.text || lecture.content_text || '');
+    if (!fullText) {
+      return null;
+    }
+
+    const fallbackDurationMs = Math.max(lecture.duration_minutes * 60_000, fullText.length * 40, 180_000);
+    const segments = input.segments?.length
+      ? input.segments.map((segment, index) => ({
+          index,
+          start_ms: Math.max(0, Math.round(segment.start_ms)),
+          end_ms: Math.max(Math.round(segment.start_ms), Math.round(segment.end_ms)),
+          text: normalizeText(segment.text),
+        }))
+      : splitIntoSegments(fullText, input.duration_ms ?? fallbackDurationMs);
+    const durationMs =
+      input.duration_ms ??
+      (segments.length > 0 ? segments[segments.length - 1]?.end_ms ?? fallbackDurationMs : fallbackDurationMs);
+    const wordCount =
+      input.word_count ??
+      fullText.split(/\s+/).filter(Boolean).length;
+    const transcript: LectureTranscript = {
+      id: createId('trs', demoLectureTranscripts.length),
+      lecture_id: lecture.id,
+      user_id: userId,
+      language: input.language ?? 'ko',
+      full_text: fullText,
+      segments,
+      word_count: wordCount,
+      duration_ms: durationMs,
+      stt_provider: input.stt_provider ?? (input.text ? 'text-derived-stt' : 'demo-stt'),
+      stt_model: input.stt_model ?? 'pseudo-stt-v1',
+      created_at: now(),
+    };
+
+    demoLectureTranscripts.push(transcript);
+    const pipeline = upsertMemoryPipeline({
+      lecture_id: lecture.id,
+      transcript_status: 'COMPLETED',
+      transcript_id: transcript.id,
+    });
+
+    return { transcript, pipeline };
+  },
+  listLectureNotes(lectureId: string): LectureNote[] {
+    return demoLectureNotes
+      .filter((item) => item.lecture_id === lectureId)
+      .sort((a, b) => b.created_at.localeCompare(a.created_at));
+  },
+  createLectureSummaryNote(
+    userId: string,
+    input: MediaSummaryRequest,
+  ): { note: LectureNote; pipeline: LecturePipeline; keyConcepts: string[]; keywords: string[] } | null {
+    const lecture = findLecture(input.lecture_id);
+    if (!lecture) {
+      return null;
+    }
+
+    const transcript = demoLectureTranscripts.find((item) => item.lecture_id === lecture.id);
+    const sourceText = transcript?.full_text ?? lecture.content_text;
+    const style = input.style ?? 'brief';
+    const keyConcepts = sourceText
+      .replaceAll(/\s+/g, ' ')
+      .split(/[.!?]\s+|,\s+/)
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .filter((part, index, self) => self.indexOf(part) === index)
+      .slice(0, style === 'detailed' ? 5 : 3);
+    const keywords = sourceText
+      .replaceAll(/\s+/g, ' ')
+      .toLowerCase()
+      .split(/[^a-zA-Z0-9가-힣]+/g)
+      .map((token) => token.trim())
+      .filter((token) => token.length > 1)
+      .slice(0, 5);
+    const summaryContent =
+      style === 'detailed'
+        ? sourceText
+            .replaceAll(/\s+/g, ' ')
+            .split(/[.!?]\s+/)
+            .map((sentence, index) => `${index + 1}. ${sentence.trim()}`)
+            .slice(0, 4)
+            .join('\n')
+        : style === 'timeline'
+          ? sourceText
+              .replaceAll(/\s+/g, ' ')
+              .split(/[.!?]\s+/)
+              .map((sentence, index) => `[${String(index).padStart(1, '0')}:00] ${sentence.trim()}`)
+              .slice(0, 4)
+              .join('\n')
+          : sourceText
+              .replaceAll(/\s+/g, ' ')
+              .split(/[.!?]\s+/)
+              .slice(0, 2)
+              .join(' ');
+
+    const noteType: LectureNote['note_type'] =
+      style === 'detailed' ? 'ai_detailed' : style === 'timeline' ? 'ai_timeline' : 'ai_summary';
+    const titleSuffix = style === 'detailed' ? '상세 요약' : style === 'timeline' ? '타임라인 요약' : '핵심 요약';
+    const note: LectureNote = {
+      id: createId('note', demoLectureNotes.length),
+      lecture_id: lecture.id,
+      user_id: userId,
+      note_type: noteType,
+      title: `${lecture.title} - ${titleSuffix}`,
+      content: summaryContent,
+      key_concepts: keyConcepts,
+      keywords,
+      timestamps: null,
+      language: input.language ?? 'ko',
+      ai_model: 'demo-summary-v1',
+      created_at: now(),
+    };
+
+    demoLectureNotes.push(note);
+    const pipeline = upsertMemoryPipeline({
+      lecture_id: lecture.id,
+      summary_status: 'COMPLETED',
+      note_id: note.id,
+    });
+
+    return { note, pipeline, keyConcepts, keywords };
+  },
+  listAudioExtractions(lectureId: string): AudioExtraction[] {
+    return demoAudioExtractions
+      .filter((item) => item.lecture_id === lectureId)
+      .sort((a, b) => b.created_at.localeCompare(a.created_at));
+  },
+  getAudioExtraction(extractionId: string): AudioExtraction | undefined {
+    return demoAudioExtractions.find((item) => item.id === extractionId);
+  },
+  createAudioExtraction(
+    userId: string,
+    input: AudioExtractionRequest,
+  ): { extraction: AudioExtraction; pipeline: LecturePipeline } | null {
+    const lecture = findLecture(input.lecture_id);
+    if (!lecture) {
+      return null;
+    }
+
+    const existingTranscript = demoLectureTranscripts.find((item) => item.lecture_id === lecture.id);
+    const extraction: AudioExtraction = {
+      id: createId('aud', demoAudioExtractions.length),
+      lecture_id: lecture.id,
+      user_id: userId,
+      source_type: 'video',
+      source_url: input.video_url ?? '/static/media/demo-lecture.mp4',
+      source_video_key: input.video_asset_key,
+      source_video_name: input.source_file_name,
+      source_content_type: input.source_content_type,
+      source_size_bytes: input.source_size_bytes,
+      language: input.language ?? 'ko',
+      requested_stt_provider: input.stt_provider,
+      requested_stt_model: input.stt_model,
+      processing_job_id: null,
+      processing_error: null,
+      audio_url: input.audio_url ?? null,
+      audio_format: input.audio_url ? inferAudioFormat(input.audio_url) : 'pending',
+      audio_duration_ms: Math.max(lecture.duration_minutes * 60_000, 30_000),
+      sample_rate: 16_000,
+      channels: 1,
+      status: input.audio_url ? 'COMPLETED' : 'PROCESSING',
+      transcript_id: existingTranscript?.id ?? null,
+      stt_status: existingTranscript ? 'COMPLETED' : input.audio_url ? 'PROCESSING' : 'PENDING',
+      created_at: now(),
+      processed_at: input.audio_url ? now() : null,
+      updated_at: now(),
+    };
+
+    demoAudioExtractions.push(extraction);
+    const pipeline = upsertMemoryPipeline({
+      lecture_id: lecture.id,
+      audio_status: extraction.status,
+      extraction_id: extraction.id,
+    });
+
+    return { extraction, pipeline };
+  },
+  updateAudioExtraction(
+    input: AudioExtractionCallbackRequest & {
+      transcript_id?: string | null;
+      stt_status?: AudioExtraction['stt_status'];
+    },
+  ): { extraction: AudioExtraction; pipeline: LecturePipeline } | null {
+    const targetIndex = demoAudioExtractions.findIndex((item) => item.id === input.extraction_id && item.lecture_id === input.lecture_id);
+    if (targetIndex < 0) {
+      return null;
+    }
+
+    const current = demoAudioExtractions[targetIndex];
+    const nextStatus = input.status;
+    const next: AudioExtraction = {
+      ...current,
+      processing_job_id: input.processing_job_id ?? current.processing_job_id ?? null,
+      processing_error: input.error_message ?? (nextStatus === 'FAILED' ? '오디오 추출에 실패했습니다.' : null),
+      audio_url: input.audio_url ?? current.audio_url ?? null,
+      audio_format: input.audio_format ?? (input.audio_url ? inferAudioFormat(input.audio_url) : current.audio_format),
+      audio_duration_ms: input.audio_duration_ms ?? current.audio_duration_ms,
+      sample_rate: input.sample_rate ?? current.sample_rate,
+      channels: input.channels ?? current.channels,
+      status: nextStatus,
+      transcript_id: input.transcript_id ?? current.transcript_id,
+      stt_status:
+        input.stt_status ??
+        (nextStatus === 'FAILED'
+          ? 'FAILED'
+          : input.transcript_id
+            ? 'COMPLETED'
+            : current.stt_status),
+      processed_at: nextStatus === 'COMPLETED' ? now() : current.processed_at ?? null,
+      updated_at: now(),
+    };
+
+    demoAudioExtractions[targetIndex] = next;
+    const pipeline = upsertMemoryPipeline({
+      lecture_id: next.lecture_id,
+      audio_status: next.status,
+      extraction_id: next.id,
+      transcript_status: next.transcript_id ? 'COMPLETED' : next.stt_status,
+      transcript_id: next.transcript_id,
+    });
+
+    return { extraction: next, pipeline };
+  },
+  getLecturePipeline(lectureId: string): LecturePipeline {
+    const existing = demoLecturePipelines.find((item) => item.lecture_id === lectureId);
+
+    if (existing) {
+      return existing;
+    }
+
+    const transcript = demoLectureTranscripts.find((item) => item.lecture_id === lectureId);
+    const notes = demoLectureNotes.filter((item) => item.lecture_id === lectureId);
+    const extractions = demoAudioExtractions.filter((item) => item.lecture_id === lectureId);
+    const latestExtraction = extractions[0];
+
+    return {
+      lecture_id: lectureId,
+      transcript_status: transcript ? 'COMPLETED' : 'PENDING',
+      summary_status: notes.length > 0 ? 'COMPLETED' : 'PENDING',
+      audio_status: latestExtraction?.status ?? 'PENDING',
+      transcript_id: transcript?.id ?? null,
+      note_id: notes[0]?.id ?? null,
+      extraction_id: latestExtraction?.id ?? null,
+      updated_at: now(),
+    };
+  },
+  upsertPipeline(partial: Partial<LecturePipeline> & { lecture_id: string }): LecturePipeline {
+    return upsertMemoryPipeline(partial);
+  },
+};

--- a/packages/shared/src/lms/media/summary.ts
+++ b/packages/shared/src/lms/media/summary.ts
@@ -1,75 +1,20 @@
-import { demoLectureNotes } from '../../data/demo-data';
-import type { LectureNote, MediaSummaryRequest } from '../../types';
-import {
-  buildTimelineMarkers,
-  extractKeyConcepts,
-  extractKeywords,
-  findLecture,
-  normalizeText,
-  splitIntoSegments,
-  summarizeByStyle,
-  upsertPipeline,
-  now,
-  createId,
-} from './helpers';
-import { getLectureTranscript } from './transcript';
+import type { LectureNote, LecturePipeline, MediaSummaryRequest } from '../../types';
+import { memoryMediaRepository, type MediaRepository } from './store';
 
-export function listLectureNotes(lectureId: string): LectureNote[] {
-  return demoLectureNotes
-    .filter((item) => item.lecture_id === lectureId)
-    .sort((a, b) => b.created_at.localeCompare(a.created_at));
+export async function listLectureNotes(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<LectureNote[]> {
+  return await repository.listLectureNotes(lectureId);
 }
 
-export function createLectureSummaryNote(
+export async function createLectureSummaryNote(
   userId: string,
   input: MediaSummaryRequest,
-): { note: LectureNote; pipeline: ReturnType<typeof upsertPipeline>; keyConcepts: string[]; keywords: string[] } | null {
-  const lecture = findLecture(input.lecture_id);
-  if (!lecture) {
-    return null;
-  }
-
-  const transcript = getLectureTranscript(lecture.id);
-  const sourceText = transcript?.full_text ?? lecture.content_text;
-  const style = input.style ?? 'brief';
-  const keyConcepts = extractKeyConcepts(sourceText, style === 'detailed' ? 5 : 3);
-  const keywords = extractKeywords(sourceText, 5);
-  const summaryContent = summarizeByStyle(sourceText, style);
-  const timestamps = style === 'timeline'
-    ? buildTimelineMarkers(transcript?.segments ?? splitIntoSegments(sourceText, Math.max(lecture.duration_minutes * 60_000, 180_000)))
-    : null;
-
-  let noteType: LectureNote['note_type'] = 'ai_summary';
-  let titleSuffix = '핵심 요약';
-  if (style === 'detailed') {
-    noteType = 'ai_detailed';
-    titleSuffix = '상세 요약';
-  } else if (style === 'timeline') {
-    noteType = 'ai_timeline';
-    titleSuffix = '타임라인 요약';
-  }
-
-  const note: LectureNote = {
-    id: createId('note', demoLectureNotes.length),
-    lecture_id: lecture.id,
-    user_id: userId,
-    note_type: noteType,
-    title: `${lecture.title} - ${titleSuffix}`,
-    content: summaryContent,
-    key_concepts: keyConcepts,
-    keywords,
-    timestamps,
-    language: input.language ?? 'ko',
-    ai_model: 'demo-summary-v1',
-    created_at: now(),
-  };
-
-  demoLectureNotes.push(note);
-  const pipeline = upsertPipeline({
-    lecture_id: lecture.id,
-    summary_status: 'COMPLETED',
-    note_id: note.id,
-  });
-
-  return { note, pipeline, keyConcepts, keywords };
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<
+  | { note: LectureNote; pipeline: LecturePipeline; keyConcepts: string[]; keywords: string[] }
+  | null
+> {
+  return await repository.createLectureSummaryNote(userId, input);
 }

--- a/packages/shared/src/lms/media/transcript.ts
+++ b/packages/shared/src/lms/media/transcript.ts
@@ -1,66 +1,24 @@
-import { demoLectureTranscripts } from '../../data/demo-data';
-import type { LectureTranscript, TranscriptCreateRequest } from '../../types';
-import { createId, findLecture, now, splitIntoSegments, upsertPipeline, normalizeText } from './helpers';
+import type { LecturePipeline, LectureTranscript, TranscriptCreateRequest } from '../../types';
+import { memoryMediaRepository, type MediaRepository } from './store';
 
-export function getLectureTranscript(lectureId: string): LectureTranscript | undefined {
-  return demoLectureTranscripts.find((item) => item.lecture_id === lectureId);
+export async function getLectureTranscript(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<LectureTranscript | undefined> {
+  return await repository.getLectureTranscript(lectureId);
 }
 
-export function listLectureTranscripts(lectureId: string): LectureTranscript[] {
-  return demoLectureTranscripts
-    .filter((item) => item.lecture_id === lectureId)
-    .sort((a, b) => b.created_at.localeCompare(a.created_at));
+export async function listLectureTranscripts(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<LectureTranscript[]> {
+  return await repository.listLectureTranscripts(lectureId);
 }
 
-export function createLectureTranscript(
+export async function createLectureTranscript(
   userId: string,
   input: TranscriptCreateRequest,
-): { transcript: LectureTranscript; pipeline: ReturnType<typeof upsertPipeline> } | null {
-  const lecture = findLecture(input.lecture_id);
-  if (!lecture) {
-    return null;
-  }
-
-  const fullText = normalizeText(input.text || lecture.content_text || '');
-  if (!fullText) {
-    return null;
-  }
-
-  const fallbackDurationMs = Math.max(lecture.duration_minutes * 60_000, fullText.length * 40, 180_000);
-  const segments = input.segments?.length
-    ? input.segments.map((segment, index) => ({
-        index,
-        start_ms: Math.max(0, Math.round(segment.start_ms)),
-        end_ms: Math.max(Math.round(segment.start_ms), Math.round(segment.end_ms)),
-        text: normalizeText(segment.text),
-      }))
-    : splitIntoSegments(fullText, input.duration_ms ?? fallbackDurationMs);
-  const durationMs =
-    input.duration_ms ??
-    (segments.length > 0 ? segments[segments.length - 1]?.end_ms ?? fallbackDurationMs : fallbackDurationMs);
-  const wordCount =
-    input.word_count ??
-    fullText.split(/\s+/).filter(Boolean).length;
-  const transcript: LectureTranscript = {
-    id: createId('trs', demoLectureTranscripts.length),
-    lecture_id: lecture.id,
-    user_id: userId,
-    language: input.language ?? 'ko',
-    full_text: fullText,
-    segments,
-    word_count: wordCount,
-    duration_ms: durationMs,
-    stt_provider: input.stt_provider ?? (input.text ? 'text-derived-stt' : 'demo-stt'),
-    stt_model: input.stt_model ?? 'pseudo-stt-v1',
-    created_at: now(),
-  };
-
-  demoLectureTranscripts.push(transcript);
-  const pipeline = upsertPipeline({
-    lecture_id: lecture.id,
-    transcript_status: 'COMPLETED',
-    transcript_id: transcript.id,
-  });
-
-  return { transcript, pipeline };
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<{ transcript: LectureTranscript; pipeline: LecturePipeline } | null> {
+  return await repository.createLectureTranscript(userId, input);
 }

--- a/packages/shared/src/rag/chunking.ts
+++ b/packages/shared/src/rag/chunking.ts
@@ -1,198 +1,38 @@
-import { demoLectures } from '../data/demo-data';
-import { getCourseLectures, getLectureDetail } from '../lms/learning';
-import { getLectureTranscript, listLectureNotes } from '../lms/media';
 import type { AIRagChunk, AIRagRequest } from '../types';
+import { memoryMediaRepository, type MediaRepository } from '../lms/media';
+import {
+  buildChunkText as buildChunkTextFromIntentCorpus,
+  buildCorpus as buildIntentCorpus,
+  buildCorpusForCourse as buildIntentCorpusForCourse,
+  buildCorpusForLecture as buildIntentCorpusForLecture,
+  rankChunks as rankIntentChunks,
+} from '../ai/intent/corpus';
 
-const STOP_WORDS = new Set([
-  '그리고', '하지만', '때문에', '정리', '설명', '강의', '내용', '질문', '답변',
-  'the', 'and', 'for', 'with', 'that', 'this', 'from', 'about', 'into',
-]);
-
-function normalizeText(text: string): string {
-  return text.replaceAll(/\s+/g, ' ').trim();
+export function buildChunkText(text: string, maxChunks = 3): string[] {
+  return buildChunkTextFromIntentCorpus(text, maxChunks);
 }
 
-function tokenize(text: string): string[] {
-  return normalizeText(text)
-    .toLowerCase()
-    .split(/[^a-zA-Z0-9가-힣]+/g)
-    .map((token) => token.trim())
-    .filter((token) => token.length > 1 && !STOP_WORDS.has(token));
-}
-
-function splitSentences(text: string): string[] {
-  return normalizeText(text)
-    .split(/[.!?]\s+|\n+/)
-    .map((sentence) => sentence.trim())
-    .filter(Boolean);
-}
-
-function createChunkText(sentences: string[], maxChunks: number): string[] {
-  if (sentences.length === 0) {
-    return [];
-  }
-
-  const chunkSize = Math.max(1, Math.ceil(sentences.length / Math.max(1, maxChunks)));
-  const chunks: string[] = [];
-
-  for (let index = 0; index < sentences.length; index += chunkSize) {
-    chunks.push(sentences.slice(index, index + chunkSize).join(' '));
-  }
-
-  return chunks.filter(Boolean);
-}
-
-function countTokens(text: string): number {
-  return tokenize(text).length;
-}
-
-function createHit(
+export async function buildCorpusForLecture(
   lectureId: string,
-  sourceType: AIRagChunk['source_scope'],
-  sourceId: string,
-  title: string,
-  content: string,
-  chunkIndex: number,
-  extra: Pick<AIRagChunk, 'token_count' | 'source_scope'> & Partial<Pick<AIRagChunk, 'start_ms' | 'end_ms'>>,
-): AIRagChunk {
-  return {
-    id: `${sourceType}_${sourceId}_${String(chunkIndex + 1).padStart(2, '0')}`,
-    lecture_id: lectureId,
-    source_type: sourceType,
-    source_id: sourceId,
-    title,
-    content: content.slice(0, 240),
-    excerpt: content.slice(0, 240),
-    similarity: 0,
-    chunk_index: chunkIndex,
-    ...extra,
-  };
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIRagChunk[]> {
+  return await buildIntentCorpusForLecture(lectureId, repository);
 }
 
-export function buildCorpusForLecture(lectureId: string): AIRagChunk[] {
-  const lecture = getLectureDetail(lectureId);
-  if (!lecture) {
-    return [];
-  }
-
-  const transcript = getLectureTranscript(lectureId);
-  const note = listLectureNotes(lectureId)[0];
-  const chunks: AIRagChunk[] = [];
-
-  const lectureChunks = createChunkText(splitSentences(`${lecture.title}. ${lecture.content_text}`), 2);
-  lectureChunks.forEach((chunk, index) => {
-    chunks.push(
-      createHit(
-        lecture.id,
-        'lecture',
-        lecture.id,
-        `${lecture.course_title} · ${lecture.title} · 강의 본문`,
-        chunk,
-        index,
-        {
-          token_count: countTokens(chunk),
-          source_scope: 'lecture',
-        },
-      ),
-    );
-  });
-
-  transcript?.segments.forEach((segment) => {
-    const content = normalizeText(segment.text);
-    if (!content) {
-      return;
-    }
-
-    chunks.push(
-      createHit(
-        lecture.id,
-        'transcript',
-        transcript.id,
-        `${lecture.title} · 트랜스크립트`,
-        content,
-        segment.index,
-        {
-          token_count: countTokens(content),
-          source_scope: 'transcript',
-          start_ms: segment.start_ms,
-          end_ms: segment.end_ms,
-        },
-      ),
-    );
-  });
-
-  if (note) {
-    const noteChunks = createChunkText(splitSentences(`${note.title}. ${note.content}`), 2);
-    noteChunks.forEach((chunk, index) => {
-      chunks.push(
-        createHit(
-          lecture.id,
-          'note',
-          note.id,
-          `${lecture.title} · 요약 노트`,
-          chunk,
-          index,
-          {
-            token_count: countTokens(chunk),
-            source_scope: 'note',
-          },
-        ),
-      );
-    });
-  }
-
-  return chunks;
+export async function buildCorpusForCourse(
+  courseId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIRagChunk[]> {
+  return await buildIntentCorpusForCourse(courseId, repository);
 }
 
-export function buildCorpusForCourse(courseId: string): AIRagChunk[] {
-  return getCourseLectures(courseId).flatMap((lecture) => buildCorpusForLecture(lecture.id));
+export async function buildCorpus(
+  input: AIRagRequest,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIRagChunk[]> {
+  return await buildIntentCorpus(input, repository);
 }
 
-export function buildCorpus(input: AIRagRequest): AIRagChunk[] {
-  if (input.lecture_id) {
-    return buildCorpusForLecture(input.lecture_id);
-  }
-
-  if (input.course_id) {
-    return buildCorpusForCourse(input.course_id);
-  }
-
-  return demoLectures.flatMap((lecture) => buildCorpusForLecture(lecture.id));
-}
-
-function scoreChunk(queryTokens: string[], query: string, chunk: AIRagChunk): number {
-  if (queryTokens.length === 0) {
-    if (chunk.source_scope === 'transcript') {
-      return 0.62;
-    }
-    if (chunk.source_scope === 'note') {
-      return 0.58;
-    }
-    return 0.55;
-  }
-
-  const haystackTokens = tokenize(`${chunk.title} ${chunk.content}`);
-  const overlap = queryTokens.filter((token) => haystackTokens.includes(token)).length;
-  const coverage = overlap / Math.max(3, queryTokens.length);
-  const exactMatch = normalizeText(chunk.content).includes(normalizeText(query)) ? 0.14 : 0;
-  const titleBoost = normalizeText(chunk.title).includes(normalizeText(query)) ? 0.06 : 0;
-  let scopeBoost = 0;
-  if (chunk.source_scope === 'transcript') {
-    scopeBoost = 0.05;
-  } else if (chunk.source_scope === 'note') {
-    scopeBoost = 0.03;
-  }
-  return Math.min(0.99, coverage + exactMatch + titleBoost + scopeBoost);
-}
-
-export function rankChunks(query: string, chunks: AIRagChunk[], limit: number): AIRagChunk[] {
-  const queryTokens = tokenize(query);
-  const rankedChunks = chunks
-    .map((chunk) => ({
-      ...chunk,
-      similarity: scoreChunk(queryTokens, query, chunk),
-    }))
-    .filter((chunk) => chunk.similarity > 0 || queryTokens.length === 0);
-  rankedChunks.sort((left, right) => right.similarity - left.similarity || left.title.localeCompare(right.title));
-  return rankedChunks.slice(0, limit);
+export async function rankChunks(query: string, chunks: AIRagChunk[], limit: number): Promise<AIRagChunk[]> {
+  return await rankIntentChunks(query, chunks, limit);
 }

--- a/packages/shared/src/rag/pipeline.ts
+++ b/packages/shared/src/rag/pipeline.ts
@@ -1,6 +1,7 @@
 import { demoCourses } from '../data/demo-data';
 import { getLectureDetail } from '../lms/learning';
 import { classifyAIIntent } from '../ai/ai-intent';
+import { memoryMediaRepository, type MediaRepository } from '../lms/media';
 import type {
   AIAnswerResult,
   AIIntentResult,
@@ -23,7 +24,7 @@ function resolveLabel(input: AIRagRequest): string {
   return '현재 강의';
 }
 
-function buildSearchResult(query: string, lectureId: string | null, chunks: ReturnType<typeof rankChunks>): AISearchResult {
+function buildSearchResult(query: string, lectureId: string | null, chunks: Awaited<ReturnType<typeof rankChunks>>): AISearchResult {
   return {
     query,
     lecture_id: lectureId,
@@ -35,7 +36,7 @@ function buildAnswerResult(
   query: string,
   lectureId: string | null,
   intent: AIIntentResult,
-  chunks: ReturnType<typeof rankChunks>,
+  chunks: Awaited<ReturnType<typeof rankChunks>>,
   label: string,
 ): AIAnswerResult {
   return {
@@ -48,14 +49,17 @@ function buildAnswerResult(
   };
 }
 
-export function buildAIRAGOverview(input: AIRagRequest): AIRagResult {
+export async function buildAIRAGOverview(
+  input: AIRagRequest,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<AIRagResult> {
   const query = input.query.replaceAll(/\s+/g, ' ').trim();
   const intent = classifyAIIntent({
     message: query,
     lecture_id: input.lecture_id,
     context: input.context,
   });
-  const chunks = rankChunks(query, buildCorpus(input), Math.max(1, Math.min(6, input.limit ?? 4)));
+  const chunks = await rankChunks(query, await buildCorpus(input, repository), Math.max(1, Math.min(6, input.limit ?? 4)));
   const label = resolveLabel(input);
 
   return {
@@ -71,16 +75,16 @@ export function buildAIRAGOverview(input: AIRagRequest): AIRagResult {
   };
 }
 
-export function collectAIRagChunks(input: AIRagRequest) {
-  return buildCorpus(input);
+export async function collectAIRagChunks(input: AIRagRequest, repository: MediaRepository = memoryMediaRepository) {
+  return await buildCorpus(input, repository);
 }
 
 export function collectAIRagEntities(input: AIRagRequest) {
   return extractEntities(input);
 }
 
-export function buildAIRagSearch(input: AIRagRequest): AISearchResult {
+export async function buildAIRagSearch(input: AIRagRequest, repository: MediaRepository = memoryMediaRepository): Promise<AISearchResult> {
   const query = input.query.replaceAll(/\s+/g, ' ').trim();
-  const chunks = rankChunks(query, buildCorpus(input), Math.max(1, Math.min(6, input.limit ?? 4)));
+  const chunks = await rankChunks(query, await buildCorpus(input, repository), Math.max(1, Math.min(6, input.limit ?? 4)));
   return buildSearchResult(query, input.lecture_id ?? null, chunks);
 }


### PR DESCRIPTION
## Summary
- Move lecture transcripts, notes, audio extractions, and lecture pipeline state into D1-backed storage.
- Keep R2 for uploaded video assets and reserve the quota D1 for usage control.
- Preserve the memory repository as a fallback for dev/demo flows.

## Verification
- npm run verify
- npm --workspace @myway/backend run build
- Applied the D1 migration to myway-class-data remotely

## Related
- Closes #139
- Follows #138 for D1 binding setup