### PR TITLE
feat: redesign home, lecture watch, and shortform UX

### DIFF
--- a/docs/dev-logs/2026-04-13-ux-home-lecture-shortform-ab.md
+++ b/docs/dev-logs/2026-04-13-ux-home-lecture-shortform-ab.md
@@ -1,0 +1,26 @@
+# 2026-04-13 UX Home Lecture Shortform AB
+
+## 변경 요약
+- 홈 화면을 탐색 허브 형태로 재구성했다.
+- 강의 상세와 강의 시청 페이지를 분리하고 `lecture-watch` 경로를 추가했다.
+- 숏폼 제작 화면에 단계 요약, 고정 사이드바, 진행 맥락을 보강했다.
+
+## 검증
+- `npm --workspace @myway/frontend run build`
+
+## 선택 이유
+- 숏폼 제작 흐름에 단계 안내와 고정 요약이 더 잘 드러나고, 사용자가 현재 위치와 다음 행동을 더 쉽게 이해할 수 있다.
+- 홈과 강의 시청 분리도 유지하면서, 전체적으로 작업 맥락을 잃지 않도록 구성된 쪽이 B였다.
+
+## 영향 범위
+- `frontend/src/features/lms/pages/PublicHomePage.tsx`
+- `frontend/src/features/lms/components/CourseExploreDetailPanel.tsx`
+- `frontend/src/features/lms/pages/LectureWatchPage.tsx`
+- `frontend/src/features/lms/pages/RolePageRouter.tsx`
+- `frontend/src/features/lms/pages/CoursesPage.tsx`
+- `frontend/src/features/lms/config.ts`
+- `frontend/src/features/lms/types.ts`
+- `frontend/src/features/lms/components/ShortformWizard.tsx`
+- `frontend/src/features/lms/components/ShortformWizardSidebar.tsx`
+- `frontend/src/features/lms/components/ShortformWizardStep2.tsx`
+- `frontend/src/features/lms/components/ShortformWizardStep3.tsx`

--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -6,11 +6,12 @@ type CourseExploreDetailPanelProps = {
   course: CourseDetail | null;
   highlightedLecture: LectureDetail | null;
   selectedLectureId: string;
+  viewMode: 'detail' | 'watch';
   activeTab: '강의' | '공지' | '자료' | 'Q&A';
   canManageCurrent: boolean;
   onSelectLecture: (lectureId: string) => void;
   onTabChange: (tab: '강의' | '공지' | '자료' | 'Q&A') => void;
-  onNavigate: (page: 'courses' | 'shortform' | 'ai-chat' | 'course-create' | 'lecture-studio' | 'media-pipeline') => void;
+  onNavigate: (page: 'courses' | 'lecture-watch' | 'shortform' | 'ai-chat' | 'course-create' | 'lecture-studio' | 'media-pipeline') => void;
 };
 
 const courseTabs: { key: '강의' | '공지' | '자료' | 'Q&A'; label: string; icon: string }[] = [
@@ -116,6 +117,7 @@ export function CourseExploreDetailPanel({
   course,
   highlightedLecture,
   selectedLectureId,
+  viewMode,
   activeTab,
   canManageCurrent,
   onSelectLecture,
@@ -246,36 +248,59 @@ export function CourseExploreDetailPanel({
                           <i className="ri-play-circle-line" />
                         </div>
                       </div>
-                      <p className="mt-4 text-[13px] leading-7 text-slate-600">{detailLecture.transcript_excerpt}</p>
-                      {detailLecture.video_url ? (
+                      <p className="mt-4 text-[13px] leading-7 text-slate-600">
+                        {viewMode === 'watch' ? detailLecture.transcript_excerpt : course.description}
+                      </p>
+                      {viewMode === 'watch' && detailLecture.video_url ? (
                         <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-black">
                           <video className="h-auto w-full max-h-[240px]" controls preload="metadata" src={detailLecture.video_url} />
                         </div>
                       ) : null}
                       <div className="mt-4 flex flex-wrap gap-2">
-                        <button
-                          type="button"
-                          onClick={() => onNavigate('ai-chat')}
-                          className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
-                        >
-                          챗봇으로 질문
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => onNavigate('shortform')}
-                          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
-                        >
-                          숏폼 만들기
-                        </button>
-                        {canManageCurrent ? (
-                          <button
-                            type="button"
-                            onClick={() => onNavigate('media-pipeline')}
-                            className="rounded-full border border-indigo-200 bg-indigo-50 px-4 py-2 text-[12px] font-semibold text-indigo-700 transition hover:bg-indigo-100"
-                          >
-                            업로드/전사 관리
-                          </button>
-                        ) : null}
+                        {viewMode === 'watch' ? (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => onNavigate('courses')}
+                              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
+                            >
+                              강의 상세로 돌아가기
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => onNavigate('shortform')}
+                              className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                            >
+                              숏폼 만들기
+                            </button>
+                            {canManageCurrent ? (
+                              <button
+                                type="button"
+                                onClick={() => onNavigate('media-pipeline')}
+                                className="rounded-full border border-indigo-200 bg-indigo-50 px-4 py-2 text-[12px] font-semibold text-indigo-700 transition hover:bg-indigo-100"
+                              >
+                                업로드/전사 관리
+                              </button>
+                            ) : null}
+                          </>
+                        ) : (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => onNavigate('lecture-watch')}
+                              className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                            >
+                              강의 시청으로 이동
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => onNavigate('ai-chat')}
+                              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
+                            >
+                              챗봇으로 질문
+                            </button>
+                          </>
+                        )}
                       </div>
                     </div>
                   ) : null}

