### PR TITLE
fix: allow processor asset access and polish course creation UI

### DIFF
--- a/backend/src/lib/media-processor.ts
+++ b/backend/src/lib/media-processor.ts
@@ -64,6 +64,17 @@ export function verifyMediaCallbackSecret(request: Request, env?: RuntimeBinding
   return request.headers.get('x-myway-media-callback-secret') === callback_secret;
 }
 
+export function verifyMediaProcessorToken(request: Request, env?: RuntimeBindings): boolean {
+  const { token } = getMediaProcessorRuntimeSettings(env);
+  if (!token) {
+    return false;
+  }
+
+  const authorization = request.headers.get('authorization');
+  const customToken = request.headers.get('x-myway-media-processor-token');
+  return authorization === `Bearer ${token}` || customToken === token;
+}
+
 export async function dispatchMediaProcessorJob(
   input: MediaProcessorDispatchInput,
   env?: RuntimeBindings,

--- a/backend/src/routes/media.ts
+++ b/backend/src/routes/media.ts
@@ -17,7 +17,12 @@ import { jsonFailure, jsonSuccess, readJsonBody } from '../lib/http';
 import { readLectureVideoAsset, uploadLectureVideoAsset } from '../lib/media-assets';
 import { completeMediaExtractionJob, createMediaExtractionJob } from '../lib/media-pipeline';
 import { createMediaRepository } from '../lib/media-repository';
-import { loadMediaProcessorHealth, normalizeMediaCallbackPayload, verifyMediaCallbackSecret } from '../lib/media-processor';
+import {
+  loadMediaProcessorHealth,
+  normalizeMediaCallbackPayload,
+  verifyMediaCallbackSecret,
+  verifyMediaProcessorToken,
+} from '../lib/media-processor';
 import { buildExtractionCallbackResponse, buildExtractionResponse } from '../lib/media-response';
 import { getSTTProviderOverview } from '../lib/stt-provider';
 import { PUBLIC_STT_MAX_DURATION_MS, runTranscriptGeneration } from '../lib/stt-adapter';
@@ -157,7 +162,7 @@ media.get('/assets/:assetKey', async (c) => {
   const user = getAuthenticatedUser(c.req.raw);
   const assetKey = c.req.param('assetKey');
 
-  if (!user) {
+  if (!user && !verifyMediaProcessorToken(c.req.raw, c.env as RuntimeBindings | undefined)) {
     return jsonFailure('UNAUTHENTICATED', '로그인이 필요합니다.', 401);
   }
 

--- a/docs/dev-logs/2026-04-12-media-asset-auth-and-course-create-ux.md
+++ b/docs/dev-logs/2026-04-12-media-asset-auth-and-course-create-ux.md
@@ -1,0 +1,20 @@
+# 2026-04-12 미디어 자산 인증 경로와 강의 개설 UX 개선
+
+## 왜 바꿨는지
+- 미디어 processor가 업로드된 원본 영상을 가져올 때 `/api/v1/media/assets/:assetKey` 가 사용자 로그인만 허용해서 `401`이 발생했다.
+- 배포 환경에서도 다른 사용자의 요청이 같은 흐름으로 처리되려면, processor는 사용자 세션이 아니라 별도 서버 간 인증으로 원본 영상에 접근해야 했다.
+- 강의 개설 화면은 기능은 있었지만, 첫 사용자가 바로 이해하기에는 문구와 흐름이 조금 딱딱했다.
+
+## 무엇을 바꿨는지
+- `backend/src/routes/media.ts`에서 asset 다운로드 경로가 로그인 사용자뿐 아니라 media processor 토큰도 허용하도록 바꿨다.
+- `backend/src/lib/media-processor.ts`에 processor 토큰 검증 함수를 추가했다.
+- `scripts/media-processor/service.ts`와 `scripts/media-processor/storage.ts`에서 원본 영상을 받을 때 processor 토큰을 함께 보내도록 바꿨다.
+- `frontend/src/features/lms/components/CourseCreateCard.tsx`와 `frontend/src/features/lms/pages/CourseCreatePage.tsx`에서 강의 개설 안내 문구, 미리보기, 버튼 표현을 더 친절하게 다듬었다.
+
+## 어떻게 검증했는지
+- `npm run verify`를 실행해 backend, media processor, frontend 타입 검사를 모두 통과시켰다.
+- media processor 쪽에서 `HeadersInit` 타입이 빠져 있어서 처음 한 번 실패했지만, `Record<string, string>`으로 바꿔 다시 검증했고 통과했다.
+
+## 참고
+- 이 수정은 사용자 인증을 약하게 만드는 변경이 아니라, 사용자용 접근과 processor용 접근을 분리하는 변경이다.
+- 운영 환경에서는 backend와 media processor가 같은 토큰 설정을 공유해야 한다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-12-media-asset-auth-and-course-create-ux.md`
 - `2026-04-12-course-create-a-b-compare.md`
 - `2026-04-12-media-upload-stt-smoke-check.md`
 - `2026-04-11-d1-media-binding.md`

--- a/frontend/src/features/lms/components/CourseCreateCard.tsx
+++ b/frontend/src/features/lms/components/CourseCreateCard.tsx
@@ -35,7 +35,8 @@ function splitLectureTitles(value: string): string[] {
 
 export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: CourseCreateCardProps) {
   const [form, setForm] = useState<FormState>(defaultState);
-  const [message, setMessage] = useState('새 강의를 만들면 목록과 스튜디오가 바로 연결됩니다.');
+  const [message, setMessage] = useState('기본 정보만 채우면 강의를 바로 만들 수 있습니다.');
+  const lectureCount = splitLectureTitles(form.lectureTitlesText).length;
 
   if (!canCreate) {
     return (
@@ -88,9 +89,9 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
             <i className="ri-add-circle-line" />
             강의 개설
           </div>
-          <h3 className="mt-3 text-[18px] font-extrabold tracking-[-0.03em] text-slate-900">새 강의를 바로 만들고 스튜디오로 이어가기</h3>
+          <h3 className="mt-3 text-[18px] font-extrabold tracking-[-0.03em] text-slate-900">기본 정보만 넣고 바로 강의 만들기</h3>
           <p className="mt-2 text-[12px] leading-6 text-slate-600">
-            제목, 설명, 카테고리, 난이도, 차시 제목을 입력하면 기본 자료와 공지가 함께 생성되고, 배포 버전에서도 같은 흐름으로 사용할 수 있습니다.
+            제목, 소개, 분류, 난이도, 차시 제목만 입력하면 기본 자료와 공지가 함께 생성되고, 만들자마자 제작 스튜디오로 이어집니다.
           </p>
         </div>
         <div className="rounded-2xl border border-indigo-100 bg-white/80 px-4 py-3 text-[12px] text-slate-500">
@@ -147,8 +148,9 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
             onChange={(event) => setForm((current) => ({ ...current, lectureTitlesText: event.target.value }))}
             rows={4}
             className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-[13px] leading-6 outline-none transition focus:border-indigo-400"
-            placeholder="한 줄에 하나씩 입력하세요."
+            placeholder="한 줄에 하나씩 입력하세요. 예: 1주차 개요 / 2주차 핵심 / 3주차 실습"
           />
+          <div className="text-[11px] leading-5 text-slate-500">빈 줄은 자동으로 제외되고, 입력한 순서대로 차시가 만들어집니다.</div>
         </label>
         <label className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 xl:col-span-2">
           <div>
@@ -166,8 +168,21 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
         </label>
 
         <div className="xl:col-span-2">
-          <div className="rounded-2xl border border-dashed border-indigo-200 bg-white px-4 py-4 text-[12px] leading-6 text-slate-600">
-            {message}
+        <div className="rounded-2xl border border-dashed border-indigo-200 bg-white px-4 py-4 text-[12px] leading-6 text-slate-600">
+          {message}
+        </div>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-[12px] leading-6 text-slate-600 xl:col-span-2">
+          <div className="font-semibold text-slate-900">지금 생성될 내용</div>
+          <div className="mt-1 grid gap-2 sm:grid-cols-2">
+            <div>• 강의명: {form.title.trim() || '아직 입력되지 않음'}</div>
+            <div>• 분류: {form.category.trim() || '아직 입력되지 않음'}</div>
+            <div>• 난이도: {form.difficulty}</div>
+            <div>• 차시: {lectureCount}개</div>
+          </div>
+          <div className="mt-2 text-slate-500">
+            입력한 차시는 순서대로 등록되고, 기본 안내 자료와 공지가 같이 붙습니다.
           </div>
         </div>
 
@@ -177,7 +192,7 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
             disabled={busy}
             className="rounded-full bg-indigo-600 px-5 py-2.5 text-[13px] font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {busy ? '개설 중...' : '새 강의 개설'}
+            {busy ? '개설 중...' : '강의 만들기'}
           </button>
           <div className="rounded-full bg-slate-100 px-4 py-2.5 text-[12px] font-semibold text-slate-600">
             생성 후 기본 자료와 공지 초안이 함께 들어갑니다.

--- a/frontend/src/features/lms/pages/CourseCreatePage.tsx
+++ b/frontend/src/features/lms/pages/CourseCreatePage.tsx
@@ -32,7 +32,7 @@ export function CourseCreatePage({
               <i className="ri-add-circle-line" />
               강의 개설 워크스페이스
             </div>
-            <h1 className="mt-4 text-[28px] font-extrabold tracking-[-0.05em]">새 강의를 만들고 바로 제작 흐름으로 넘기기</h1>
+            <h1 className="mt-4 text-[28px] font-extrabold tracking-[-0.05em]">새 강의를 쉽게 만들고 바로 제작 흐름으로 넘기기</h1>
             <p className="mt-2 text-[13px] leading-7 text-white/75">
               교수, 강사, 운영자가 배포 환경에서도 새 강의를 직접 개설하고, 첫 차시와 기본 자료/공지 초안을 함께 만들 수 있는 진입점입니다.
             </p>
@@ -69,12 +69,12 @@ export function CourseCreatePage({
 
         <aside className="space-y-5">
           <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
-            <h2 className="text-[15px] font-bold text-slate-900">생성 이후 흐름</h2>
+            <h2 className="text-[15px] font-bold text-slate-900">처음 만들 때 안내</h2>
             <div className="mt-4 space-y-3 text-[12px] leading-6 text-slate-600">
-              <div className="rounded-2xl bg-slate-50 px-4 py-3">1. 새 강의 레코드와 첫 차시가 생성됩니다.</div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-3">2. 기본 자료와 공지 초안이 함께 들어갑니다.</div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-3">3. 생성 직후 강의 제작 스튜디오로 이동합니다.</div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-3">4. 이후 미디어 업로드와 STT 자동화 이슈로 이어집니다.</div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">1. 제목과 소개만 먼저 넣어도 바로 시작할 수 있습니다.</div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">2. 차시는 한 줄씩 적으면 입력한 순서대로 등록됩니다.</div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">3. 만들고 나면 강의 스튜디오로 곧바로 이어집니다.</div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">4. 이후 영상 업로드와 STT 자동화까지 연결됩니다.</div>
             </div>
           </section>
 

--- a/scripts/media-processor/service.ts
+++ b/scripts/media-processor/service.ts
@@ -23,7 +23,9 @@ export async function processAudioExtractionJob(
 
   try {
     await ensureWorkDirs(config.workDir);
-    await downloadSourceVideo(job.sourceVideoUrl, paths.videoPath);
+    await downloadSourceVideo(job.sourceVideoUrl, paths.videoPath, {
+      Authorization: `Bearer ${config.token}`,
+    });
     jobStore.updateJob(job.id, {
       stage: 'extracting',
       step: 'FFmpeg로 오디오를 추출하는 중',

--- a/scripts/media-processor/storage.ts
+++ b/scripts/media-processor/storage.ts
@@ -19,8 +19,14 @@ export function buildJobPaths(workDir: string, jobId: string): {
   };
 }
 
-export async function downloadSourceVideo(sourceUrl: string, targetPath: string): Promise<void> {
-  const response = await fetch(sourceUrl);
+export async function downloadSourceVideo(
+  sourceUrl: string,
+  targetPath: string,
+  headers?: Record<string, string>,
+): Promise<void> {
+  const response = await fetch(sourceUrl, {
+    headers,
+  });
   if (!response.ok || !response.body) {
     throw new Error(`영상 다운로드에 실패했습니다. (${response.status})`);
   }


### PR DESCRIPTION
# 변경 요약
미디어 processor가 업로드된 원본 영상을 서버 간 인증으로 가져오도록 바꿔, 배포 환경에서도 다른 사용자의 요청 흐름이 끊기지 않게 했다. 동시에 강의 개설 화면의 문구와 생성 전 미리보기를 손봐 처음 쓰는 사람도 흐름을 더 쉽게 이해할 수 있게 했다.

## 배경
기존에는 `/api/v1/media/assets/:assetKey` 가 사용자 로그인만 허용해서 processor가 원본 영상을 내려받는 과정에서 `401`이 발생했다. 그 결과 업로드 후 STT 추출과 callback 반영이 배포 환경에서 막힐 수 있었다. 또한 강의 개설 화면은 기능은 있었지만, 첫 사용자가 보기에는 안내가 조금 딱딱했다.

## 변경 내용
- `backend/src/routes/media.ts` 에서 asset 다운로드 경로가 로그인 사용자와 media processor 토큰을 모두 허용하도록 변경했다.
- `backend/src/lib/media-processor.ts` 에 processor 토큰 검증을 추가했다.
- `scripts/media-processor/service.ts` 와 `scripts/media-processor/storage.ts` 에서 원본 영상 다운로드 시 processor 토큰을 함께 전달하도록 바꿨다.
- `frontend/src/features/lms/components/CourseCreateCard.tsx` 와 `frontend/src/features/lms/pages/CourseCreatePage.tsx` 에서 강의 개설 문구, 미리보기, 안내 문구를 더 친절하게 다듬었다.
- `docs/dev-logs/2026-04-12-media-asset-auth-and-course-create-ux.md` 를 추가하고 `docs/dev-logs/README.md` 를 갱신했다.

## 연결 이슈
- 관련 이슈 없음. `#152` 후속 수정 성격의 안정화 작업이다.

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다