### PR TITLE
feat: unify course workflow hub

### DIFF
--- a/backend/src/routes/courses.ts
+++ b/backend/src/routes/courses.ts
@@ -74,6 +74,20 @@ courses.get('/', (c) => {
   return jsonSuccess(listCourseCards(userId));
 });
 
+courses.get('/manage', (c) => {
+  const user = getAuthenticatedUser(c.req.raw);
+  if (!user) {
+    return jsonFailure('UNAUTHENTICATED', '로그인이 필요합니다.', 401);
+  }
+
+  if (!canManageCourses(user.role)) {
+    return jsonFailure('FORBIDDEN', '강의 관리 페이지를 사용할 권한이 없습니다.', 403);
+  }
+
+  const managedCourses = listCourseCards(user.id).filter((course) => user.role === 'ADMIN' || course.instructor_id === user.id);
+  return jsonSuccess(managedCourses, '내 강의 목록을 조회했습니다.');
+});
+
 courses.get('/:courseId', (c) => {
   const userId = getAuthenticatedUser(c.req.raw)?.id ?? 'guest';
   const courseId = c.req.param('courseId');

--- a/docs/dev-logs/2026-04-12-course-management-workspace-and-stepflow.md
+++ b/docs/dev-logs/2026-04-12-course-management-workspace-and-stepflow.md
@@ -1,0 +1,24 @@
+# 2026-04-12 강의 관리 탭과 2단계 개설 워크플로우
+
+## 왜 바꿨는지
+- 강의 목록, 강의 개설, 강의 제작 스튜디오, 미디어 파이프라인이 흩어져 있어서, 교수와 강사가 실제로 쓰는 흐름이 끊겨 보였다.
+- 강의 개설은 정보를 먼저 입력하고, 다음 단계에서 개설을 확정한 뒤 자동으로 업로드와 STT가 이어지는 구조가 더 자연스러웠다.
+- `미디어 파이프라인` 화면은 개설 흐름의 필수 화면이 아니라 운영용 세부 상태에 가깝기 때문에 기본 메뉴에서 빼는 편이 맞았다.
+
+## 무엇을 바꿨는지
+- `frontend/src/features/lms/types.ts`에 `my-courses` 페이지를 추가했다.
+- `frontend/src/features/lms/config.ts`에서 교수/강사 기본 진입점을 `내 강의 관리`로 바꾸고, 메뉴에 `내 강의 관리`를 넣었다.
+- `frontend/src/features/lms/pages/MyCoursesPage.tsx`를 새로 만들어 내가 관리하는 강의를 한곳에서 보고, `강의 개설`과 `강의 제작 스튜디오`로 바로 이동할 수 있게 했다.
+- `frontend/src/features/lms/pages/CourseCreatePage.tsx`를 2단계 워크플로우로 정리해서, 첫 화면에서 입력을 저장하고 다음 단계에서 강의 개설을 확정하도록 바꿨다.
+- `frontend/src/features/lms/components/CourseCreateCard.tsx`를 prepare 모드에 맞게 바꿔서, 첫 단계는 `다음`으로 저장만 하고 마지막 단계에서만 실제 개설이 되게 했다.
+- `frontend/src/features/lms/pages/RolePageRouter.tsx`에서 `my-courses` 페이지를 실제로 렌더링하도록 연결했다.
+- `backend/src/routes/courses.ts`에 `GET /api/v1/courses/manage`를 추가해서 관리 중인 강의 목록을 별도로 조회할 수 있게 했다.
+- `frontend/src/features/lms/pages/CoursesPage.tsx`에 `내 강의 관리` 바로가기 버튼을 넣어 목록에서 관리 페이지로 자연스럽게 이동하게 했다.
+
+## 어떻게 검증했는지
+- `npm run verify`를 실행해 backend, media processor, frontend 타입 검사를 모두 통과시켰다.
+
+## 판단
+- 강의 관리와 강의 개설은 서로 다른 목적이므로, 별도 탭으로 나누는 편이 작업 시작과 복귀가 쉽다.
+- 개설 폼을 한 번 입력한 뒤 다음 단계로 넘기고, 마지막에만 확정하는 방식이 사용자 실수와 재입력을 줄인다.
+- 배포 버전에서는 일반 사용자가 내부 처리 화면을 볼 이유가 없으므로, `미디어 파이프라인`은 기본 메뉴에서 빼는 편이 맞다.

--- a/docs/dev-logs/2026-04-12-course-workspace-hub-and-auto-media.md
+++ b/docs/dev-logs/2026-04-12-course-workspace-hub-and-auto-media.md
@@ -8,6 +8,7 @@
 ## 변경 사항
 - [`frontend/src/features/lms/pages/CourseCreatePage.tsx`](C:/Users/ggg99/Desktop/내맘대로Class/myway-class/frontend/src/features/lms/pages/CourseCreatePage.tsx)
   - `강의 개설`, `제작 스튜디오`, `미디어 파이프라인` 탭을 한 페이지에 배치했다.
+  - 탭 전환 시 폼이 사라지지 않도록 숨김 방식으로 유지해 입력 상태가 이어지게 했다.
   - 첫 차시 영상 파일 입력과 자동 추출 토글을 추가했다.
   - 강의 개설 성공 시 영상이 선택되어 있으면 업로드와 추출을 자동 실행하고, 결과에 따라 스튜디오 또는 미디어 탭으로 넘긴다.
 - [`frontend/src/features/lms/pages/RolePageRouter.tsx`](C:/Users/ggg99/Desktop/내맘대로Class/myway-class/frontend/src/features/lms/pages/RolePageRouter.tsx)

--- a/docs/dev-logs/2026-04-12-course-workspace-hub-and-auto-media.md
+++ b/docs/dev-logs/2026-04-12-course-workspace-hub-and-auto-media.md
@@ -1,0 +1,27 @@
+# 2026-04-12 강의 워크스페이스 허브와 자동 미디어 연결
+
+## 목적
+- 분리되어 있던 `강의 개설`, `강의 제작 스튜디오`, `미디어 파이프라인` 흐름을 한 화면의 탭 구조로 묶는다.
+- 강의 개설 후 영상 파일이 선택되어 있으면 첫 차시에 대해 업로드와 오디오 추출을 자동으로 이어서 처리한다.
+- 강사 기본 진입점을 워크스페이스 허브로 옮겨, 처음부터 한 화면에서 제작을 시작하게 한다.
+
+## 변경 사항
+- [`frontend/src/features/lms/pages/CourseCreatePage.tsx`](C:/Users/ggg99/Desktop/내맘대로Class/myway-class/frontend/src/features/lms/pages/CourseCreatePage.tsx)
+  - `강의 개설`, `제작 스튜디오`, `미디어 파이프라인` 탭을 한 페이지에 배치했다.
+  - 첫 차시 영상 파일 입력과 자동 추출 토글을 추가했다.
+  - 강의 개설 성공 시 영상이 선택되어 있으면 업로드와 추출을 자동 실행하고, 결과에 따라 스튜디오 또는 미디어 탭으로 넘긴다.
+- [`frontend/src/features/lms/pages/RolePageRouter.tsx`](C:/Users/ggg99/Desktop/내맘대로Class/myway-class/frontend/src/features/lms/pages/RolePageRouter.tsx)
+  - 강의 개설 페이지에 현재 선택 강의와 세션 토큰을 넘겨 탭 내부에서 스튜디오와 미디어 화면을 재사용하게 했다.
+- [`frontend/src/features/lms/config.ts`](C:/Users/ggg99/Desktop/내맘대로Class/myway-class/frontend/src/features/lms/config.ts)
+  - 강사 기본 진입점을 `course-create`로 바꿔 워크스페이스 허브에서 시작하게 했다.
+  - 메뉴와 제목을 `강의 워크스페이스`로 정리했다.
+- [`frontend/src/features/lms/components/CourseCreateCard.tsx`](C:/Users/ggg99/Desktop/내맘대로Class/myway-class/frontend/src/features/lms/components/CourseCreateCard.tsx)
+  - 생성 후 연결 안내 문구를 워크스페이스 기준으로 맞췄다.
+
+## 검증
+- `npm run verify` 통과
+
+## 판단
+- 강의 개설을 별도 페이지로 두는 대신 허브화하는 편이 실제 작업 흐름에 더 가깝다.
+- 영상 업로드와 STT 추출은 개설 후 자동으로 시작하는 편이 사용자 조작 수를 줄인다.
+- 별도 페이지는 유지하되, 허브 안에서 같은 컴포넌트를 재사용해 이동 비용을 낮췄다.

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-12-course-management-workspace-and-stepflow.md`
 - `2026-04-12-course-workspace-hub-and-auto-media.md`
 - `2026-04-12-dev-launcher-media-pipeline-fix.md`
 - `2026-04-12-media-processor-dev-launcher-stability.md`

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-04-12-course-workspace-hub-and-auto-media.md`
 - `2026-04-12-dev-launcher-media-pipeline-fix.md`
 - `2026-04-12-media-processor-dev-launcher-stability.md`
 - `2026-04-12-media-asset-auth-and-course-create-ux.md`

--- a/frontend/src/features/lms/components/CourseCreateCard.tsx
+++ b/frontend/src/features/lms/components/CourseCreateCard.tsx
@@ -95,8 +95,8 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
           </p>
         </div>
         <div className="rounded-2xl border border-indigo-100 bg-white/80 px-4 py-3 text-[12px] text-slate-500">
-          <div className="font-semibold text-slate-900">생성 후 자동 연결</div>
-          <div className="mt-1 leading-6">강의 목록 · 상세 · 스튜디오 · 미디어 파이프라인</div>
+          <div className="font-semibold text-slate-900">생성 후 다음 단계</div>
+          <div className="mt-1 leading-6">개설 워크스페이스 · 제작 스튜디오 · 미디어 파이프라인</div>
         </div>
       </div>
 
@@ -168,9 +168,9 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
         </label>
 
         <div className="xl:col-span-2">
-        <div className="rounded-2xl border border-dashed border-indigo-200 bg-white px-4 py-4 text-[12px] leading-6 text-slate-600">
-          {message}
-        </div>
+          <div className="rounded-2xl border border-dashed border-indigo-200 bg-white px-4 py-4 text-[12px] leading-6 text-slate-600">
+            {message}
+          </div>
         </div>
 
         <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-[12px] leading-6 text-slate-600 xl:col-span-2">

--- a/frontend/src/features/lms/components/CourseCreateCard.tsx
+++ b/frontend/src/features/lms/components/CourseCreateCard.tsx
@@ -4,7 +4,10 @@ import type { CourseCreateRequest, CourseDetail } from '@myway/shared';
 type CourseCreateCardProps = {
   canCreate: boolean;
   busy: boolean;
+  submitLabel?: string;
+  submitMode?: 'create' | 'prepare';
   onCreate: (input: CourseCreateRequest) => Promise<CourseDetail | null>;
+  onPrepare?: (input: CourseCreateRequest) => void;
   onCreated?: (course: CourseDetail) => void;
 };
 
@@ -33,9 +36,13 @@ function splitLectureTitles(value: string): string[] {
     .filter(Boolean);
 }
 
-export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: CourseCreateCardProps) {
+export function CourseCreateCard({ canCreate, busy, submitLabel, submitMode = 'create', onCreate, onPrepare, onCreated }: CourseCreateCardProps) {
   const [form, setForm] = useState<FormState>(defaultState);
-  const [message, setMessage] = useState('기본 정보만 채우면 강의를 바로 만들 수 있습니다.');
+  const [message, setMessage] = useState(
+    submitMode === 'prepare'
+      ? '기본 정보를 입력한 뒤 다음 단계로 이동해 주세요.'
+      : '기본 정보만 채우면 강의를 바로 만들 수 있습니다.',
+  );
   const lectureCount = splitLectureTitles(form.lectureTitlesText).length;
 
   if (!canCreate) {
@@ -62,14 +69,22 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
       return;
     }
 
-    const result = await onCreate({
+    const input: CourseCreateRequest = {
       title: form.title.trim(),
       description: form.description.trim(),
       category: form.category.trim(),
       difficulty: form.difficulty,
       is_published: form.isPublished,
       lecture_titles: splitLectureTitles(form.lectureTitlesText),
-    });
+    };
+
+    if (submitMode === 'prepare') {
+      onPrepare?.(input);
+      setMessage('기본 정보를 저장했습니다. 다음 단계에서 강의 개설을 완료해 주세요.');
+      return;
+    }
+
+    const result = await onCreate(input);
 
     if (!result) {
       setMessage('새 강의 개설에 실패했습니다. 다시 시도해 주세요.');
@@ -96,7 +111,7 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
         </div>
         <div className="rounded-2xl border border-indigo-100 bg-white/80 px-4 py-3 text-[12px] text-slate-500">
           <div className="font-semibold text-slate-900">생성 후 다음 단계</div>
-          <div className="mt-1 leading-6">개설 워크스페이스 · 제작 스튜디오 · 미디어 파이프라인</div>
+          <div className="mt-1 leading-6">개설 워크스페이스 · 제작 스튜디오</div>
         </div>
       </div>
 
@@ -187,13 +202,13 @@ export function CourseCreateCard({ canCreate, busy, onCreate, onCreated }: Cours
         </div>
 
         <div className="flex flex-wrap gap-3 xl:col-span-2">
-          <button
-            type="submit"
-            disabled={busy}
-            className="rounded-full bg-indigo-600 px-5 py-2.5 text-[13px] font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {busy ? '개설 중...' : '강의 만들기'}
-          </button>
+        <button
+          type="submit"
+          disabled={busy}
+          className="rounded-full bg-indigo-600 px-5 py-2.5 text-[13px] font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {busy ? '진행 중...' : submitLabel ?? (submitMode === 'prepare' ? '다음' : '강의 만들기')}
+        </button>
           <div className="rounded-full bg-slate-100 px-4 py-2.5 text-[12px] font-semibold text-slate-600">
             생성 후 기본 자료와 공지 초안이 함께 들어갑니다.
           </div>

--- a/frontend/src/features/lms/config.ts
+++ b/frontend/src/features/lms/config.ts
@@ -16,7 +16,7 @@ export function userDescription(role: AuthUser['role']): string {
 export function defaultPageForRole(session: LoginResponse | null): LmsPageId {
   if (!session) return 'dashboard';
   if (session.user.role === 'ADMIN') return 'admin-automation';
-  if (session.user.role === 'INSTRUCTOR') return 'lecture-studio';
+  if (session.user.role === 'INSTRUCTOR') return 'course-create';
   return 'dashboard';
 }
 
@@ -24,7 +24,7 @@ export function pageTitle(page: LmsPageId, role: UserRole): string {
   const titles: Record<LmsPageId, string> = {
     dashboard: '대시보드',
     courses: '강의 목록',
-    'course-create': '강의 개설',
+    'course-create': '강의 워크스페이스',
     'lecture-studio': '강의 제작 스튜디오',
     shortform: '숏폼 제작',
     community: '숏폼 커뮤니티',
@@ -76,7 +76,7 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
       {
         label: '제작 도구',
         items: [
-          { page: 'course-create', icon: 'ri-add-circle-line', label: '강의 개설', badge: 'NEW' },
+          { page: 'course-create', icon: 'ri-add-circle-line', label: '강의 워크스페이스', badge: 'NEW' },
           { page: 'lecture-studio', icon: 'ri-layout-masonry-line', label: '강의 제작 스튜디오', badge: 'NEW' },
           { page: 'media-pipeline', icon: 'ri-movie-2-line', label: '미디어 파이프라인' },
           { page: 'shortform', icon: 'ri-scissors-cut-line', label: '숏폼 제작' },
@@ -107,7 +107,7 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
       {
         label: '강의 관리',
         items: [
-          { page: 'course-create', icon: 'ri-add-circle-line', label: '강의 개설' },
+          { page: 'course-create', icon: 'ri-add-circle-line', label: '강의 워크스페이스' },
           { page: 'admin-instructors', icon: 'ri-user-star-line', label: '강사 관리' },
           { page: 'admin-assign', icon: 'ri-links-line', label: '강사·수강생 배정' },
           { page: 'admin-stats', icon: 'ri-bar-chart-box-line', label: '통계 현황' },

--- a/frontend/src/features/lms/config.ts
+++ b/frontend/src/features/lms/config.ts
@@ -16,7 +16,7 @@ export function userDescription(role: AuthUser['role']): string {
 export function defaultPageForRole(session: LoginResponse | null): LmsPageId {
   if (!session) return 'dashboard';
   if (session.user.role === 'ADMIN') return 'admin-automation';
-  if (session.user.role === 'INSTRUCTOR') return 'course-create';
+  if (session.user.role === 'INSTRUCTOR') return 'my-courses';
   return 'dashboard';
 }
 
@@ -24,6 +24,7 @@ export function pageTitle(page: LmsPageId, role: UserRole): string {
   const titles: Record<LmsPageId, string> = {
     dashboard: '대시보드',
     courses: '강의 목록',
+    'my-courses': '내 강의 관리',
     'course-create': '강의 워크스페이스',
     'lecture-studio': '강의 제작 스튜디오',
     shortform: '숏폼 제작',
@@ -76,9 +77,9 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
       {
         label: '제작 도구',
         items: [
+          { page: 'my-courses', icon: 'ri-folder-user-line', label: '내 강의 관리', badge: 'NEW' },
           { page: 'course-create', icon: 'ri-add-circle-line', label: '강의 워크스페이스', badge: 'NEW' },
           { page: 'lecture-studio', icon: 'ri-layout-masonry-line', label: '강의 제작 스튜디오', badge: 'NEW' },
-          { page: 'media-pipeline', icon: 'ri-movie-2-line', label: '미디어 파이프라인' },
           { page: 'shortform', icon: 'ri-scissors-cut-line', label: '숏폼 제작' },
           { page: 'community', icon: 'ri-group-line', label: '숏폼 커뮤니티' },
           { page: 'ai-chat', icon: 'ri-robot-line', label: 'AI 챗' },
@@ -100,8 +101,8 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
       {
         label: '운영 관리',
         items: [
+          { page: 'my-courses', icon: 'ri-folder-user-line', label: '내 강의 관리' },
           { page: 'admin-users', icon: 'ri-user-settings-line', label: '사용자 관리', aliases: ['admin-user-detail'] },
-          { page: 'media-pipeline', icon: 'ri-movie-2-line', label: '미디어 파이프라인' },
         ],
       },
       {

--- a/frontend/src/features/lms/pages/CourseCreatePage.tsx
+++ b/frontend/src/features/lms/pages/CourseCreatePage.tsx
@@ -25,6 +25,12 @@ const tabList: Array<{ id: WorkspaceTab; label: string; hint: string; icon: stri
   { id: 'media', label: '미디어 파이프라인', hint: '영상 업로드와 STT 상태를 확인합니다.', icon: 'ri-movie-2-line' },
 ];
 
+const stepLabels: Record<WorkspaceTab, string> = {
+  create: '1. 강의 개설',
+  studio: '2. 제작 스튜디오',
+  media: '3. 미디어 파이프라인',
+};
+
 export function CourseCreatePage({
   courses,
   canManageCurrent,
@@ -165,8 +171,19 @@ export function CourseCreatePage({
         </div>
       </section>
 
-      {activeTab === 'create' ? (
-        <section className="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="text-[12px] font-semibold uppercase tracking-[0.12em] text-slate-400">진행 단계</div>
+            <div className="mt-1 text-[14px] font-bold text-slate-900">{stepLabels[activeTab]}</div>
+          </div>
+          <div className="text-[12px] leading-6 text-slate-500">
+            입력한 정보는 탭을 옮겨도 유지되고, 개설이 끝나면 다음 단계로 바로 이어집니다.
+          </div>
+        </div>
+      </section>
+
+      <section hidden={activeTab !== 'create'} aria-hidden={activeTab !== 'create'} className="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
           <div className="space-y-5">
             <CourseCreateCard
               canCreate={canManageCurrent}
@@ -250,19 +267,22 @@ export function CourseCreatePage({
               </div>
             </section>
           </aside>
-        </section>
-      ) : null}
+      </section>
 
-      {activeTab === 'studio' ? (
-        <section className="space-y-4">
+      <section hidden={activeTab !== 'studio'} aria-hidden={activeTab !== 'studio'} className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
             <div>
               <h2 className="text-[15px] font-bold text-slate-900">제작 스튜디오를 같은 흐름에서 이어가기</h2>
               <p className="mt-1 text-[12px] text-slate-500">강의 개설 직후 바로 제작 옵션과 발행 준비를 다듬을 수 있습니다.</p>
             </div>
-            <button type="button" onClick={() => setActiveTab('media')} className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500">
-              미디어 탭으로 이동
-            </button>
+            <div className="flex flex-wrap gap-2">
+              <button type="button" onClick={() => setActiveTab('create')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
+                이전: 개설
+              </button>
+              <button type="button" onClick={() => setActiveTab('media')} className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500">
+                미디어 탭으로 이동
+              </button>
+            </div>
           </div>
           <LectureStudioPage
             courses={courses}
@@ -270,23 +290,25 @@ export function CourseCreatePage({
             highlightedLecture={activeLecture}
             onSelectCourse={onSelectCourse}
           />
-        </section>
-      ) : null}
+      </section>
 
-      {activeTab === 'media' ? (
-        <section className="space-y-4">
+      <section hidden={activeTab !== 'media'} aria-hidden={activeTab !== 'media'} className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
             <div>
               <h2 className="text-[15px] font-bold text-slate-900">미디어 파이프라인을 같은 화면에서 확인하기</h2>
               <p className="mt-1 text-[12px] text-slate-500">업로드, 오디오 추출, STT, 타임스탬프 상태를 따로 이동하지 않고 바로 확인합니다.</p>
             </div>
-            <button type="button" onClick={() => setActiveTab('create')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
-              개설 탭으로 돌아가기
-            </button>
+            <div className="flex flex-wrap gap-2">
+              <button type="button" onClick={() => setActiveTab('studio')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
+                이전: 스튜디오
+              </button>
+              <button type="button" onClick={() => setActiveTab('create')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
+                처음으로
+              </button>
+            </div>
           </div>
           <MediaPipelinePage selectedCourse={activeCourse} highlightedLecture={highlightedLecture} sessionToken={sessionToken} />
-        </section>
-      ) : null}
+      </section>
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/CourseCreatePage.tsx
+++ b/frontend/src/features/lms/pages/CourseCreatePage.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 import type { CourseCard, CourseCreateRequest, CourseDetail, LectureDetail } from '@myway/shared';
 import { CourseCreateCard } from '../components/CourseCreateCard';
 import { LectureStudioPage } from './LectureStudioPage';
-import { MediaPipelinePage } from './MediaPipelinePage';
 import { createAudioExtractionDetailed, uploadLectureVideoDetailed } from '../../../lib/api-media';
 
 type CourseCreatePageProps = {
@@ -17,18 +16,16 @@ type CourseCreatePageProps = {
   onSelectLecture: (lectureId: string) => void;
 };
 
-type WorkspaceTab = 'create' | 'studio' | 'media';
+type WorkspaceTab = 'create' | 'studio';
 
 const tabList: Array<{ id: WorkspaceTab; label: string; hint: string; icon: string }> = [
   { id: 'create', label: '강의 개설', hint: '기본 정보와 첫 차시를 등록합니다.', icon: 'ri-add-circle-line' },
-  { id: 'studio', label: '제작 스튜디오', hint: '강의 제작 세부 옵션을 조정합니다.', icon: 'ri-layout-masonry-line' },
-  { id: 'media', label: '미디어 파이프라인', hint: '영상 업로드와 STT 상태를 확인합니다.', icon: 'ri-movie-2-line' },
+  { id: 'studio', label: '제작 스튜디오', hint: '강의 개설 후 세부 옵션과 자동 처리를 이어갑니다.', icon: 'ri-layout-masonry-line' },
 ];
 
 const stepLabels: Record<WorkspaceTab, string> = {
   create: '1. 강의 개설',
   studio: '2. 제작 스튜디오',
-  media: '3. 미디어 파이프라인',
 };
 
 export function CourseCreatePage({
@@ -44,13 +41,13 @@ export function CourseCreatePage({
 }: CourseCreatePageProps) {
   const [activeTab, setActiveTab] = useState<WorkspaceTab>('create');
   const [createdCourse, setCreatedCourse] = useState<CourseDetail | null>(null);
+  const [pendingCreateInput, setPendingCreateInput] = useState<CourseCreateRequest | null>(null);
   const [videoFile, setVideoFile] = useState<File | null>(null);
   const [autoExtract, setAutoExtract] = useState(true);
-  const [workspaceNote, setWorkspaceNote] = useState('강의 개설, 스튜디오, 미디어 파이프라인을 한 곳에서 이어서 사용할 수 있습니다.');
+  const [workspaceNote, setWorkspaceNote] = useState('강의 개설, 제작 스튜디오, 자동 전사 흐름을 한 번에 이어서 사용할 수 있습니다.');
 
   const categoryCount = new Set(courses.map((item) => item.category)).size;
-  const activeCourse = selectedCourse ?? createdCourse;
-  const activeLecture = highlightedLecture ?? activeCourse?.lectures[0] ?? null;
+  const activeCourse = createdCourse ?? selectedCourse;
 
   const courseSummary = useMemo(
     () => ({
@@ -61,14 +58,30 @@ export function CourseCreatePage({
     [activeCourse],
   );
 
+  const pendingSummary = useMemo(
+    () => ({
+      title: pendingCreateInput?.title?.trim() ?? '아직 입력되지 않음',
+      description: pendingCreateInput?.description?.trim() ?? '아직 입력되지 않음',
+      category: pendingCreateInput?.category?.trim() ?? '아직 입력되지 않음',
+      difficulty: pendingCreateInput?.difficulty ?? 'intermediate',
+      lectureCount: pendingCreateInput?.lecture_titles?.length ?? 0,
+    }),
+    [pendingCreateInput],
+  );
+
+  function handlePrepareCreate(input: CourseCreateRequest) {
+    setPendingCreateInput(input);
+    setWorkspaceNote('기본 정보를 저장했습니다. 이제 스튜디오 단계에서 강의 개설을 완료할 수 있습니다.');
+    setActiveTab('studio');
+  }
+
   async function runAutoMediaPipeline(course: CourseDetail) {
     const lecture = course.lectures[0];
     if (!lecture || !videoFile || !autoExtract) {
-      setWorkspaceNote('강의 개설이 끝났습니다. 제작 스튜디오와 미디어 탭에서 다음 단계를 이어갈 수 있습니다.');
+      setWorkspaceNote('강의 개설이 끝났습니다. 제작 스튜디오에서 다음 단계를 이어갈 수 있습니다.');
       return;
     }
 
-    setActiveTab('media');
     setWorkspaceNote(`${lecture.title}에 업로드된 영상을 연결하고 오디오 추출을 자동으로 시작합니다.`);
 
     const uploadResult = await uploadLectureVideoDetailed(lecture.id, videoFile, sessionToken);
@@ -96,15 +109,36 @@ export function CourseCreatePage({
     );
 
     if (!extractionResult?.success || !extractionResult.data) {
-      setWorkspaceNote('영상 업로드는 완료되었지만 오디오 추출 요청은 실패했습니다. 미디어 탭에서 다시 시도해 주세요.');
+      setWorkspaceNote('영상 업로드는 완료되었지만 오디오 추출 요청은 실패했습니다. 제작 스튜디오에서 다시 시도해 주세요.');
       return;
     }
 
-    setWorkspaceNote(
-      extractionResult.data.transcript_id
-        ? '업로드, 오디오 추출, 전사까지 자동으로 완료되었습니다.'
-        : '업로드와 오디오 추출 요청이 완료되었습니다. 미디어 탭에서 처리 상태를 확인할 수 있습니다.',
-    );
+      setWorkspaceNote(
+        extractionResult.data.transcript_id
+          ? '업로드, 오디오 추출, 전사까지 자동으로 완료되었습니다.'
+          : '업로드와 오디오 추출 요청이 완료되었습니다. 제작 스튜디오에서 처리 상태를 확인할 수 있습니다.',
+      );
+  }
+
+  async function handleFinalizeCreate() {
+    if (!pendingCreateInput) {
+      setWorkspaceNote('먼저 강의 개설 정보를 입력해 주세요.');
+      setActiveTab('create');
+      return;
+    }
+
+    const created = await onCreateCourse(pendingCreateInput);
+    if (!created) {
+      setWorkspaceNote('강의 개설에 실패했습니다. 입력값을 다시 확인해 주세요.');
+      return;
+    }
+
+    setCreatedCourse(created);
+    onSelectCourse(created.id);
+    onSelectLecture(created.lectures[0]?.id ?? '');
+    setActiveTab('studio');
+    setWorkspaceNote(`${created.title} 강의를 개설했습니다. 자동 처리와 스튜디오 설정을 이어갑니다.`);
+    void runAutoMediaPipeline(created);
   }
 
   return (
@@ -116,9 +150,9 @@ export function CourseCreatePage({
               <i className="ri-add-circle-line" />
               강의 개설 워크스페이스
             </div>
-            <h1 className="mt-4 text-[28px] font-extrabold tracking-[-0.05em]">새 강의를 쉽게 만들고 바로 제작 흐름으로 넘기기</h1>
+            <h1 className="mt-4 text-[28px] font-extrabold tracking-[-0.05em]">새 강의를 입력하고, 개설과 스튜디오를 한 번에 이어가기</h1>
             <p className="mt-2 text-[13px] leading-7 text-white/75">
-              교수, 강사, 운영자가 배포 환경에서도 새 강의를 직접 개설하고, 첫 차시와 기본 자료/공지 초안을 함께 만들 수 있는 진입점입니다.
+              교수, 강사, 운영자가 개설 정보를 먼저 입력하고 다음 단계로 넘어가면, 그 정보 그대로 강의를 개설하고 제작 스튜디오로 이어갈 수 있습니다.
             </p>
           </div>
 
@@ -133,7 +167,7 @@ export function CourseCreatePage({
             </div>
             <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
               <div className="font-semibold text-white">진입 방식</div>
-              <div className="mt-1 text-[18px] font-extrabold text-white">전용 페이지</div>
+              <div className="mt-1 text-[18px] font-extrabold text-white">2단계 워크플로우</div>
             </div>
           </div>
         </div>
@@ -143,7 +177,7 @@ export function CourseCreatePage({
       </section>
 
       <section className="rounded-3xl border border-slate-200 bg-white p-2 shadow-sm">
-        <div className="grid gap-2 md:grid-cols-3">
+        <div className="grid gap-2 md:grid-cols-2">
           {tabList.map((tab) => {
             const active = activeTab === tab.id;
             return (
@@ -177,137 +211,169 @@ export function CourseCreatePage({
             <div className="text-[12px] font-semibold uppercase tracking-[0.12em] text-slate-400">진행 단계</div>
             <div className="mt-1 text-[14px] font-bold text-slate-900">{stepLabels[activeTab]}</div>
           </div>
-          <div className="text-[12px] leading-6 text-slate-500">
-            입력한 정보는 탭을 옮겨도 유지되고, 개설이 끝나면 다음 단계로 바로 이어집니다.
-          </div>
+            <div className="text-[12px] leading-6 text-slate-500">
+              입력한 정보는 탭을 옮겨도 유지되고, 다음 단계에서 강의 개설과 자동 전사 처리가 이어집니다.
+            </div>
         </div>
       </section>
 
       <section hidden={activeTab !== 'create'} aria-hidden={activeTab !== 'create'} className="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
-          <div className="space-y-5">
-            <CourseCreateCard
-              canCreate={canManageCurrent}
-              busy={busy}
-              onCreate={onCreateCourse}
-              onCreated={(course) => {
-                setCreatedCourse(course);
-                onSelectCourse(course.id);
-                onSelectLecture(course.lectures[0]?.id ?? '');
-                setWorkspaceNote(`${course.title} 강의를 개설했습니다. 이어서 스튜디오와 미디어 설정을 진행할 수 있습니다.`);
-                void runAutoMediaPipeline(course);
-                if (!videoFile || !autoExtract) {
-                  setActiveTab('studio');
-                }
-              }}
-            />
+        <div className="space-y-5">
+          <CourseCreateCard
+            canCreate={canManageCurrent}
+            busy={busy}
+            submitMode="prepare"
+            submitLabel="다음"
+            onPrepare={handlePrepareCreate}
+            onCreate={onCreateCourse}
+          />
 
-            <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
-              <h2 className="text-[15px] font-bold text-slate-900">영상과 자동 추출</h2>
-              <p className="mt-1 text-[12px] leading-6 text-slate-500">
-                첫 차시용 영상을 먼저 선택해 두면, 강의 개설 후 바로 업로드와 오디오 추출을 이어서 처리합니다.
-              </p>
+          <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+            <h2 className="text-[15px] font-bold text-slate-900">자동 전사 안내</h2>
+            <p className="mt-1 text-[12px] leading-6 text-slate-500">
+              첫 차시 영상이 준비되어 있으면, 강의가 개설된 뒤 곧바로 업로드와 오디오 추출, STT 전사가 자동으로 이어집니다.
+            </p>
 
-              <div className="mt-4 grid gap-4 md:grid-cols-2">
-                <label className="space-y-2 md:col-span-2">
-                  <span className="text-[12px] font-semibold text-slate-700">첫 차시 영상</span>
-                  <input
-                    type="file"
-                    accept="video/*"
-                    onChange={(event) => setVideoFile(event.target.files?.[0] ?? null)}
-                    className="block w-full cursor-pointer rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-indigo-600 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white"
-                  />
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="space-y-2 md:col-span-2">
+                <span className="text-[12px] font-semibold text-slate-700">첫 차시 영상</span>
+                <input
+                  type="file"
+                  accept="video/*"
+                  onChange={(event) => setVideoFile(event.target.files?.[0] ?? null)}
+                  className="block w-full cursor-pointer rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-indigo-600 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white"
+                />
                   <div className="text-[11px] leading-5 text-slate-500">
-                    선택된 영상은 생성된 첫 차시에 연결됩니다. 업로드가 끝나면 오디오 추출과 STT가 자동으로 이어집니다.
+                    선택된 영상은 개설 후 자동 처리 단계로 넘어갑니다. 업로드가 끝나면 오디오 추출과 STT가 이어집니다.
                   </div>
-                  <div className="text-[12px] text-slate-600">{videoFile ? `선택됨: ${videoFile.name}` : '아직 선택된 영상이 없습니다.'}</div>
-                </label>
+                <div className="text-[12px] text-slate-600">{videoFile ? `선택됨: ${videoFile.name}` : '아직 선택된 영상이 없습니다.'}</div>
+              </label>
 
-                <button
-                  type="button"
-                  onClick={() => setAutoExtract((current) => !current)}
-                  className={`flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition ${
-                    autoExtract ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-slate-50 text-slate-600'
-                  }`}
-                >
-                  <div>
-                    <div className="text-[13px] font-semibold">강의 개설 후 자동 추출</div>
-                    <div className="mt-1 text-[12px] leading-6 opacity-80">업로드된 영상이 바로 오디오 추출 파이프라인으로 넘어갑니다.</div>
-                  </div>
-                  <div className={`flex h-6 w-11 items-center rounded-full p-1 transition ${autoExtract ? 'bg-emerald-500' : 'bg-slate-300'}`}>
-                    <span className={`h-4 w-4 rounded-full bg-white transition ${autoExtract ? 'translate-x-5' : 'translate-x-0'}`} />
-                  </div>
-                </button>
+              <button
+                type="button"
+                onClick={() => setAutoExtract((current) => !current)}
+                className={`flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition ${
+                  autoExtract ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-slate-50 text-slate-600'
+                }`}
+              >
+                <div>
+                  <div className="text-[13px] font-semibold">개설 후 자동 추출</div>
+                  <div className="mt-1 text-[12px] leading-6 opacity-80">업로드된 영상이 오디오 추출과 STT 처리로 바로 넘어갑니다.</div>
+                </div>
+                <div className={`flex h-6 w-11 items-center rounded-full p-1 transition ${autoExtract ? 'bg-emerald-500' : 'bg-slate-300'}`}>
+                  <span className={`h-4 w-4 rounded-full bg-white transition ${autoExtract ? 'translate-x-5' : 'translate-x-0'}`} />
+                </div>
+              </button>
+            </div>
+          </section>
+        </div>
+
+        <aside className="space-y-5">
+          <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+            <h2 className="text-[15px] font-bold text-slate-900">입력된 개설 정보</h2>
+            <div className="mt-4 space-y-3 text-[12px] leading-6 text-slate-600">
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">강의명: {pendingSummary.title}</div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">카테고리: {pendingSummary.category}</div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">난이도: {pendingSummary.difficulty}</div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">차시: {pendingSummary.lectureCount}개</div>
+              <div className="rounded-2xl bg-slate-50 px-4 py-3">설명: {pendingSummary.description}</div>
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-dashed border-indigo-200 bg-indigo-50 px-5 py-5 text-[12px] leading-6 text-indigo-900">
+            <div className="font-bold">권한 안내</div>
+            <p className="mt-2 text-indigo-800">
+              {canManageCurrent
+                ? '현재 계정은 강의 개설 권한이 있습니다.'
+                : '현재 계정은 강의 개설 권한이 없습니다. 관리자 또는 강사 계정으로 전환해 주세요.'}
+            </p>
+            <div className="mt-3 rounded-2xl bg-white/70 px-4 py-3 text-slate-600">
+              <div className="font-semibold text-slate-900">현재 선택 정보</div>
+              <div className="mt-1">강의: {courseSummary.title}</div>
+              <div>차시 수: {courseSummary.lectureCount}개</div>
+              <div>담당자: {courseSummary.instructor}</div>
+            </div>
+          </section>
+        </aside>
+      </section>
+
+      <section hidden={activeTab !== 'studio'} aria-hidden={activeTab !== 'studio'} className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+            <div>
+              <h2 className="text-[15px] font-bold text-slate-900">제작 스튜디오에서 강의 개설 완료</h2>
+              <p className="mt-1 text-[12px] text-slate-500">
+                입력한 정보로 강의를 생성하고, 이후 제작 세부 옵션과 오디오 추출, STT 전사를 바로 이어갑니다.
+              </p>
+            </div>
+          <div className="flex flex-wrap gap-2">
+            <button type="button" onClick={() => setActiveTab('create')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
+              이전: 정보 입력
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleFinalizeCreate()}
+              disabled={busy}
+              className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {busy ? '개설 중...' : '강의 개설하고 스튜디오 열기'}
+            </button>
+          </div>
+        </div>
+
+        <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.75fr)]">
+          <div className="space-y-5">
+            <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+              <h3 className="text-[14px] font-bold text-slate-900">강의 개설 전 확인</h3>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl bg-slate-50 px-4 py-3 text-[12px] leading-6 text-slate-600">제목: {pendingSummary.title}</div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3 text-[12px] leading-6 text-slate-600">카테고리: {pendingSummary.category}</div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3 text-[12px] leading-6 text-slate-600">난이도: {pendingSummary.difficulty}</div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3 text-[12px] leading-6 text-slate-600">첫 차시 수: {pendingSummary.lectureCount}개</div>
+              </div>
+              <div className="mt-4 rounded-2xl border border-dashed border-indigo-200 bg-indigo-50 px-4 py-4 text-[12px] leading-6 text-indigo-900">
+                강의 개설 버튼을 누르면 입력값으로 실제 강의가 만들어지고, 첫 차시 영상이 있으면 업로드와 오디오 추출이 자동으로 이어집니다.
               </div>
             </section>
+
+            {activeCourse ? (
+              <LectureStudioPage
+                courses={courses}
+                selectedCourse={activeCourse}
+                highlightedLecture={highlightedLecture}
+                onSelectCourse={onSelectCourse}
+              />
+            ) : (
+              <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+                <h3 className="text-[14px] font-bold text-slate-900">스튜디오 대기 상태</h3>
+                <p className="mt-2 text-[12px] leading-6 text-slate-500">
+                  아직 개설된 강의가 없습니다. 위의 버튼으로 강의를 개설해야 스튜디오 설정이 활성화됩니다.
+                </p>
+              </section>
+            )}
           </div>
 
           <aside className="space-y-5">
             <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
-              <h2 className="text-[15px] font-bold text-slate-900">처음 만들 때 안내</h2>
-              <div className="mt-4 space-y-3 text-[12px] leading-6 text-slate-600">
-                <div className="rounded-2xl bg-slate-50 px-4 py-3">1. 제목과 소개만 먼저 넣어도 바로 시작할 수 있습니다.</div>
-                <div className="rounded-2xl bg-slate-50 px-4 py-3">2. 차시는 한 줄씩 적으면 입력한 순서대로 등록됩니다.</div>
-                <div className="rounded-2xl bg-slate-50 px-4 py-3">3. 영상이 있으면 개설 후 바로 업로드와 추출이 이어집니다.</div>
-                <div className="rounded-2xl bg-slate-50 px-4 py-3">4. 개설이 끝나면 스튜디오와 미디어 탭으로 이어서 이동합니다.</div>
-              </div>
-            </section>
+                <h2 className="text-[15px] font-bold text-slate-900">자동 처리 순서</h2>
+                <div className="mt-4 space-y-3 text-[12px] leading-6 text-slate-600">
+                  <div className="rounded-2xl bg-slate-50 px-4 py-3">1. 강의 개설</div>
+                  <div className="rounded-2xl bg-slate-50 px-4 py-3">2. 첫 차시 연결</div>
+                  <div className="rounded-2xl bg-slate-50 px-4 py-3">3. 영상 업로드</div>
+                  <div className="rounded-2xl bg-slate-50 px-4 py-3">4. 오디오 추출과 STT 자동 진행</div>
+                </div>
+              </section>
 
             <section className="rounded-3xl border border-dashed border-indigo-200 bg-indigo-50 px-5 py-5 text-[12px] leading-6 text-indigo-900">
-              <div className="font-bold">권한 안내</div>
-              <p className="mt-2 text-indigo-800">
-                {canManageCurrent
-                  ? '현재 계정은 강의 개설 권한이 있습니다.'
-                  : '현재 계정은 강의 개설 권한이 없습니다. 관리자 또는 강사 계정으로 전환해 주세요.'}
-              </p>
+              <div className="font-bold">현재 상태</div>
+              <p className="mt-2 text-indigo-800">{workspaceNote}</p>
               <div className="mt-3 rounded-2xl bg-white/70 px-4 py-3 text-slate-600">
-                <div className="font-semibold text-slate-900">현재 선택 정보</div>
-                <div className="mt-1">강의: {courseSummary.title}</div>
-                <div>차시 수: {courseSummary.lectureCount}개</div>
-                <div>담당자: {courseSummary.instructor}</div>
+                <div className="font-semibold text-slate-900">영상 처리</div>
+                <div className="mt-1">{videoFile ? videoFile.name : '아직 선택된 영상이 없습니다.'}</div>
+                <div className="mt-1">{autoExtract ? '자동 추출 사용' : '자동 추출 해제'}</div>
               </div>
             </section>
           </aside>
-      </section>
-
-      <section hidden={activeTab !== 'studio'} aria-hidden={activeTab !== 'studio'} className="space-y-4">
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
-            <div>
-              <h2 className="text-[15px] font-bold text-slate-900">제작 스튜디오를 같은 흐름에서 이어가기</h2>
-              <p className="mt-1 text-[12px] text-slate-500">강의 개설 직후 바로 제작 옵션과 발행 준비를 다듬을 수 있습니다.</p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <button type="button" onClick={() => setActiveTab('create')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
-                이전: 개설
-              </button>
-              <button type="button" onClick={() => setActiveTab('media')} className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500">
-                미디어 탭으로 이동
-              </button>
-            </div>
-          </div>
-          <LectureStudioPage
-            courses={courses}
-            selectedCourse={activeCourse}
-            highlightedLecture={activeLecture}
-            onSelectCourse={onSelectCourse}
-          />
-      </section>
-
-      <section hidden={activeTab !== 'media'} aria-hidden={activeTab !== 'media'} className="space-y-4">
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
-            <div>
-              <h2 className="text-[15px] font-bold text-slate-900">미디어 파이프라인을 같은 화면에서 확인하기</h2>
-              <p className="mt-1 text-[12px] text-slate-500">업로드, 오디오 추출, STT, 타임스탬프 상태를 따로 이동하지 않고 바로 확인합니다.</p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <button type="button" onClick={() => setActiveTab('studio')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
-                이전: 스튜디오
-              </button>
-              <button type="button" onClick={() => setActiveTab('create')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
-                처음으로
-              </button>
-            </div>
-          </div>
-          <MediaPipelinePage selectedCourse={activeCourse} highlightedLecture={highlightedLecture} sessionToken={sessionToken} />
+        </section>
       </section>
     </div>
   );

--- a/frontend/src/features/lms/pages/CourseCreatePage.tsx
+++ b/frontend/src/features/lms/pages/CourseCreatePage.tsx
@@ -1,27 +1,105 @@
-import type { CourseCard, CourseCreateRequest, CourseDetail } from '@myway/shared';
-import type { LmsPageId } from '../types';
+import { useMemo, useState } from 'react';
+import type { CourseCard, CourseCreateRequest, CourseDetail, LectureDetail } from '@myway/shared';
 import { CourseCreateCard } from '../components/CourseCreateCard';
+import { LectureStudioPage } from './LectureStudioPage';
+import { MediaPipelinePage } from './MediaPipelinePage';
+import { createAudioExtractionDetailed, uploadLectureVideoDetailed } from '../../../lib/api-media';
 
 type CourseCreatePageProps = {
   courses: CourseCard[];
   canManageCurrent: boolean;
   busy: boolean;
+  sessionToken: string;
+  selectedCourse: CourseDetail | null;
+  highlightedLecture: LectureDetail | null;
   onCreateCourse: (input: CourseCreateRequest) => Promise<CourseDetail | null>;
   onSelectCourse: (courseId: string) => void;
   onSelectLecture: (lectureId: string) => void;
-  onNavigate: (page: LmsPageId) => void;
 };
+
+type WorkspaceTab = 'create' | 'studio' | 'media';
+
+const tabList: Array<{ id: WorkspaceTab; label: string; hint: string; icon: string }> = [
+  { id: 'create', label: '강의 개설', hint: '기본 정보와 첫 차시를 등록합니다.', icon: 'ri-add-circle-line' },
+  { id: 'studio', label: '제작 스튜디오', hint: '강의 제작 세부 옵션을 조정합니다.', icon: 'ri-layout-masonry-line' },
+  { id: 'media', label: '미디어 파이프라인', hint: '영상 업로드와 STT 상태를 확인합니다.', icon: 'ri-movie-2-line' },
+];
 
 export function CourseCreatePage({
   courses,
   canManageCurrent,
   busy,
+  sessionToken,
+  selectedCourse,
+  highlightedLecture,
   onCreateCourse,
   onSelectCourse,
   onSelectLecture,
-  onNavigate,
 }: CourseCreatePageProps) {
+  const [activeTab, setActiveTab] = useState<WorkspaceTab>('create');
+  const [createdCourse, setCreatedCourse] = useState<CourseDetail | null>(null);
+  const [videoFile, setVideoFile] = useState<File | null>(null);
+  const [autoExtract, setAutoExtract] = useState(true);
+  const [workspaceNote, setWorkspaceNote] = useState('강의 개설, 스튜디오, 미디어 파이프라인을 한 곳에서 이어서 사용할 수 있습니다.');
+
   const categoryCount = new Set(courses.map((item) => item.category)).size;
+  const activeCourse = selectedCourse ?? createdCourse;
+  const activeLecture = highlightedLecture ?? activeCourse?.lectures[0] ?? null;
+
+  const courseSummary = useMemo(
+    () => ({
+      title: activeCourse?.title ?? '선택된 강의 없음',
+      lectureCount: activeCourse?.lectures.length ?? 0,
+      instructor: activeCourse?.instructor_name ?? '강의 개설 후 확인',
+    }),
+    [activeCourse],
+  );
+
+  async function runAutoMediaPipeline(course: CourseDetail) {
+    const lecture = course.lectures[0];
+    if (!lecture || !videoFile || !autoExtract) {
+      setWorkspaceNote('강의 개설이 끝났습니다. 제작 스튜디오와 미디어 탭에서 다음 단계를 이어갈 수 있습니다.');
+      return;
+    }
+
+    setActiveTab('media');
+    setWorkspaceNote(`${lecture.title}에 업로드된 영상을 연결하고 오디오 추출을 자동으로 시작합니다.`);
+
+    const uploadResult = await uploadLectureVideoDetailed(lecture.id, videoFile, sessionToken);
+    if (!uploadResult?.success || !uploadResult.data) {
+      setWorkspaceNote(
+        uploadResult
+          ? '영상 업로드는 실패했습니다. R2 binding, 권한, 저장소 상태를 확인해 주세요.'
+          : '백엔드에 연결할 수 없습니다. `npm run dev`로 backend와 media processor가 실행 중인지 확인해 주세요.',
+      );
+      return;
+    }
+
+    const upload = uploadResult.data;
+    const extractionResult = await createAudioExtractionDetailed(
+      {
+        lecture_id: lecture.id,
+        video_url: upload.video_url,
+        video_asset_key: upload.asset_key,
+        source_file_name: upload.file_name,
+        source_content_type: upload.content_type,
+        source_size_bytes: upload.size_bytes,
+        language: 'ko',
+      },
+      sessionToken,
+    );
+
+    if (!extractionResult?.success || !extractionResult.data) {
+      setWorkspaceNote('영상 업로드는 완료되었지만 오디오 추출 요청은 실패했습니다. 미디어 탭에서 다시 시도해 주세요.');
+      return;
+    }
+
+    setWorkspaceNote(
+      extractionResult.data.transcript_id
+        ? '업로드, 오디오 추출, 전사까지 자동으로 완료되었습니다.'
+        : '업로드와 오디오 추출 요청이 완료되었습니다. 미디어 탭에서 처리 상태를 확인할 수 있습니다.',
+    );
+  }
 
   return (
     <div className="space-y-5">
@@ -53,48 +131,162 @@ export function CourseCreatePage({
             </div>
           </div>
         </div>
+        <div className="mt-5 rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] leading-6 text-slate-200">
+          {workspaceNote}
+        </div>
       </section>
 
-      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
-        <CourseCreateCard
-          canCreate={canManageCurrent}
-          busy={busy}
-          onCreate={onCreateCourse}
-          onCreated={(course) => {
-            onSelectCourse(course.id);
-            onSelectLecture(course.lectures[0]?.id ?? '');
-            onNavigate('lecture-studio');
-          }}
-        />
+      <section className="rounded-3xl border border-slate-200 bg-white p-2 shadow-sm">
+        <div className="grid gap-2 md:grid-cols-3">
+          {tabList.map((tab) => {
+            const active = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                className={`rounded-2xl border px-4 py-4 text-left transition ${
+                  active ? 'border-indigo-400 bg-indigo-50 ring-2 ring-indigo-100' : 'border-slate-200 bg-slate-50/70 hover:bg-white'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="inline-flex items-center gap-2 text-[12px] font-semibold text-slate-900">
+                      <i className={tab.icon} />
+                      {tab.label}
+                    </div>
+                    <div className="mt-1 text-[12px] leading-6 text-slate-500">{tab.hint}</div>
+                  </div>
+                  {active ? <i className="ri-checkbox-circle-fill text-[18px] text-indigo-600" /> : <i className="ri-checkbox-blank-circle-line text-[18px] text-slate-300" />}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </section>
 
-        <aside className="space-y-5">
-          <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
-            <h2 className="text-[15px] font-bold text-slate-900">처음 만들 때 안내</h2>
-            <div className="mt-4 space-y-3 text-[12px] leading-6 text-slate-600">
-              <div className="rounded-2xl bg-slate-50 px-4 py-3">1. 제목과 소개만 먼저 넣어도 바로 시작할 수 있습니다.</div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-3">2. 차시는 한 줄씩 적으면 입력한 순서대로 등록됩니다.</div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-3">3. 만들고 나면 강의 스튜디오로 곧바로 이어집니다.</div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-3">4. 이후 영상 업로드와 STT 자동화까지 연결됩니다.</div>
+      {activeTab === 'create' ? (
+        <section className="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+          <div className="space-y-5">
+            <CourseCreateCard
+              canCreate={canManageCurrent}
+              busy={busy}
+              onCreate={onCreateCourse}
+              onCreated={(course) => {
+                setCreatedCourse(course);
+                onSelectCourse(course.id);
+                onSelectLecture(course.lectures[0]?.id ?? '');
+                setWorkspaceNote(`${course.title} 강의를 개설했습니다. 이어서 스튜디오와 미디어 설정을 진행할 수 있습니다.`);
+                void runAutoMediaPipeline(course);
+                if (!videoFile || !autoExtract) {
+                  setActiveTab('studio');
+                }
+              }}
+            />
+
+            <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+              <h2 className="text-[15px] font-bold text-slate-900">영상과 자동 추출</h2>
+              <p className="mt-1 text-[12px] leading-6 text-slate-500">
+                첫 차시용 영상을 먼저 선택해 두면, 강의 개설 후 바로 업로드와 오디오 추출을 이어서 처리합니다.
+              </p>
+
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <label className="space-y-2 md:col-span-2">
+                  <span className="text-[12px] font-semibold text-slate-700">첫 차시 영상</span>
+                  <input
+                    type="file"
+                    accept="video/*"
+                    onChange={(event) => setVideoFile(event.target.files?.[0] ?? null)}
+                    className="block w-full cursor-pointer rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-indigo-600 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white"
+                  />
+                  <div className="text-[11px] leading-5 text-slate-500">
+                    선택된 영상은 생성된 첫 차시에 연결됩니다. 업로드가 끝나면 오디오 추출과 STT가 자동으로 이어집니다.
+                  </div>
+                  <div className="text-[12px] text-slate-600">{videoFile ? `선택됨: ${videoFile.name}` : '아직 선택된 영상이 없습니다.'}</div>
+                </label>
+
+                <button
+                  type="button"
+                  onClick={() => setAutoExtract((current) => !current)}
+                  className={`flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition ${
+                    autoExtract ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-slate-50 text-slate-600'
+                  }`}
+                >
+                  <div>
+                    <div className="text-[13px] font-semibold">강의 개설 후 자동 추출</div>
+                    <div className="mt-1 text-[12px] leading-6 opacity-80">업로드된 영상이 바로 오디오 추출 파이프라인으로 넘어갑니다.</div>
+                  </div>
+                  <div className={`flex h-6 w-11 items-center rounded-full p-1 transition ${autoExtract ? 'bg-emerald-500' : 'bg-slate-300'}`}>
+                    <span className={`h-4 w-4 rounded-full bg-white transition ${autoExtract ? 'translate-x-5' : 'translate-x-0'}`} />
+                  </div>
+                </button>
+              </div>
+            </section>
+          </div>
+
+          <aside className="space-y-5">
+            <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+              <h2 className="text-[15px] font-bold text-slate-900">처음 만들 때 안내</h2>
+              <div className="mt-4 space-y-3 text-[12px] leading-6 text-slate-600">
+                <div className="rounded-2xl bg-slate-50 px-4 py-3">1. 제목과 소개만 먼저 넣어도 바로 시작할 수 있습니다.</div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3">2. 차시는 한 줄씩 적으면 입력한 순서대로 등록됩니다.</div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3">3. 영상이 있으면 개설 후 바로 업로드와 추출이 이어집니다.</div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3">4. 개설이 끝나면 스튜디오와 미디어 탭으로 이어서 이동합니다.</div>
+              </div>
+            </section>
+
+            <section className="rounded-3xl border border-dashed border-indigo-200 bg-indigo-50 px-5 py-5 text-[12px] leading-6 text-indigo-900">
+              <div className="font-bold">권한 안내</div>
+              <p className="mt-2 text-indigo-800">
+                {canManageCurrent
+                  ? '현재 계정은 강의 개설 권한이 있습니다.'
+                  : '현재 계정은 강의 개설 권한이 없습니다. 관리자 또는 강사 계정으로 전환해 주세요.'}
+              </p>
+              <div className="mt-3 rounded-2xl bg-white/70 px-4 py-3 text-slate-600">
+                <div className="font-semibold text-slate-900">현재 선택 정보</div>
+                <div className="mt-1">강의: {courseSummary.title}</div>
+                <div>차시 수: {courseSummary.lectureCount}개</div>
+                <div>담당자: {courseSummary.instructor}</div>
+              </div>
+            </section>
+          </aside>
+        </section>
+      ) : null}
+
+      {activeTab === 'studio' ? (
+        <section className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+            <div>
+              <h2 className="text-[15px] font-bold text-slate-900">제작 스튜디오를 같은 흐름에서 이어가기</h2>
+              <p className="mt-1 text-[12px] text-slate-500">강의 개설 직후 바로 제작 옵션과 발행 준비를 다듬을 수 있습니다.</p>
             </div>
-          </section>
-
-          <section className="rounded-3xl border border-dashed border-indigo-200 bg-indigo-50 px-5 py-5 text-[12px] leading-6 text-indigo-900">
-            <div className="font-bold">권한 안내</div>
-            <p className="mt-2 text-indigo-800">
-              {canManageCurrent
-                ? '현재 계정은 강의 개설 권한이 있습니다.'
-                : '현재 계정은 강의 개설 권한이 없습니다. 관리자 또는 강사 계정으로 전환해 주세요.'}
-            </p>
-            <button
-              type="button"
-              onClick={() => onNavigate('courses')}
-              className="mt-4 rounded-full bg-white px-4 py-2 text-[12px] font-semibold text-indigo-700 shadow-sm transition hover:bg-indigo-100"
-            >
-              강의 목록으로 돌아가기
+            <button type="button" onClick={() => setActiveTab('media')} className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500">
+              미디어 탭으로 이동
             </button>
-          </section>
-        </aside>
-      </section>
+          </div>
+          <LectureStudioPage
+            courses={courses}
+            selectedCourse={activeCourse}
+            highlightedLecture={activeLecture}
+            onSelectCourse={onSelectCourse}
+          />
+        </section>
+      ) : null}
+
+      {activeTab === 'media' ? (
+        <section className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+            <div>
+              <h2 className="text-[15px] font-bold text-slate-900">미디어 파이프라인을 같은 화면에서 확인하기</h2>
+              <p className="mt-1 text-[12px] text-slate-500">업로드, 오디오 추출, STT, 타임스탬프 상태를 따로 이동하지 않고 바로 확인합니다.</p>
+            </div>
+            <button type="button" onClick={() => setActiveTab('create')} className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50">
+              개설 탭으로 돌아가기
+            </button>
+          </div>
+          <MediaPipelinePage selectedCourse={activeCourse} highlightedLecture={highlightedLecture} sessionToken={sessionToken} />
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/CoursesPage.tsx
+++ b/frontend/src/features/lms/pages/CoursesPage.tsx
@@ -96,18 +96,27 @@ export function CoursesPage({
                 <i className="ri-add-circle-line" />
                 강의 개설 바로가기
               </div>
-              <h3 className="mt-3 text-[16px] font-extrabold tracking-[-0.03em] text-slate-900">새 강의는 전용 페이지에서 바로 만들 수 있습니다.</h3>
+              <h3 className="mt-3 text-[16px] font-extrabold tracking-[-0.03em] text-slate-900">새 강의와 내 강의 관리를 전용 페이지에서 바로 열 수 있습니다.</h3>
               <p className="mt-2 text-[12px] leading-6 text-slate-500">
-                교수, 강사, 운영자 권한은 강의 목록에서 바로 개설 페이지로 이동해 기본 정보와 차시를 입력하면 됩니다.
+                교수, 강사, 운영자 권한은 강의 목록에서 바로 개설 페이지나 관리 페이지로 이동해 필요한 작업을 이어가면 됩니다.
               </p>
             </div>
-            <button
-              type="button"
-              onClick={() => onNavigate('course-create')}
-              className="rounded-full bg-indigo-600 px-4 py-2.5 text-[13px] font-semibold text-white transition hover:bg-indigo-500"
-            >
-              강의 개설 페이지 열기
-            </button>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => onNavigate('my-courses')}
+                className="rounded-full border border-slate-200 bg-white px-4 py-2.5 text-[13px] font-semibold text-slate-700 transition hover:bg-slate-50"
+              >
+                내 강의 관리
+              </button>
+              <button
+                type="button"
+                onClick={() => onNavigate('course-create')}
+                className="rounded-full bg-indigo-600 px-4 py-2.5 text-[13px] font-semibold text-white transition hover:bg-indigo-500"
+              >
+                강의 개설 페이지 열기
+              </button>
+            </div>
           </div>
         </section>
       ) : null}

--- a/frontend/src/features/lms/pages/MyCoursesPage.tsx
+++ b/frontend/src/features/lms/pages/MyCoursesPage.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { CourseCard, CourseDetail, LoginResponse } from '@myway/shared';
+import { loadManagedCourses } from '../../../lib/api';
+
+type MyCoursesPageProps = {
+  session: LoginResponse;
+  courses: CourseCard[];
+  selectedCourse: CourseDetail | null;
+  onSelectCourse: (courseId: string) => void;
+  onNavigate: (page: 'my-courses' | 'course-create' | 'lecture-studio' | 'courses') => void;
+};
+
+export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse, onNavigate }: MyCoursesPageProps) {
+  const [managedCourses, setManagedCourses] = useState<CourseCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [notice, setNotice] = useState('내가 개설한 강의만 모아서 보고, 바로 개설 워크플로우나 제작 스튜디오로 이어갑니다.');
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      setLoading(true);
+      const result = await loadManagedCourses(session.session_token);
+      if (!active) {
+        return;
+      }
+
+      setManagedCourses(result);
+      setLoading(false);
+      setNotice(result.length > 0 ? `관리 중인 강의 ${result.length}개를 확인할 수 있습니다.` : '아직 관리 중인 강의가 없습니다.');
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [session.session_token]);
+
+  const currentCourses = managedCourses.length > 0
+    ? managedCourses
+    : courses.filter((course) => session.user.role === 'ADMIN' || course.instructor_id === session.user.id);
+
+  const stats = useMemo(
+    () => ({
+      total: currentCourses.length,
+      published: currentCourses.filter((course) => course.is_published).length,
+      totalLectures: currentCourses.reduce((sum, course) => sum + course.lecture_count, 0),
+    }),
+    [currentCourses],
+  );
+
+  return (
+    <div className="space-y-5">
+      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 px-6 py-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-indigo-200">My Courses</div>
+            <h2 className="mt-2 text-[24px] font-extrabold tracking-[-0.04em]">내 강의 관리</h2>
+            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-300">
+              내가 개설한 강의를 한곳에서 확인하고, 바로 개설 워크플로우나 제작 스튜디오로 이동할 수 있습니다.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+            <div className="font-semibold text-white">{session.user.name}</div>
+            <div className="mt-1">{session.user.role}</div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{stats.total}</div>
+          <div className="mt-1 text-[12px] text-slate-500">관리 강의 수</div>
+        </article>
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{stats.published}</div>
+          <div className="mt-1 text-[12px] text-slate-500">공개 강의</div>
+        </article>
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{stats.totalLectures}</div>
+          <div className="mt-1 text-[12px] text-slate-500">총 차시 수</div>
+        </article>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-[15px] font-bold text-slate-900">내가 개설한 강의</h3>
+            <p className="mt-1 text-[12px] text-slate-500">{notice}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onNavigate('course-create')}
+            className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+          >
+            새 강의 개설
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="mt-4 rounded-2xl bg-slate-50 px-4 py-5 text-sm text-slate-500">내 강의 목록을 불러오는 중입니다.</div>
+        ) : currentCourses.length === 0 ? (
+          <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-sm text-slate-500">
+            아직 관리 중인 강의가 없습니다. 강의 개설 워크플로우에서 새 강의를 시작해 주세요.
+          </div>
+        ) : (
+          <div className="mt-4 grid gap-4 xl:grid-cols-2">
+            {currentCourses.map((course) => {
+              const active = selectedCourse?.id === course.id;
+              return (
+                <article
+                  key={course.id}
+                  className={`rounded-3xl border px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)] ${
+                    active ? 'border-indigo-400 bg-indigo-50 ring-2 ring-indigo-100' : 'border-slate-200 bg-white'
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-[14px] font-bold text-slate-900">{course.title}</div>
+                      <div className="mt-1 text-[12px] text-slate-500">
+                        {course.category} · {course.difficulty} · {course.lecture_count}차시
+                      </div>
+                    </div>
+                    <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${course.is_published ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'}`}>
+                      {course.is_published ? '공개' : '비공개'}
+                    </span>
+                  </div>
+
+                  <p className="mt-3 text-[12px] leading-6 text-slate-600">{course.description}</p>
+
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onSelectCourse(course.id);
+                        onNavigate('course-create');
+                      }}
+                      className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                    >
+                      개설 워크플로우
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onSelectCourse(course.id);
+                        onNavigate('lecture-studio');
+                      }}
+                      className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
+                    >
+                      제작 스튜디오
+                    </button>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -101,10 +101,12 @@ export function RolePageRouter({
             courses={courseCards}
             canManageCurrent={true}
             busy={busy}
+            sessionToken={sessionToken}
+            selectedCourse={selectedCourse}
+            highlightedLecture={highlightedLecture}
             onCreateCourse={onCreateCourse}
             onSelectCourse={onSelectCourse}
             onSelectLecture={onSelectLecture}
-            onNavigate={onNavigate}
           />
         );
       case 'admin-users':
@@ -154,10 +156,12 @@ export function RolePageRouter({
           courses={courseCards}
           canManageCurrent={true}
           busy={busy}
+          sessionToken={sessionToken}
+          selectedCourse={selectedCourse}
+          highlightedLecture={highlightedLecture}
           onCreateCourse={onCreateCourse}
           onSelectCourse={onSelectCourse}
           onSelectLecture={onSelectLecture}
-          onNavigate={onNavigate}
         />
       );
     }

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -14,6 +14,7 @@ import { CourseCreatePage } from './CourseCreatePage';
 import { CoursesPage } from './CoursesPage';
 import { InstructorDashboardPage } from './InstructorDashboardPage';
 import { LectureStudioPage } from './LectureStudioPage';
+import { MyCoursesPage } from './MyCoursesPage';
 import { MediaPipelinePage } from './MediaPipelinePage';
 import { MyShortformsPage } from './MyShortformsPage';
 import { QuizGenPage } from './QuizGenPage';
@@ -80,6 +81,16 @@ export function RolePageRouter({
     switch (page) {
       case 'dashboard':
         return <AdminDashboardPage dashboard={dashboard} users={demoUsers} courses={courseCards} insights={insights} />;
+      case 'my-courses':
+        return (
+          <MyCoursesPage
+            session={session}
+            courses={courseCards}
+            selectedCourse={selectedCourse}
+            onSelectCourse={onSelectCourse}
+            onNavigate={onNavigate}
+          />
+        );
       case 'courses':
         return (
           <CoursesPage
@@ -133,6 +144,18 @@ export function RolePageRouter({
   }
 
   if (session.user.role === 'INSTRUCTOR') {
+    if (page === 'my-courses') {
+      return (
+        <MyCoursesPage
+          session={session}
+          courses={courseCards}
+          selectedCourse={selectedCourse}
+          onSelectCourse={onSelectCourse}
+          onNavigate={onNavigate}
+        />
+      );
+    }
+
     if (page === 'courses') {
       return (
         <CoursesPage

--- a/frontend/src/features/lms/types.ts
+++ b/frontend/src/features/lms/types.ts
@@ -17,6 +17,7 @@ import type {
 export type LmsPageId =
   | 'dashboard'
   | 'courses'
+  | 'my-courses'
   | 'course-create'
   | 'lecture-studio'
   | 'shortform'

--- a/frontend/src/lib/api-courses.ts
+++ b/frontend/src/lib/api-courses.ts
@@ -1,6 +1,7 @@
 import {
   createCourseRecord,
   canEnroll,
+  canManageCourses,
   completeLectureProgress,
   enrollUser,
   getCourseDetail,
@@ -31,6 +32,27 @@ export async function loadCourses(sessionToken?: string | null): Promise<CourseC
   const userId = getFallbackUserId();
   const response = await request<CourseCard[]>(`/api/v1/courses?userId=${encodeURIComponent(userId)}`, undefined, token);
   return unwrap(response, () => getDashboard(userId).courses);
+}
+
+export async function loadManagedCourses(sessionToken?: string | null): Promise<CourseCard[]> {
+  const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
+  const storedAuth = getStoredAuth();
+
+  if (!storedAuth) {
+    return [];
+  }
+
+  const response = await request<CourseCard[]>('/api/v1/courses/manage', undefined, token);
+  if (response?.success && response.data) {
+    return response.data;
+  }
+
+  const fallbackCourses = await loadCourses(token);
+  if (!canManageCourses(storedAuth.user.role)) {
+    return [];
+  }
+
+  return fallbackCourses.filter((course) => storedAuth.user.role === 'ADMIN' || course.instructor_id === storedAuth.user.id);
 }
 
 export async function createCourse(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,6 +32,7 @@ export {
 } from './api-shortforms';
 export {
   loadCourses,
+  loadManagedCourses,
   createCourse,
   loadCourseDetail,
   loadLectureDetail,


### PR DESCRIPTION
﻿## 변경 요약
- 강의 관리 전용 탭(`내 강의 관리`)을 추가하고, 강의 개설은 2단계 워크플로우로 단순화했습니다.
- 첫 화면에서 입력한 정보는 유지되고, 다음 단계에서 강의 개설을 확정한 뒤 필요하면 자동으로 업로드와 STT 전사가 이어지게 했습니다.
- `미디어 파이프라인`은 기본 사용자 흐름에서 빼고, 운영/세부 확인용으로만 남겼습니다.

## 배경
- 기존에는 강의 목록, 강의 개설, 제작 스튜디오, 미디어 파이프라인이 분리되어 있어서 사용자가 흐름을 따라가기 불편했습니다.
- 강의 개설 정보를 입력한 뒤 다른 화면으로 이동하면 상태가 끊기는 문제가 있었습니다.
- 개설이 끝난 뒤 별도 화면에서 업로드와 추출을 다시 시작해야 해서 동선이 길었습니다.
- 교수/강사 입장에서는 `내 강의 관리`에서 시작해 개설과 제작을 한 흐름으로 이어가는 편이 더 자연스럽습니다.

## 변경 내용
- `frontend/src/features/lms/types.ts`에 `my-courses` 페이지를 추가했습니다.
- `frontend/src/features/lms/config.ts`에서 교수/강사 기본 진입점을 `내 강의 관리`로 바꾸고 메뉴에 추가했습니다.
- `frontend/src/features/lms/pages/MyCoursesPage.tsx`를 새로 만들어 내가 관리하는 강의를 모아서 보고, 개설 워크플로우나 제작 스튜디오로 바로 이동할 수 있게 했습니다.
- `frontend/src/features/lms/pages/CourseCreatePage.tsx`를 2단계 워크플로우로 정리해서, 첫 화면에서는 정보 입력만 하고 다음 단계에서 강의를 실제로 개설하도록 바꿨습니다.
- `frontend/src/features/lms/components/CourseCreateCard.tsx`를 prepare 모드에 맞게 바꿔서, 첫 단계는 `다음`으로 저장만 하게 했습니다.
- `frontend/src/features/lms/pages/RolePageRouter.tsx`에서 `my-courses` 페이지를 실제로 렌더링하도록 연결했습니다.
- `backend/src/routes/courses.ts`에 `GET /api/v1/courses/manage`를 추가해서 관리 중인 강의 목록을 별도로 조회할 수 있게 했습니다.
- `frontend/src/features/lms/pages/CoursesPage.tsx`에 `내 강의 관리` 바로가기 버튼을 넣어 목록에서 관리 페이지로 자연스럽게 이동하게 했습니다.

## 연결 이슈
- Closes #152
- Fixes #146

## 검증
- [x] `npm run verify` 통과
- [x] 프론트/백엔드 타입 검사 통과
- [x] 개발 로그 갱신 완료

## 코드리뷰
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 요구사항에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