--- a/frontend/src/features/lms/components/ShortformWizard.tsx
+++ b/frontend/src/features/lms/components/ShortformWizard.tsx
@@ -207,6 +207,7 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
 
   const totalDurationMs = selectedClips.reduce((sum, clip) => sum + (clip.end_time_ms - clip.start_time_ms), 0);
   const totalDurationLabel = formatDuration(totalDurationMs);
+  const stepLabel = step === 1 ? '강좌 선택' : step === 2 ? '구간 선택' : '미리보기 / 저장';
 
   async function handleCompose() {
     if (!courseDetail || selectedClips.length === 0) {
@@ -284,16 +285,60 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
 
   return (
     <div className="space-y-5">
+      <section className="overflow-hidden rounded-3xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-[0_1px_3px_rgba(15,23,42,0.05)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
+              <i className="ri-scissors-cut-line" />
+              숏폼 제작 허브
+            </div>
+            <h1 className="mt-3 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[30px]">선택이 쉬운 숏폼 제작 화면</h1>
+            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-white/75">
+              강좌 선택, 추천 구간 선택, 미리보기 저장을 하나의 흐름으로 정리해 중간에 길을 잃지 않도록 바꿨습니다.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+              <div className="font-semibold text-white">현재 강좌</div>
+              <div className="mt-1">{courseDetail?.title ?? '강좌 선택 필요'}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+              <div className="font-semibold text-white">선택 클립</div>
+              <div className="mt-1">{selectedClips.length}개 · {totalDurationLabel}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+              <div className="font-semibold text-white">현재 단계</div>
+              <div className="mt-1">{stepLabel}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-2xl bg-white/10 px-4 py-3 text-[12px] text-slate-200 backdrop-blur">
+            <div className="font-semibold text-white">차시 바로 시작</div>
+            <div className="mt-1">현재 보고 있는 강의에서 곧바로 구간을 좁힐 수 있습니다.</div>
+          </div>
+          <div className="rounded-2xl bg-white/10 px-4 py-3 text-[12px] text-slate-200 backdrop-blur">
+            <div className="font-semibold text-white">추천 구간 확인</div>
+            <div className="mt-1">차시별 추천 후보를 탭으로 빠르게 좁힙니다.</div>
+          </div>
+          <div className="rounded-2xl bg-white/10 px-4 py-3 text-[12px] text-slate-200 backdrop-blur">
+            <div className="font-semibold text-white">저장 전 확인</div>
+            <div className="mt-1">미리보기와 제목을 마지막에 정리할 수 있습니다.</div>
+          </div>
+        </div>
+      </section>
+
       <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.05)]">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <h1 className="text-[20px] font-extrabold tracking-[-0.03em] text-slate-900">숏폼 제작</h1>
+            <h2 className="text-[20px] font-extrabold tracking-[-0.03em] text-slate-900">제작 흐름</h2>
             <p className="mt-2 text-[13px] leading-6 text-slate-500">
-              강좌 선택 → 차시별 구간 선택 → 제목/미리보기/저장의 3단계로 구성해, 레퍼런스와 같은 제작 흐름을 유지합니다.
+              강좌 선택 → 차시별 구간 선택 → 제목/미리보기/저장의 3단계로 정리했습니다.
             </p>
           </div>
           <span className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">
-            {courseDetail?.title ?? '강좌 선택 필요'}
+            {selectedClips.length}개 클립
           </span>
         </div>
 

--- a/frontend/src/features/lms/components/ShortformWizardSidebar.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardSidebar.tsx
@@ -16,7 +16,7 @@ export function ShortformWizardSidebar({
   communityItems,
 }: ShortformWizardSidebarProps) {
   return (
-    <aside className="space-y-5">
+    <aside className="space-y-5 lg:sticky lg:top-20">
       <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
         <h3 className="text-[15px] font-bold text-slate-900">선택 요약</h3>
         <div className="mt-4 space-y-3">
@@ -33,6 +33,24 @@ export function ShortformWizardSidebar({
           <div className="rounded-2xl bg-slate-50 px-4 py-4">
             <div className="text-[12px] text-slate-500">선택한 강의</div>
             <div className="mt-1 text-[14px] font-semibold text-slate-900">{highlightedLectureTitle ?? '없음'}</div>
+          </div>
+        </div>
+      </article>
+
+      <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+        <h3 className="text-[15px] font-bold text-slate-900">작업 흐름</h3>
+        <div className="mt-4 space-y-2 text-[13px] leading-6 text-slate-500">
+          <div className="rounded-2xl bg-slate-50 px-4 py-3">
+            <span className="font-semibold text-slate-800">1. 강좌 선택</span>
+            <p className="mt-1">숏폼을 만들 강의를 먼저 고릅니다.</p>
+          </div>
+          <div className="rounded-2xl bg-slate-50 px-4 py-3">
+            <span className="font-semibold text-slate-800">2. 구간 선택</span>
+            <p className="mt-1">추천 구간을 눌러 후보를 좁힙니다.</p>
+          </div>
+          <div className="rounded-2xl bg-slate-50 px-4 py-3">
+            <span className="font-semibold text-slate-800">3. 미리보기 저장</span>
+            <p className="mt-1">제목과 설명을 정리하고 저장합니다.</p>
           </div>
         </div>
       </article>

--- a/frontend/src/features/lms/components/ShortformWizardStep2.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep2.tsx
@@ -39,9 +39,14 @@ export function ShortformWizardStep2({
           </div>
           <p className="mt-1 text-[12px] text-slate-500">레퍼런스처럼 차시 필터 탭으로 구간을 좁히고, 핵심 구간을 카드 단위로 선택합니다.</p>
         </div>
-        <button type="button" onClick={onBack} className="rounded-full border border-slate-200 px-4 py-2 text-[12px] font-semibold text-slate-600">
-          이전
-        </button>
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">
+            선택 {selectedClipKeys.length}개
+          </span>
+          <button type="button" onClick={onBack} className="rounded-full border border-slate-200 px-4 py-2 text-[12px] font-semibold text-slate-600">
+            이전
+          </button>
+        </div>
       </div>
 
       <div className="mt-4 flex gap-2 overflow-x-auto pb-1">

--- a/frontend/src/features/lms/components/ShortformWizardStep3.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep3.tsx
@@ -80,9 +80,12 @@ export function ShortformWizardStep3({
           </div>
           <p className="mt-1 text-[12px] text-slate-500">선택한 클립을 미리보고 제목과 설명을 입력한 뒤 저장합니다.</p>
         </div>
-        <button type="button" onClick={onBack} className="rounded-full border border-slate-200 px-4 py-2 text-[12px] font-semibold text-slate-600">
-          이전
-        </button>
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">{formatDuration(totalDurationMs)} 합계</span>
+          <button type="button" onClick={onBack} className="rounded-full border border-slate-200 px-4 py-2 text-[12px] font-semibold text-slate-600">
+            이전
+          </button>
+        </div>
       </div>
 
       <div className="overflow-hidden rounded-3xl bg-slate-950 p-5 text-white">

--- a/frontend/src/features/lms/config.ts
+++ b/frontend/src/features/lms/config.ts
@@ -21,6 +21,7 @@ export function pageTitle(page: LmsPageId, role: UserRole): string {
   const titles: Record<LmsPageId, string> = {
     dashboard: '홈',
     courses: '강의 목록',
+    'lecture-watch': '강의 시청',
     'my-courses': '내 강의 관리',
     'course-create': '강의 워크스페이스',
     'lecture-studio': '강의 제작 스튜디오',

--- a/frontend/src/features/lms/pages/CoursesPage.tsx
+++ b/frontend/src/features/lms/pages/CoursesPage.tsx
@@ -154,6 +154,7 @@ export function CoursesPage({
               course={course}
               highlightedLecture={detailLecture}
               selectedLectureId={selectedLectureId}
+              viewMode="detail"
               activeTab={activeTab}
               canManageCurrent={canManageCurrent}
               onSelectLecture={onSelectLecture}

--- a/frontend/src/features/lms/pages/LectureWatchPage.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPage.tsx
@@ -1,0 +1,67 @@
+import type { CourseDetail, LectureDetail } from '@myway/shared';
+import { CourseExploreDetailPanel } from '../components/CourseExploreDetailPanel';
+
+type LectureWatchPageProps = {
+  selectedCourse: CourseDetail | null;
+  highlightedLecture: LectureDetail | null;
+  selectedLectureId: string;
+  canManageCurrent: boolean;
+  onSelectLecture: (lectureId: string) => void;
+  onNavigate: (page: 'courses' | 'lecture-watch' | 'shortform' | 'ai-chat' | 'course-create' | 'lecture-studio' | 'media-pipeline') => void;
+};
+
+export function LectureWatchPage({
+  selectedCourse,
+  highlightedLecture,
+  selectedLectureId,
+  canManageCurrent,
+  onSelectLecture,
+  onNavigate,
+}: LectureWatchPageProps) {
+  return (
+    <div className="space-y-5">
+      <section className="overflow-hidden rounded-3xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
+              <i className="ri-play-circle-line" />
+              강의 시청
+            </div>
+            <h1 className="mt-3 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[30px]">
+              강의는 여기서 보고, 상세는 한 단계 뒤로
+            </h1>
+            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-white/75">
+              시청 화면은 재생, 메모, 다음 차시 이동에 집중하고, 강의 소개와 공지는 상세 페이지에서 이어서 볼 수 있게 분리했습니다.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+              <div className="font-semibold text-white">선택 강의</div>
+              <div className="mt-1">{selectedCourse?.title ?? '강의 미선택'}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+              <div className="font-semibold text-white">현재 차시</div>
+              <div className="mt-1">{highlightedLecture?.title ?? '차시 미선택'}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+              <div className="font-semibold text-white">역할</div>
+              <div className="mt-1">{canManageCurrent ? '교강사 시청 모드' : '학습자 시청 모드'}</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <CourseExploreDetailPanel
+        course={selectedCourse}
+        highlightedLecture={highlightedLecture}
+        selectedLectureId={selectedLectureId}
+        viewMode="watch"
+        activeTab="강의"
+        canManageCurrent={canManageCurrent}
+        onSelectLecture={onSelectLecture}
+        onTabChange={() => undefined}
+        onNavigate={onNavigate}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/lms/pages/PublicHomePage.tsx
+++ b/frontend/src/features/lms/pages/PublicHomePage.tsx
@@ -74,6 +74,7 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
   const totalProgress = Math.round(
     courseCards.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courseCards.length, 1),
   );
+  const visualCourses = courseCards.slice(0, 3);
 
   return (
     <div className="min-h-screen bg-[#f8f9fb]">
@@ -123,23 +124,23 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
       </header>
 
       <main className="mx-auto max-w-[1320px] space-y-6 px-4 py-6 sm:px-6 lg:px-8">
-        <section className="grid gap-5">
-          <div className="relative overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#6d62ef_0%,#4f46e5_46%,#7c3aed_100%)] px-7 py-8 text-white shadow-[0_30px_70px_rgba(79,70,229,0.16)] lg:px-8 lg:py-9">
+        <section className="grid gap-5 xl:grid-cols-[1.15fr_0.85fr]">
+          <div className="relative overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-7 py-8 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8 lg:py-9">
             <div className="pointer-events-none absolute -right-8 top-10 h-64 w-64 rounded-full bg-white/10 blur-3xl" />
             <div className="pointer-events-none absolute -bottom-20 left-1/3 h-56 w-56 rounded-full bg-cyan-300/10 blur-3xl" />
 
             <div className="relative z-10 max-w-2xl">
               <span className="inline-flex rounded-full bg-white/14 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
-                AI 기반 맞춤형 학습 플랫폼
+                강의 탐색 허브
               </span>
               <h1 className="mt-5 text-[2.1rem] font-extrabold tracking-[-0.05em] text-white lg:text-[3.2rem]">
-                내맘대로 배우고,
+                찾기 쉽고,
                 <br />
-                내맘대로 성장하세요
+                보기 쉬운 학습 화면
               </h1>
               <p className="mt-4 max-w-2xl text-[14px] leading-7 text-white/80 lg:text-[15px]">
-                강의 탐색, 자동 STT 전사, 우측 챗봇, 숏폼 복습까지 하나의 흐름으로 이어지는 LMS 메인 화면입니다.
-                로그인 전에는 탐색과 체험만, 로그인 후에는 학습과 제작이 바로 연결됩니다.
+                검색, 카테고리, 추천 강의, 이미지 섹션을 첫 화면에 모아두고 상세와 시청은 다음 단계로 분리했습니다.
+                사용자는 무엇부터 눌러야 하는지 바로 알 수 있습니다.
               </p>
 
               <div className="mt-7 flex flex-wrap gap-3">
@@ -155,7 +156,7 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
                   onClick={onOpenLogin}
                   className="rounded-full border border-white/30 bg-white/10 px-5 py-3 text-[13px] font-semibold text-white backdrop-blur transition hover:bg-white/15"
                 >
-                  무료로 시작하기
+                  로그인 후 계속
                 </button>
               </div>
 
@@ -172,6 +173,83 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
                   </span>
                 )}
               </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4">
+            <div className="rounded-[28px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Search</div>
+                  <h2 className="mt-2 text-[18px] font-extrabold tracking-[-0.03em] text-slate-900">원하는 강의를 바로 찾기</h2>
+                </div>
+                <button
+                  type="button"
+                  onClick={onOpenLogin}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
+                >
+                  로그인
+                </button>
+              </div>
+              <div className="mt-4 relative">
+                <i className="ri-search-line pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" />
+                <input
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="강좌명, 카테고리, 태그, 강사명 검색"
+                  className="h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 pl-11 pr-4 text-[13px] text-slate-900 outline-none placeholder:text-slate-400 focus:border-indigo-300 focus:bg-white"
+                />
+              </div>
+              <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <div className="rounded-2xl bg-slate-50 px-4 py-3">
+                  <div className="text-[11px] text-slate-500">평균 진도</div>
+                  <div className="mt-1 text-[18px] font-extrabold text-slate-900">{totalProgress}%</div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3">
+                  <div className="text-[11px] text-slate-500">강의</div>
+                  <div className="mt-1 text-[18px] font-extrabold text-slate-900">{courseCards.length}</div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3">
+                  <div className="text-[11px] text-slate-500">카테고리</div>
+                  <div className="mt-1 text-[18px] font-extrabold text-slate-900">{categories.length}</div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-4 py-3">
+                  <div className="text-[11px] text-slate-500">태그</div>
+                  <div className="mt-1 text-[18px] font-extrabold text-slate-900">{countUnique(courseCards.flatMap((course) => course.tags))}</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              {visualCourses.length > 0 ? (
+                visualCourses.map((course) => (
+                  <article
+                    key={course.id}
+                    className="overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-sm transition hover:-translate-y-0.5"
+                  >
+                    <div className="relative h-32 bg-[linear-gradient(135deg,#4338ca,#1d4ed8)]">
+                      <div className="absolute inset-0 opacity-20">
+                        <i className={`${course.thumbnail_palette === 'emerald' ? 'ri-layout-grid-line' : course.thumbnail_palette === 'violet' ? 'ri-video-line' : course.thumbnail_palette === 'amber' ? 'ri-lightbulb-flash-line' : 'ri-brain-line'} absolute -right-5 -bottom-5 text-[92px] text-white`} />
+                      </div>
+                      <div className="absolute left-4 top-4 rounded-full bg-white/15 px-2.5 py-1 text-[10px] font-semibold text-white backdrop-blur">
+                        {course.category}
+                      </div>
+                    </div>
+                    <div className="px-4 py-4">
+                      <div className="text-[11px] text-slate-500">{course.instructor_name}</div>
+                      <div className="mt-1 line-clamp-2 text-[15px] font-bold tracking-[-0.02em] text-slate-900">{course.title}</div>
+                      <div className="mt-3 flex items-center justify-between text-[11px] text-slate-500">
+                        <span>{course.lecture_count}강의</span>
+                        <span>{course.enrolled ? `${course.progress_percent}% 진행` : '수강 전'}</span>
+                      </div>
+                    </div>
+                  </article>
+                ))
+              ) : (
+                <div className="sm:col-span-3 rounded-[28px] border border-dashed border-slate-200 bg-white px-5 py-7 text-center text-[13px] text-slate-500">
+                  아직 소개할 강의가 없습니다.
+                </div>
+              )}
             </div>
           </div>
         </section>

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -13,6 +13,7 @@ import { CommunityPage } from './CommunityPage';
 import { CourseCreatePage } from './CourseCreatePage';
 import { CoursesPage } from './CoursesPage';
 import { InstructorDashboardPage } from './InstructorDashboardPage';
+import { LectureWatchPage } from './LectureWatchPage';
 import { LectureStudioPage } from './LectureStudioPage';
 import { MyCoursesPage } from './MyCoursesPage';
 import { MediaPipelinePage } from './MediaPipelinePage';
@@ -107,6 +108,17 @@ export function RolePageRouter({
             onSelectLecture={onSelectLecture}
           />
         );
+      case 'lecture-watch':
+        return (
+          <LectureWatchPage
+            selectedCourse={selectedCourse}
+            highlightedLecture={highlightedLecture}
+            selectedLectureId={selectedLectureId}
+            canManageCurrent={true}
+            onSelectLecture={onSelectLecture}
+            onNavigate={onNavigate}
+          />
+        );
       case 'course-create':
         return (
           <CourseCreatePage
@@ -178,6 +190,19 @@ export function RolePageRouter({
           onNavigate={onNavigate}
           onSelectCourse={onSelectCourse}
           onSelectLecture={onSelectLecture}
+        />
+      );
+    }
+
+    if (page === 'lecture-watch') {
+      return (
+        <LectureWatchPage
+          selectedCourse={selectedCourse}
+          highlightedLecture={highlightedLecture}
+          selectedLectureId={selectedLectureId}
+          canManageCurrent={true}
+          onSelectLecture={onSelectLecture}
+          onNavigate={onNavigate}
         />
       );
     }
@@ -269,6 +294,19 @@ export function RolePageRouter({
         onNavigate={onNavigate}
         onSelectCourse={onSelectCourse}
         onSelectLecture={onSelectLecture}
+      />
+    );
+  }
+
+  if (page === 'lecture-watch') {
+    return (
+      <LectureWatchPage
+        selectedCourse={selectedCourse}
+        highlightedLecture={highlightedLecture}
+        selectedLectureId={selectedLectureId}
+        canManageCurrent={false}
+        onSelectLecture={onSelectLecture}
+        onNavigate={onNavigate}
       />
     );
   }

--- a/frontend/src/features/lms/types.ts
+++ b/frontend/src/features/lms/types.ts
@@ -17,6 +17,7 @@ import type {
 export type LmsPageId =
   | 'dashboard'
   | 'courses'
+  | 'lecture-watch'
   | 'my-courses'
   | 'course-create'
   | 'lecture-studio'


### PR DESCRIPTION
# 변경 요약
홈 화면, 강의 상세/시청 분리, 숏폼 제작 흐름을 한 번에 정리해 탐색과 학습, 제작의 경계를 더 분명하게 만들었습니다.

## 배경
Inflearn 같은 탐색 허브 구조를 기준으로, 첫 화면에서 무엇을 해야 하는지 더 빨리 보이게 하고 강의 상세와 시청, 숏폼 제작의 역할을 분리할 필요가 있었습니다.

## 변경 내용
- 홈 화면을 검색/카테고리/추천 강의/이미지 섹션 중심의 탐색 허브로 재구성했습니다.
- 강의 상세와 강의 시청을 분리하고 `lecture-watch` 경로를 추가했습니다.
- 숏폼 제작 화면에 단계 요약, 고정 사이드바, 선택 개수와 누적 시간 표시를 추가했습니다.
- 프론트 문서용 devlog에 B안을 메인으로 선택한 이유를 기록했습니다.

## 연결 이슈
- Closes #164
- Fixes #164

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- `npm --workspace @myway/frontend run build`

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트: 홈의 정보 구조가 탐색 허브로 읽히는지, 강의 상세와 시청의 경계가 충분히 분리됐는지, 숏폼 제작 단계가 실제 작업 흐름에 맞게 안내되는지 확인 부탁드립니다.

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다