### PR TITLE
fix: stabilize media processor dev launcher

### DIFF
--- a/docs/dev-logs/2026-04-12-media-processor-dev-launcher-stability.md
+++ b/docs/dev-logs/2026-04-12-media-processor-dev-launcher-stability.md
@@ -1,0 +1,17 @@
+# 2026-04-12 media processor dev launcher stability
+
+## 왜 바꿨는지
+- `tsx`로 `scripts/media-processor/server.ts` 를 직접 실행할 때 Windows 백그라운드 실행 경로에서 `spawn EPERM` 이 발생했다.
+- TS/TSX 소스는 그대로 두되, 실행 진입점만 안정적으로 고정해야 로컬 dev에서 media processor를 계속 살릴 수 있었다.
+
+## 무엇을 바꿨는지
+- 루트 `package.json` 의 `dev:media-processor` 를 `esbuild` 번들 후 `node` 실행 방식으로 바꿨다.
+- `tsx` 의존성을 루트에서 제거했다.
+- `npm install` 로 lockfile을 현재 설치 상태에 맞췄다.
+
+## 어떻게 검증했는지
+- `npm run verify` 를 다시 돌려서 backend, frontend, media processor 타입 검사를 통과시켰다.
+- `scripts/media-processor/server.ts` 는 그대로 TS 소스로 유지된다.
+
+## 참고
+- 이 변경은 소스 언어를 바꾸는 작업이 아니라, Windows dev 환경에서 프로세스를 안정적으로 띄우기 위한 런처 정리다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-12-media-processor-dev-launcher-stability.md`
 - `2026-04-12-media-asset-auth-and-course-create-ux.md`
 - `2026-04-12-course-create-a-b-compare.md`
 - `2026-04-12-media-upload-stt-smoke-check.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@cspotcode/source-map-support": "^0.8.1",
-        "tsx": "^4.21.0"
+        "@cspotcode/source-map-support": "^0.8.1"
       }
     },
     "backend": {
@@ -382,6 +381,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -399,6 +399,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -416,6 +417,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -433,6 +435,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -450,6 +453,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -467,6 +471,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -484,6 +489,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -501,6 +507,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -518,6 +525,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -535,6 +543,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -552,6 +561,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -569,6 +579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -586,6 +597,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -603,6 +615,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -620,6 +633,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -637,6 +651,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -654,6 +669,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -671,6 +687,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -688,6 +705,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -705,6 +723,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -722,6 +741,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -739,6 +759,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -756,6 +777,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -773,6 +795,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -790,6 +813,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -807,6 +831,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1399,6 +1424,8 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1566,6 +1593,8 @@
       "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -2204,6 +2233,8 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -2511,6 +2542,8 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "cmd /c scripts\\dev.bat",
     "dev:frontend": "npm --workspace @myway/frontend run dev",
     "dev:backend": "npm --workspace @myway/backend run dev",
-    "dev:media-processor": "tsx scripts/media-processor/server.ts",
+    "dev:media-processor": "npx esbuild scripts/media-processor/server.ts --bundle --platform=node --format=esm --outfile=dist/media-processor.bundle.mjs && node dist/media-processor.bundle.mjs",
     "check:media-processor": "tsc -p scripts/media-processor/tsconfig.json --noEmit",
     "check:frontend-deps": "npm ls --workspace @myway/frontend --depth=0",
     "check:backend-deps": "npm ls --workspace @myway/backend --depth=0",
@@ -22,7 +22,6 @@
     "verify": "npm run check:deps && npm run check:media-processor && npm run build:backend && npm exec --workspace @myway/frontend -- tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@cspotcode/source-map-support": "^0.8.1",
-    "tsx": "^4.21.0"
+    "@cspotcode/source-map-support": "^0.8.1"
   }
 }


### PR DESCRIPTION
# 변경 요약
Windows dev 환경에서 media processor가 `tsx` 실행 경로의 `spawn EPERM` 때문에 불안정하게 죽던 문제를 줄이기 위해, 실행 진입점을 번들+node 방식으로 안정화했다. TS 소스는 그대로 유지했다.

## 배경
`tsx`로 `scripts/media-processor/server.ts` 를 직접 띄울 때 백그라운드 실행 경로에서 `spawn EPERM` 이 발생했다. 소스 언어를 바꾸기보다 실행 런처를 안정화하는 편이 맞았다.

## 변경 내용
- 루트 `package.json` 의 `dev:media-processor` 를 `esbuild` 번들 후 `node` 실행 방식으로 바꿨다.
- `tsx` 루트 의존성을 제거했다.
- `npm install` 로 lockfile을 현재 설치 상태에 맞췄다.
- `docs/dev-logs/2026-04-12-media-processor-dev-launcher-stability.md` 를 추가하고 `docs/dev-logs/README.md` 를 갱신했다.

## 연결 이슈
- 없음. 로컬 dev 안정화 작업이다.

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다