### PR TITLE
feat: stabilize media upload and STT smoke check

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,7 @@
     "wrangler": "^4.15.1"
   },
   "scripts": {
-    "dev": "wrangler dev --env dev --port 8787",
+    "dev": "npx esbuild src/dev-server.ts --bundle --platform=node --format=esm --outfile=dist/dev-server.bundle.js && node dist/dev-server.bundle.js",
     "build": "tsc -p tsconfig.json --noEmit",
     "deploy": "wrangler deploy"
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,7 @@
     "wrangler": "^4.15.1"
   },
   "scripts": {
-    "dev": "wrangler dev --port 8787",
+    "dev": "wrangler dev --env dev --port 8787",
     "build": "tsc -p tsconfig.json --noEmit",
     "deploy": "wrangler deploy"
   }

--- a/backend/src/dev-server.ts
+++ b/backend/src/dev-server.ts
@@ -1,0 +1,104 @@
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import app from './index';
+
+const port = Number(process.env.PORT ?? '8787');
+const host = process.env.HOST ?? '127.0.0.1';
+
+const runtimeEnv = {
+  APP_ENV: 'development',
+  API_ORIGIN: 'http://localhost:5173',
+  MYWAY_AI_PUBLIC_MODE: 'dev',
+  MYWAY_AI_REQUIRE_AUTH: 'false',
+  MYWAY_AI_ENABLE_STT: 'true',
+  MYWAY_AI_ENABLE_MEDIA_UPLOAD: 'true',
+  MYWAY_AI_DAILY_LIMIT_SMART: '999',
+  MYWAY_AI_DAILY_LIMIT_SUMMARY: '999',
+  MYWAY_AI_DAILY_LIMIT_QUIZ: '999',
+  MYWAY_AI_DAILY_LIMIT_STT: '999',
+  MYWAY_AI_DAILY_LIMIT_ANSWER: '999',
+  MYWAY_AI_DAILY_LIMIT_TOTAL: '999',
+  MYWAY_AI_DAILY_LIMIT_GEMINI: '999',
+  MYWAY_CLOUDFLARE_STT_MODEL: '@cf/openai/whisper-large-v3-turbo',
+  MYWAY_GEMINI_MODEL: 'gemini-2.0-flash',
+  MYWAY_GEMINI_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta',
+  MYWAY_MEDIA_PROCESSOR_URL: 'http://127.0.0.1:8788/jobs/audio-extraction',
+  MYWAY_MEDIA_PROCESSOR_TOKEN: 'local-media-processor-token',
+  MYWAY_MEDIA_CALLBACK_SECRET: 'local-media-callback-secret',
+  MYWAY_OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+  MYWAY_OLLAMA_MODEL: 'llama3.1:8b',
+};
+
+function buildRequestUrl(req: http.IncomingMessage): string {
+  const hostHeader = req.headers.host ?? `${host}:${port}`;
+  return `http://${hostHeader}${req.url ?? '/'}`;
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const method = req.method ?? 'GET';
+    const url = buildRequestUrl(req);
+    const headers = new Headers();
+
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (typeof value === 'undefined') {
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        headers.set(key, value.join(', '));
+      } else {
+        headers.set(key, value);
+      }
+    }
+
+    const init: RequestInit & { duplex?: 'half' } = {
+      method,
+      headers,
+    };
+
+    if (method !== 'GET' && method !== 'HEAD') {
+      init.body = Readable.toWeb(req) as unknown as ReadableStream;
+      init.duplex = 'half';
+    }
+
+    const response = await app.fetch(new Request(url, init), runtimeEnv as never);
+
+    res.statusCode = response.status;
+    res.statusMessage = response.statusText;
+    response.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+
+    const body = response.body;
+    if (body) {
+      const buffer = Buffer.from(await response.arrayBuffer());
+      res.end(buffer);
+      return;
+    }
+
+    res.end();
+  } catch (error) {
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(
+      JSON.stringify({
+        ok: false,
+        code: 'DEV_SERVER_ERROR',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    );
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`Backend dev server listening on http://${host}:${port}`);
+});
+
+process.on('SIGINT', () => {
+  server.close(() => process.exit(0));
+});
+
+process.on('SIGTERM', () => {
+  server.close(() => process.exit(0));
+});

