### PR TITLE
fix: launch media processor with dev and clarify upload errors

### DIFF
--- a/docs/dev-logs/2026-04-12-dev-launcher-media-pipeline-fix.md
+++ b/docs/dev-logs/2026-04-12-dev-launcher-media-pipeline-fix.md
@@ -1,0 +1,15 @@
+# 2026-04-12 dev launcher와 media pipeline 실패 메시지 정리
+
+## 왜 바꿨는지
+- `npm run dev` 만으로는 media processor가 같이 뜨지 않아, 업로드 후 처리 상태판이 비어 보이기 쉬웠다.
+- 업로드 실패 메시지가 backend 연결 실패와 R2/storage 실패를 구분하지 못해서, 실제 원인을 찾기 어려웠다.
+
+## 무엇을 바꿨는지
+- `scripts/dev.bat` 에서 frontend, backend와 함께 media processor도 같이 띄우도록 했다.
+- `frontend/src/features/lms/pages/MediaPipelinePage.tsx` 에서 업로드 실패 메시지를 네트워크 실패와 저장소 실패로 나눠서 보여주도록 했다.
+
+## 어떻게 검증했는지
+- `npm run verify` 를 실행해 backend, frontend, media processor 타입 및 빌드 검사를 통과시켰다.
+
+## 참고
+- TS/TSX 소스는 그대로 유지하고, 실행 런처와 메시지만 정리한 변경이다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-12-dev-launcher-media-pipeline-fix.md`
 - `2026-04-12-media-processor-dev-launcher-stability.md`
 - `2026-04-12-media-asset-auth-and-course-create-ux.md`
 - `2026-04-12-course-create-a-b-compare.md`

--- a/frontend/src/features/lms/pages/MediaPipelinePage.tsx
+++ b/frontend/src/features/lms/pages/MediaPipelinePage.tsx
@@ -211,9 +211,12 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
     try {
       const uploadResult = await uploadLectureVideoDetailed(lectureId, videoFile, sessionToken);
       if (!uploadResult?.success || !uploadResult.data) {
-        setBannerDescription(getAiErrorMessage(uploadResult, '영상 업로드에 실패했습니다. R2 binding과 권한을 확인해 주세요.'));
+        const fallbackMessage = uploadResult
+          ? '영상 업로드에 실패했습니다. R2 binding, 권한, 또는 저장소 상태를 확인해 주세요.'
+          : '백엔드에 연결할 수 없습니다. `npm run dev`로 backend와 media processor가 실행 중인지 확인해 주세요.';
+        setBannerDescription(getAiErrorMessage(uploadResult, fallbackMessage));
         setBannerMeta(getQuotaStatusText(uploadResult));
-        setNotice(getAiErrorMessage(uploadResult, '영상 업로드에 실패했습니다. R2 binding과 권한을 확인해 주세요.'));
+        setNotice(getAiErrorMessage(uploadResult, fallbackMessage));
         return;
       }
 

--- a/scripts/dev.bat
+++ b/scripts/dev.bat
@@ -2,3 +2,4 @@
 set "ROOT=%~dp0.."
 start "" /D "%ROOT%\frontend" cmd /c npm run dev
 start "" /D "%ROOT%\backend" cmd /c npm run dev
+start "" /D "%ROOT%" cmd /c npm run dev:media-processor


### PR DESCRIPTION
# 변경 요약
`npm run dev` 만으로 frontend, backend, media processor가 함께 떠서 미디어 업로드와 STT 흐름을 바로 확인할 수 있게 했다. 업로드 실패 메시지도 backend 미기동과 R2/storage 문제를 구분하도록 나눴다.

## 배경
현재 화면에서 업로드가 실패하면 R2 문제인지 backend 연결 문제인지 구분이 어려웠다. 또 media processor가 자동으로 같이 뜨지 않으면 처리 상태판과 추출 흐름이 비어 보였다.

## 변경 내용
- `scripts/dev.bat` 에서 frontend, backend와 함께 media processor도 같이 띄우도록 했다.
- `frontend/src/features/lms/pages/MediaPipelinePage.tsx` 에서 업로드 실패 시 네트워크 실패와 저장소 실패 메시지를 다르게 보여주도록 바꿨다.
- `docs/dev-logs/2026-04-12-dev-launcher-media-pipeline-fix.md` 를 추가하고 `docs/dev-logs/README.md` 를 갱신했다.

## 연결 이슈
- 없음. 로컬 dev 안정화와 오류 메시지 개선 작업이다.

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다