### PR TITLE
[Feature] 무료 AI API 기반 transcript 검색·인텐트 연결

### DIFF
--- a/docs/dev-logs/2026-04-13-ai-transcript-corpus-policy-ab-comparison.md
+++ b/docs/dev-logs/2026-04-13-ai-transcript-corpus-policy-ab-comparison.md
@@ -1,0 +1,18 @@
+# 2026-04-13 AI transcript corpus policy A/B comparison
+
+## 변경 요약
+- `#150`의 AI 검색/인텐트/답변/요약 연결을 A/B 워킹트리로 비교했다.
+- A안은 `createAISummary`와 `generateAIQuiz`만 전사 본문 우선으로 바꾸는 최소 수정이었다.
+- B안은 강의 전사/요약/본문을 하나의 `lecture source snapshot`으로 묶고, 검색 reference 순서도 transcript 우선으로 재정렬하는 방식이었다.
+
+## 선택 결과
+- B안을 채택했다.
+
+## 선택 이유
+- 검색과 요약이 서로 다른 소스 우선순위를 쓰면, 사용자는 같은 강의를 두 번 물어도 다른 근거를 받는다고 느낄 수 있다.
+- B안은 transcript, note, lecture 본문을 하나의 snapshot으로 묶어서 `summary/quiz`와 `search/answer`가 같은 기준을 보게 만든다.
+- transcript를 앞에 두기 때문에 STT가 쌓일수록 검색 품질이 자연스럽게 올라간다.
+
+## 제외한 방향
+- A안은 수정 범위가 작지만, summary/quiz만 고치고 검색 corpus 순서는 그대로 남겨서 일관성이 약하다.
+- 기능별로 source order가 갈라지면 이후 디버깅과 품질 개선이 다시 복잡해진다.

--- a/packages/shared/src/ai/ai-learning.ts
+++ b/packages/shared/src/ai/ai-learning.ts
@@ -1,6 +1,5 @@
 import { getLectureDetail } from '../lms/learning';