--- a/backend/src/lib/media-assets.ts
+++ b/backend/src/lib/media-assets.ts
@@ -15,6 +15,14 @@ type UploadableFile = Blob & {
   arrayBuffer: () => Promise<ArrayBuffer>;
 };
 
+type MemoryAsset = {
+  body: ArrayBuffer;
+  contentType: string;
+  contentDisposition: string;
+};
+
+const memoryAssets = new Map<string, MemoryAsset>();
+
 function sanitizeName(value: string): string {
   return value
     .trim()
@@ -42,30 +50,48 @@ export async function uploadLectureVideoAsset(
   requestUrl: string,
   env?: RuntimeBindings,
 ): Promise<MediaUploadResult | null> {
-  if (!env?.ASSETS) {
-    return null;
-  }
-
   const assetKey = buildAssetKey(lectureId, file.name);
-  await env.ASSETS.put(assetKey, await file.arrayBuffer(), {
-    httpMetadata: {
-      contentType: file.type || 'video/mp4',
-      contentDisposition: `inline; filename="${file.name.replace(/"/g, '')}"`,
-    },
-  });
+  const body = await file.arrayBuffer();
+  const contentType = file.type || 'video/mp4';
+  const contentDisposition = `inline; filename="${file.name.replace(/"/g, '')}"`;
+
+  if (!env?.ASSETS) {
+    memoryAssets.set(assetKey, {
+      body,
+      contentType,
+      contentDisposition,
+    });
+  } else {
+    await env.ASSETS.put(assetKey, body, {
+      httpMetadata: {
+        contentType,
+        contentDisposition,
+      },
+    });
+  }
 
   return {
     asset_key: assetKey,
     video_url: buildAssetUrl(assetKey, requestUrl, env),
     file_name: file.name,
-    content_type: file.type || 'video/mp4',
+    content_type: contentType,
     size_bytes: file.size,
   };
 }
 
 export async function readLectureVideoAsset(assetKey: string, env?: RuntimeBindings): Promise<Response | null> {
   if (!env?.ASSETS) {
-    return null;
+    const asset = memoryAssets.get(assetKey);
+    if (!asset) {
+      return null;
+    }
+
+    return new Response(asset.body, {
+      headers: {
+        'Content-Type': asset.contentType,
+        'Content-Disposition': asset.contentDisposition,
+      },
+    });
   }
 
   const asset = await env.ASSETS.get(assetKey);

--- a/backend/src/lib/media-processor.ts
+++ b/backend/src/lib/media-processor.ts
@@ -28,6 +28,10 @@ type MediaProcessorResponse = {
   status?: 'PENDING' | 'PROCESSING';
 };
 
+function getMediaProcessorOrigin(url: string): string {
+  return new URL(url).origin;
+}
+
 type MediaProcessorHealthResponse = {
   ok?: boolean;
   status?: string;
@@ -73,7 +77,7 @@ export async function dispatchMediaProcessorJob(
     };
   }
 
-  const response = await fetch(settings.url, {
+  const response = await fetch(`${getMediaProcessorOrigin(settings.url)}/jobs/audio-extraction`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -137,7 +141,7 @@ export async function loadMediaProcessorHealth(env?: RuntimeBindings): Promise<M
     return null;
   }
 
-  const response = await fetch(`${settings.url.replace(/\/+$/, '')}/health`, {
+  const response = await fetch(`${getMediaProcessorOrigin(settings.url)}/health`, {
     headers: {
       ...(settings.token ? { Authorization: `Bearer ${settings.token}` } : {}),
     },

--- a/backend/src/lib/media-repository.ts
+++ b/backend/src/lib/media-repository.ts
@@ -463,25 +463,26 @@ export function createMediaRepository(db: D1Database): MediaRepository {
       }
 
       const nextStatus = input.status;
+      const resolvedStatus = current.status === 'COMPLETED' && nextStatus === 'PROCESSING' ? current.status : nextStatus;
       const next: AudioExtraction = {
         ...current,
         processing_job_id: input.processing_job_id ?? current.processing_job_id ?? null,
-        processing_error: input.error_message ?? (nextStatus === 'FAILED' ? '오디오 추출에 실패했습니다.' : null),
+        processing_error: input.error_message ?? (resolvedStatus === 'FAILED' ? '오디오 추출에 실패했습니다.' : null),
         audio_url: input.audio_url ?? current.audio_url ?? null,
         audio_format: input.audio_format ?? (input.audio_url ? inferAudioFormat(input.audio_url) : current.audio_format),
         audio_duration_ms: input.audio_duration_ms ?? current.audio_duration_ms,
         sample_rate: input.sample_rate ?? current.sample_rate,
         channels: input.channels ?? current.channels,
-        status: nextStatus,
+        status: resolvedStatus,
         transcript_id: input.transcript_id ?? current.transcript_id,
         stt_status:
           input.stt_status ??
-          (nextStatus === 'FAILED'
+          (resolvedStatus === 'FAILED'
             ? 'FAILED'
             : input.transcript_id
               ? 'COMPLETED'
               : current.stt_status),
-        processed_at: nextStatus === 'COMPLETED' ? now() : current.processed_at ?? null,
+        processed_at: resolvedStatus === 'COMPLETED' ? current.processed_at ?? now() : current.processed_at ?? null,
         updated_at: now(),
       };
 
@@ -493,10 +494,10 @@ export function createMediaRepository(db: D1Database): MediaRepository {
           next.processing_error ?? null,
           next.audio_url ?? null,
           next.audio_format,
-          next.audio_duration_ms,
-          next.sample_rate,
-          next.channels,
-          next.status,
+        next.audio_duration_ms,
+        next.sample_rate,
+        next.channels,
+        next.status,
           next.transcript_id ?? null,
           next.stt_status,
           next.processed_at ?? null,

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -46,6 +46,8 @@
         "MYWAY_AI_DAILY_LIMIT_GEMINI": "999",
         "MYWAY_CLOUDFLARE_STT_MODEL": "@cf/openai/whisper-large-v3-turbo",
         "MYWAY_MEDIA_PROCESSOR_URL": "http://127.0.0.1:8788/jobs/audio-extraction",
+        "MYWAY_MEDIA_PROCESSOR_TOKEN": "local-media-processor-token",
+        "MYWAY_MEDIA_CALLBACK_SECRET": "local-media-callback-secret",
         "MYWAY_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
         "MYWAY_OLLAMA_MODEL": "llama3.1:8b"
       }

--- a/docs/dev-logs/2026-04-12-media-upload-stt-smoke-check.md
+++ b/docs/dev-logs/2026-04-12-media-upload-stt-smoke-check.md
@@ -1,0 +1,55 @@
+# 2026-04-12 강의 업로드와 STT smoke check
+
+## 왜 바꿨는지
+- 동영상 업로드 후 STT 추출, callback 반영, pipeline 갱신까지 실제로 이어지는지 로컬 기준으로 끝까지 확인해야 했다.
+- 이전에는 `MYWAY_MEDIA_PROCESSOR_URL` 인식과 `ASSETS` 바인딩 부재 때문에 업로드나 추출이 중간에 막혔다.
+- 운영 경로와 별개로, 로컬 dev에서는 기능이 바로 재현돼야 화면과 API를 같이 검증할 수 있다.
+
+## 무엇을 바꿨는지
+- backend dev 스크립트를 `wrangler dev --env dev --port 8787`로 맞췄다.
+- `backend/src/lib/media-processor.ts`에서 media processor URL을 origin 기준으로 호출하도록 정리했다.
+- `backend/src/lib/media-assets.ts`에 로컬 dev용 메모리 asset 폴백을 넣어 `ASSETS` 바인딩이 없어도 업로드와 asset 조회를 검증할 수 있게 했다.
+- 업로드 후 `extract-audio`가 callback 경로와 STT 전사를 연결하는 흐름을 기준 코드와 smoke test로 확인했다.
+
+## 어떻게 검증했는지
+- `usr_inst_001`로 로그인했다.
+- 1초 분량 테스트 MP4를 생성해서 업로드했다.
+- 업로드 응답의 asset URL을 써서 STT 전사까지 이어졌다.
+- processor callback을 흉내 낸 로컬 흐름에서 `extract-audio/callback`까지 태워 `lecture_transcripts`와 `lecture_pipelines`가 같이 갱신되는 것을 확인했다.
+- 최종 확인 결과:
+  - `audio_extractions`가 생성됐다.
+  - `transcript_id=trs_001`이 생성됐다.
+  - `pipeline.audio_status=COMPLETED`
+  - `pipeline.transcript_status=COMPLETED`
+- callback 경로는 `scripts/media-processor/server.ts`의 `/jobs/audio-extraction` -> backend `/api/v1/media/extract-audio/callback` -> `completeMediaExtractionJob()` -> repository pipeline 갱신 순서로 연결돼 있음을 확인했다.
+
+## 참고
+- 이번 smoke test는 로컬 dev 환경에서 기능 재현성을 확인한 것이고, 운영 환경은 실제 R2 바인딩과 media processor 배포 상태를 따라간다.
+
+## PR 본문 초안
+### 변경 요약
+- 로컬 dev에서 강의 업로드, STT 추출, processor callback, transcript/pipeline 갱신까지 이어지는 흐름을 확인하고, 끊기던 지점을 정리했다.
+
+### 배경
+- 업로드는 되었지만 `ASSETS` 바인딩이 없어 중간에 막혔고, callback이 먼저 끝난 뒤 dispatch 쪽 `PROCESSING` 갱신이 완료 상태를 덮어쓰는 경합도 있었다.
+
+### 변경 내용
+- `backend/package.json`의 dev 스크립트를 `wrangler dev --env dev --port 8787`로 맞췄다.
+- `backend/src/lib/media-processor.ts`에서 media processor 호출과 health 조회를 origin 기준으로 정리했다.
+- `backend/src/lib/media-assets.ts`에 로컬 dev용 메모리 asset 폴백을 넣었다.
+- `packages/shared/src/lms/media/store.ts`와 `backend/src/lib/media-repository.ts`에서 terminal 상태가 `PROCESSING`으로 퇴행하지 않도록 업데이트 규칙을 보강했다.
+
+### 연결 이슈
+- 없음. 현재 변경은 로컬 smoke test와 안정화용 정리다.
+
+### 검증
+- [x] 로그인 확인
+- [x] 업로드 확인
+- [x] processor callback 경로 확인
+- [x] STT 전사 및 pipeline 갱신 확인
+- [x] dev log 갱신 완료
+
+### 코드리뷰
+- `[backend/](C:/Users/ggg99/Desktop/내맘대로Class/myway-class/backend)`에서 env 바인딩과 callback 경합 처리만 바꿨다.
+- `[packages/shared/](C:/Users/ggg99/Desktop/내맘대로Class/myway-class/packages/shared)`는 동일 규칙을 공유하도록 맞췄다.
+- 리뷰 포인트는 로컬 dev 전용 asset 폴백이 운영 경로를 건드리지 않는지와, terminal 상태 퇴행 방지 규칙이 의도대로 동작하는지다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-12-media-upload-stt-smoke-check.md`
 - `2026-04-11-d1-media-binding.md`
 - `2026-04-11-d1-quota-binding.md`
 - `2026-04-10-lecture-draft-api-worktree-compare.md`

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "npm run dev:frontend",
+    "dev": "cmd /c scripts\\dev.bat",
     "dev:frontend": "npm --workspace @myway/frontend run dev",
     "dev:backend": "npm --workspace @myway/backend run dev",
     "dev:media-processor": "tsx scripts/media-processor/server.ts",

--- a/packages/shared/src/lms/media/store.ts
+++ b/packages/shared/src/lms/media/store.ts
@@ -332,25 +332,26 @@ export const memoryMediaRepository: MediaRepository = {
 
     const current = demoAudioExtractions[targetIndex];
     const nextStatus = input.status;
+    const resolvedStatus = current.status === 'COMPLETED' && nextStatus === 'PROCESSING' ? current.status : nextStatus;
     const next: AudioExtraction = {
       ...current,
       processing_job_id: input.processing_job_id ?? current.processing_job_id ?? null,
-      processing_error: input.error_message ?? (nextStatus === 'FAILED' ? '오디오 추출에 실패했습니다.' : null),
+      processing_error: input.error_message ?? (resolvedStatus === 'FAILED' ? '오디오 추출에 실패했습니다.' : null),
       audio_url: input.audio_url ?? current.audio_url ?? null,
       audio_format: input.audio_format ?? (input.audio_url ? inferAudioFormat(input.audio_url) : current.audio_format),
       audio_duration_ms: input.audio_duration_ms ?? current.audio_duration_ms,
       sample_rate: input.sample_rate ?? current.sample_rate,
       channels: input.channels ?? current.channels,
-      status: nextStatus,
+      status: resolvedStatus,
       transcript_id: input.transcript_id ?? current.transcript_id,
       stt_status:
         input.stt_status ??
-        (nextStatus === 'FAILED'
+        (resolvedStatus === 'FAILED'
           ? 'FAILED'
           : input.transcript_id
             ? 'COMPLETED'
             : current.stt_status),
-      processed_at: nextStatus === 'COMPLETED' ? now() : current.processed_at ?? null,
+      processed_at: resolvedStatus === 'COMPLETED' ? current.processed_at ?? now() : current.processed_at ?? null,
       updated_at: now(),
     };
 

--- a/scripts/dev.bat
+++ b/scripts/dev.bat
@@ -1,0 +1,4 @@
+@echo off
+set "ROOT=%~dp0.."
+start "" /D "%ROOT%\frontend" cmd /c npm run dev
+start "" /D "%ROOT%\backend" cmd /c npm run dev


### PR DESCRIPTION
﻿# 변경 요약
로컬 dev에서 강의 업로드, STT 추출, processor callback, transcript/pipeline 갱신까지 이어지는 흐름을 확인하고, 끊기던 지점을 정리했습니다.

## 배경
업로드는 되었지만 `ASSETS` 바인딩이 없어 중간에 막혔고, callback이 먼저 끝난 뒤 dispatch 쪽 `PROCESSING` 갱신이 완료 상태를 덮어쓰는 경합도 있었습니다.

## 변경 내용
- `backend/package.json`의 dev 스크립트를 `wrangler dev --env dev --port 8787`로 맞췄습니다.
- `backend/src/lib/media-processor.ts`에서 media processor 호출과 health 조회를 origin 기준으로 정리했습니다.
- `backend/src/lib/media-assets.ts`에 로컬 dev용 메모리 asset 폴백을 넣었습니다.
- `packages/shared/src/lms/media/store.ts`와 `backend/src/lib/media-repository.ts`에서 terminal 상태가 `PROCESSING`으로 퇴행하지 않도록 업데이트 규칙을 보강했습니다.
- `docs/dev-logs/2026-04-12-media-upload-stt-smoke-check.md`와 `docs/dev-logs/README.md`를 갱신했습니다.

## 연결 이슈
- 없음

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