-import { collectLectureReferences } from './intent/corpus';
-import { getLectureTranscript, listLectureNotes } from '../lms/media';
+import { buildLectureSourceSnapshot, collectLectureReferences } from './intent/corpus';
 import type {
   AIQuizQuestion,
   AIQuizRequest,
@@ -139,9 +138,10 @@ export async function createAISummary(
     return null;
   }
 
-  const transcript = await getLectureTranscript(lecture.id, repository);
-  const note = (await listLectureNotes(lecture.id, repository))[0];
-  const sourceText = note?.content ?? transcript?.full_text ?? lecture.content_text;
+  const snapshot = await buildLectureSourceSnapshot(lecture.id, repository);
+  const transcript = snapshot?.transcript ?? null;
+  const note = snapshot?.note ?? null;
+  const sourceText = snapshot?.source_text ?? lecture.content_text;
   const style = input.style ?? 'brief';
   const titleSuffix =
     style === 'detailed'
@@ -174,9 +174,10 @@ export async function generateAIQuiz(
     return null;
   }
 
-  const transcript = await getLectureTranscript(lecture.id, repository);
-  const note = (await listLectureNotes(lecture.id, repository))[0];
-  const sourceText = note?.content ?? transcript?.full_text ?? lecture.content_text;
+  const snapshot = await buildLectureSourceSnapshot(lecture.id, repository);
+  const transcript = snapshot?.transcript ?? null;
+  const note = snapshot?.note ?? null;
+  const sourceText = snapshot?.source_text ?? lecture.content_text;
   const concepts = collectQuizConcepts(sourceText, lecture.title, lecture.course_title);
   let count = input.count ?? 4;
   if (input.difficulty === 'hard') {

--- a/packages/shared/src/ai/intent/corpus.ts
+++ b/packages/shared/src/ai/intent/corpus.ts
@@ -4,6 +4,13 @@ import { getLectureTranscript, listLectureNotes, type MediaRepository, memoryMed
 import type { AIChunkSource, AIReference, AISearchHit, AIRagChunk, AIRagRequest } from '../../types';
 import { buildChunkText as buildChunkTextFromText, scoreChunk as scoreChunkFromText } from './helpers';
 
+export type LectureSourceSnapshot = {
+  lecture: NonNullable<ReturnType<typeof getLectureDetail>>;
+  transcript: Awaited<ReturnType<typeof getLectureTranscript>> | null;
+  note: Awaited<ReturnType<typeof listLectureNotes>>[number] | null;
+  source_text: string;
+};
+
 function listTargetLectureIds(lectureId?: string): string[] {
   if (lectureId) {
     return [lectureId];
@@ -18,6 +25,26 @@ export function buildChunkText(text: string, maxChunks = 3): string[] {
 
 export function scoreChunk(queryTokens: string[], candidateText: string, title: string): number {
   return scoreChunkFromText(queryTokens, candidateText, title);
+}
+
+export async function buildLectureSourceSnapshot(
+  lectureId: string,
+  repository: MediaRepository = memoryMediaRepository,
+): Promise<LectureSourceSnapshot | null> {
+  const lecture = getLectureDetail(lectureId);
+  if (!lecture) {
+    return null;
+  }
+
+  const transcript = await getLectureTranscript(lecture.id, repository);
+  const note = (await listLectureNotes(lecture.id, repository))[0] ?? null;
+
+  return {
+    lecture,
+    transcript,
+    note,
+    source_text: [transcript?.full_text, note?.content, lecture.content_text].filter(Boolean).join('\n\n'),
+  };
 }
 
 function countTokens(text: string): number {
@@ -54,29 +81,14 @@ export async function collectLectureReferences(
   lectureId: string,
   repository: MediaRepository = memoryMediaRepository,
 ): Promise<AIReference[]> {
-  const lecture = getLectureDetail(lectureId);
-  if (!lecture) {
+  const snapshot = await buildLectureSourceSnapshot(lectureId, repository);
+  if (!snapshot) {
     return [];
   }
 
+  const { lecture, transcript, note } = snapshot;
   const references: AIReference[] = [];
   const lectureChunks = buildChunkText(`${lecture.title}. ${lecture.content_text}`, 2);
-
-  lectureChunks.forEach((chunk, index) => {
-    references.push(
-      createReference(
-        lecture.id,
-        'lecture',
-        lecture.id,
-        `${lecture.course_title} · ${lecture.title} · 강의 본문`,
-        chunk,
-        index,
-        0.82 - index * 0.05,
-      ),
-    );
-  });
-
-  const transcript = await getLectureTranscript(lecture.id, repository);
   transcript?.segments.slice(0, 2).forEach((segment, index) => {
     references.push(
       createReference(
@@ -91,7 +103,6 @@ export async function collectLectureReferences(
     );
   });
 
-  const note = (await listLectureNotes(lecture.id, repository))[0];
   if (note) {
     const noteChunks = buildChunkText(`${note.title}. ${note.content}`, 2);
     noteChunks.slice(0, 2).forEach((chunk, index) => {
@@ -109,6 +120,20 @@ export async function collectLectureReferences(
     });
   }
 
+  lectureChunks.forEach((chunk, index) => {
+    references.push(
+      createReference(
+        lecture.id,
+        'lecture',
+        lecture.id,
+        `${lecture.course_title} · ${lecture.title} · 강의 본문`,
+        chunk,
+        index,
+        0.82 - index * 0.05,
+      ),
+    );
+  });
+
   return references;
 }
 
@@ -123,31 +148,13 @@ export async function buildCorpusForLecture(
   lectureId: string,
   repository: MediaRepository = memoryMediaRepository,
 ): Promise<AIRagChunk[]> {
-  const lecture = getLectureDetail(lectureId);
-  if (!lecture) {
+  const snapshot = await buildLectureSourceSnapshot(lectureId, repository);
+  if (!snapshot) {
     return [];
   }
 
-  const transcript = await getLectureTranscript(lectureId, repository);
-  const note = (await listLectureNotes(lectureId, repository))[0];
+  const { lecture, transcript, note } = snapshot;
   const chunks: AIRagChunk[] = [];
-
-  const lectureChunks = buildChunkText(`${lecture.title}. ${lecture.content_text}`, 2);
-  lectureChunks.forEach((chunk, index) => {
-    chunks.push({
-      id: `lecture_${lecture.id}_${String(index + 1).padStart(2, '0')}`,
-      lecture_id: lecture.id,
-      source_type: 'lecture',
-      source_id: lecture.id,
-      title: `${lecture.course_title} · ${lecture.title} · 강의 본문`,
-      content: chunk.slice(0, 240),
-      excerpt: chunk.slice(0, 240),
-      similarity: 0,
-      chunk_index: index,
-      source_scope: 'lecture',
-      token_count: countTokens(chunk),
-    });
-  });
 
   transcript?.segments.forEach((segment) => {
     const content = segment.text.trim();
@@ -190,6 +197,23 @@ export async function buildCorpusForLecture(
       });
     });
   }
+
+  const lectureChunks = buildChunkText(`${lecture.title}. ${lecture.content_text}`, 2);
+  lectureChunks.forEach((chunk, index) => {
+    chunks.push({
+      id: `lecture_${lecture.id}_${String(index + 1).padStart(2, '0')}`,
+      lecture_id: lecture.id,
+      source_type: 'lecture',
+      source_id: lecture.id,
+      title: `${lecture.course_title} · ${lecture.title} · 강의 본문`,
+      content: chunk.slice(0, 240),
+      excerpt: chunk.slice(0, 240),
+      similarity: 0,
+      chunk_index: index,
+      source_scope: 'lecture',
+      token_count: countTokens(chunk),
+    });
+  });
 
   return chunks;
 }


### PR DESCRIPTION
﻿# 변경 요약
AI 검색/인텐트/답변/요약이 같은 강의 전사 축을 보도록 정리했습니다. B안은 transcript, note, lecture 본문을 하나의 snapshot으로 묶고 search corpus의 우선순위도 transcript 우선으로 맞춥니다.

## 배경
무료 AI API 환경에서는 provider fallback만 맞는다고 끝나지 않고, 같은 강의에 대해 검색과 요약이 서로 다른 소스를 보면 사용자 경험이 흔들립니다. 전사 데이터가 쌓일수록 같은 기준을 반복해서 써야 검색 품질도 올라갑니다.

## 변경 내용
- lecture 단위 source snapshot을 추가했습니다.
- summary/quiz가 transcript, note, lecture 본문을 같은 순서로 읽도록 맞췄습니다.
- search corpus가 transcript를 먼저 보도록 재정렬했습니다.
- A/B 비교 기록을 dev log에 남겼습니다.

## 연결 이슈
- Closes #150
- Fixes #150

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
