### PR TITLE
feat: refine sidebar and watch navigation UX

### DIFF
--- a/docs/dev-logs/2026-04-13-sidebar-theme-watch-navigation-ab.md
+++ b/docs/dev-logs/2026-04-13-sidebar-theme-watch-navigation-ab.md
@@ -1,0 +1,34 @@
+# 2026-04-13 Sidebar Theme Watch Navigation AB
+
+## Issue
+- #166 [사이드바/테마/내 강의/영상 시청 UX 정리](https://github.com/MyWay-Class/myway-class/issues/166)
+
+## 변경 요약
+- 사이드바 접기/펼치기, 좌우 도킹 선택, 다크/라이트 테마 전환을 공용 쉘에 넣었다.
+- 로고 클릭 시 대시보드로 복귀하도록 연결했다.
+- `대시보드 / 내 강의` 중심 내비게이션으로 재구성했다.
+- `내 강의 -> 상세/진도율 -> 차시 시청` 흐름을 분리하고, 시청 화면 우측 패널에 `차시 목록 / 카테고리 / 챗봇` 탭을 넣었다.
+- 레퍼런스 이미지에 맞게 카드형 목록과 시청 레이아웃을 정리했다.
+
+## 선택 이유
+- B를 메인으로 선택했다.
+- B는 영상 시청 화면의 우측 탭 전환과 차시 탐색 흐름이 더 직접적으로 드러나서, 사용자가 지금 무엇을 보고 무엇을 눌러야 하는지 읽기 쉽다.
+- 홈에서 내 강의, 상세/진도율, 시청으로 이어지는 정보 구조가 레퍼런스 이미지의 탐색 중심 패턴과 더 잘 맞는다.
+- 사이드바와 테마 전환 같은 공용 조작도 시청 흐름과 한 화면에서 자연스럽게 연결되어, 전체 UX가 한 덩어리로 보인다.
+
+## 검증
+- `npm install`
+- `npm --workspace @myway/frontend run build`
+
+## 영향 범위
+- `frontend/src/components/LmsDashboard.tsx`
+- `frontend/src/features/lms/components/AppHeader.tsx`
+- `frontend/src/features/lms/components/AppShell.tsx`
+- `frontend/src/features/lms/components/AppSidebar.tsx`
+- `frontend/src/features/lms/config.ts`
+- `frontend/src/features/lms/pages/LectureWatchPage.tsx`
+- `frontend/src/features/lms/pages/MyCoursesPage.tsx`
+- `frontend/src/features/lms/pages/RolePageRouter.tsx`
+- `frontend/src/features/lms/types.ts`
+- `frontend/src/styles.css`
+- `frontend/tailwind.config.ts`

--- a/frontend/src/components/LmsDashboard.tsx
+++ b/frontend/src/components/LmsDashboard.tsx
@@ -11,8 +11,8 @@ export function LmsDashboard(props: LmsDashboardProps) {
   const [activePage, setActivePage] = useState<LmsPageId>(defaultPageForRole(props.session));
   const [showAuthPage, setShowAuthPage] = useState(false);
   const activeNavKey =
-    activePage === 'courses' && props.selectedLectureId
-      ? 'lecture-watch'
+    activePage === 'courses' || activePage === 'lecture-watch'
+      ? 'my-courses'
       : activePage;
 
   useEffect(() => {

--- a/frontend/src/features/lms/components/AppHeader.tsx
+++ b/frontend/src/features/lms/components/AppHeader.tsx
@@ -1,21 +1,33 @@
 type AppHeaderProps = {
   title: string;
+  theme: 'light' | 'dark';
+  onToggleTheme: () => void;
 };
 
-export function AppHeader({ title }: AppHeaderProps) {
+export function AppHeader({ title, theme, onToggleTheme }: AppHeaderProps) {
   return (
-    <header className="sticky top-0 z-10 flex h-14 items-center justify-between border-b border-slate-200 bg-white/90 px-6 backdrop-blur">
+    <header className="sticky top-0 z-10 flex h-14 items-center justify-between border-b border-[var(--app-border)] bg-[var(--app-surface)]/90 px-6 backdrop-blur">
       <div className="flex items-center gap-3">
-        <h1 className="text-[1rem] font-bold tracking-[-0.015em] text-slate-900">{title}</h1>
+        <h1 className="text-[1rem] font-bold tracking-[-0.015em] text-[var(--app-text)]">{title}</h1>
       </div>
-      <button
-        type="button"
-        title="알림"
-        className="relative flex h-[34px] w-[34px] items-center justify-center rounded-[8px] text-[17px] text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
-      >
-        <i className="ri-notification-3-line" />
-        <span className="absolute right-[5px] top-[5px] h-[7px] w-[7px] rounded-full border border-white bg-red-500" />
-      </button>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onToggleTheme}
+          title={theme === 'light' ? '다크 모드 전환' : '라이트 모드 전환'}
+          className="relative flex h-[34px] w-[34px] items-center justify-center rounded-[8px] text-[17px] text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]"
+        >
+          <i className={theme === 'light' ? 'ri-moon-line' : 'ri-sun-line'} />
+        </button>
+        <button
+          type="button"
+          title="알림"
+          className="relative flex h-[34px] w-[34px] items-center justify-center rounded-[8px] text-[17px] text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]"
+        >
+          <i className="ri-notification-3-line" />
+          <span className="absolute right-[5px] top-[5px] h-[7px] w-[7px] rounded-full border border-white bg-red-500" />
+        </button>
+      </div>
     </header>
   );
 }

--- a/frontend/src/features/lms/components/AppShell.tsx
+++ b/frontend/src/features/lms/components/AppShell.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useState } from 'react';
 import type { LoginResponse } from '@myway/shared';
 import { AppHeader } from './AppHeader';
 import { AppSidebar } from './AppSidebar';
 import type { LmsNavKey, LmsPageId } from '../types';
+import type { ThemeMode, SidebarDock } from '../types';
 
 type AppShellProps = {
   session: LoginResponse;
@@ -13,12 +15,65 @@ type AppShellProps = {
   children: React.ReactNode;
 };
 
+const themeStorageKey = 'myway-shell-theme';
+const dockStorageKey = 'myway-shell-dock';
+const sidebarStorageKey = 'myway-shell-sidebar-collapsed';
+
+function readStorageValue<T extends string>(key: string, allowed: readonly T[], fallback: T): T {
+  if (typeof window === 'undefined') {
+    return fallback;
+  }
+
+  const value = window.localStorage.getItem(key);
+  return value && allowed.includes(value as T) ? (value as T) : fallback;
+}
+
 export function AppShell({ session, activePage, activeNavKey, title, onNavigate, onLogout, children }: AppShellProps) {
+  const [theme, setTheme] = useState<ThemeMode>(() => readStorageValue(themeStorageKey, ['light', 'dark'], 'light'));
+  const [dock, setDock] = useState<SidebarDock>(() => readStorageValue(dockStorageKey, ['left', 'right'], 'left'));
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return window.localStorage.getItem(sidebarStorageKey) === 'true';
+  });
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    window.localStorage.setItem(themeStorageKey, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    window.localStorage.setItem(dockStorageKey, dock);
+  }, [dock]);
+
+  useEffect(() => {
+    window.localStorage.setItem(sidebarStorageKey, String(collapsed));
+  }, [collapsed]);
+
+  const sidebarWidthClass = collapsed ? 'lg:w-20' : 'lg:w-72';
+  const shellOffsetClass = dock === 'right' ? (collapsed ? 'lg:mr-20' : 'lg:mr-72') : (collapsed ? 'lg:ml-20' : 'lg:ml-72');
+
   return (
-    <div className="min-h-screen bg-[#f8f9fb]">
-      <AppSidebar session={session} activePage={activePage} activeNavKey={activeNavKey} onNavigate={onNavigate} onLogout={onLogout} />
-      <div className="min-h-screen lg:ml-64">
-        <AppHeader title={title} />
+    <div className="min-h-screen bg-[var(--app-bg)] text-[var(--app-text)]">
+      <AppSidebar
+        session={session}
+        activePage={activePage}
+        activeNavKey={activeNavKey}
+        dock={dock}
+        collapsed={collapsed}
+        theme={theme}
+        sidebarWidthClass={sidebarWidthClass}
+        onNavigate={onNavigate}
+        onLogout={onLogout}
+        onToggleTheme={() => setTheme((current) => (current === 'light' ? 'dark' : 'light'))}
+        onToggleDock={() => setDock((current) => (current === 'left' ? 'right' : 'left'))}
+        onToggleCollapsed={() => setCollapsed((current) => !current)}
+      />
+      <div className={`min-h-screen ${shellOffsetClass}`}>
+        <AppHeader title={title} theme={theme} onToggleTheme={() => setTheme((current) => (current === 'light' ? 'dark' : 'light'))} />
         <main className="mx-auto max-w-[1320px] px-4 py-5 sm:px-6 lg:px-8">{children}</main>
       </div>
     </div>

--- a/frontend/src/features/lms/components/AppSidebar.tsx
+++ b/frontend/src/features/lms/components/AppSidebar.tsx
@@ -1,16 +1,36 @@
 import type { LoginResponse } from '@myway/shared';
 import { isNavItemActive, navGroupsForRole, roleLabel } from '../config';
-import type { LmsNavKey, LmsPageId } from '../types';
+import type { LmsNavKey, LmsPageId, SidebarDock, ThemeMode } from '../types';
 
 type AppSidebarProps = {
   session: LoginResponse;
   activePage: LmsPageId;
   activeNavKey: LmsNavKey;
+  dock: SidebarDock;
+  collapsed: boolean;
+  theme: ThemeMode;
+  sidebarWidthClass: string;
   onNavigate: (page: LmsPageId) => void;
   onLogout: () => void;
+  onToggleTheme: () => void;
+  onToggleDock: () => void;
+  onToggleCollapsed: () => void;
 };
 
-export function AppSidebar({ session, activePage, activeNavKey, onNavigate, onLogout }: AppSidebarProps) {
+export function AppSidebar({
+  session,
+  activePage,
+  activeNavKey,
+  dock,
+  collapsed,
+  theme,
+  sidebarWidthClass,
+  onNavigate,
+  onLogout,
+  onToggleTheme,
+  onToggleDock,
+  onToggleCollapsed,
+}: AppSidebarProps) {
   const groups = navGroupsForRole(session.user.role);
   const avatarTone =
     session.user.role === 'ADMIN'
@@ -18,22 +38,48 @@ export function AppSidebar({ session, activePage, activeNavKey, onNavigate, onLo
       : session.user.role === 'INSTRUCTOR'
         ? 'bg-violet-600'
         : 'bg-indigo-600';
+  const dockClass = dock === 'right' ? 'right-0 border-l border-r-0' : 'left-0 border-r border-l-0';
 
   return (
-    <aside className="fixed inset-y-0 left-0 z-20 hidden w-64 flex-col border-r border-slate-200 bg-white lg:flex">
-      <div className="flex h-14 items-center gap-2.5 px-[18px]">
-        <div className="flex h-[30px] w-[30px] items-center justify-center rounded-[8px] bg-indigo-600 text-[15px] text-white">
-          <i className="ri-play-circle-fill" />
-        </div>
-        <span className="text-[1.05rem] font-extrabold tracking-[-0.03em] text-slate-900">내맘대로</span>
+    <aside
+      className={`fixed inset-y-0 z-20 hidden flex-col border-[var(--app-border)] bg-[var(--app-surface)] shadow-[0_10px_30px_rgba(15,23,42,0.08)] lg:flex ${dockClass} ${sidebarWidthClass}`}
+    >
+      <div className="flex h-14 items-center justify-between gap-2 px-4">
+        <button type="button" onClick={() => onNavigate('dashboard')} className={`flex items-center gap-2 ${collapsed ? 'mx-auto' : ''}`}>
+          <div className="flex h-[30px] w-[30px] items-center justify-center rounded-[8px] bg-indigo-600 text-[15px] text-white">
+            <i className="ri-play-circle-fill" />
+          </div>
+          {!collapsed ? <span className="text-[1.05rem] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">내맘대로</span> : null}
+        </button>
+        {!collapsed ? (
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-[16px] text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]"
+            title="사이드바 접기"
+          >
+            <i className="ri-arrow-left-s-line" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            className="mx-auto flex h-8 w-8 items-center justify-center rounded-lg text-[16px] text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]"
+            title="사이드바 펼치기"
+          >
+            <i className="ri-arrow-right-s-line" />
+          </button>
+        )}
       </div>
 
-      <nav className="flex-1 overflow-y-auto px-2.5 py-2">
+      <nav className={`flex-1 overflow-y-auto ${collapsed ? 'px-2' : 'px-2.5'} py-2`}>
         {groups.map((group) => (
           <div key={group.label} className="mb-[18px]">
-            <div className="mb-1 px-2.5 text-[11px] font-bold uppercase tracking-[0.08em] text-slate-400">
-              {group.label}
-            </div>
+            {!collapsed ? (
+              <div className="mb-1 px-2.5 text-[11px] font-bold uppercase tracking-[0.08em] text-[var(--app-text-muted)]">
+                {group.label}
+              </div>
+            ) : null}
             <div className="space-y-0.5">
               {group.items.map((item) => {
                 const active = isNavItemActive(item, activeNavKey) || item.page === activePage;
@@ -42,14 +88,17 @@ export function AppSidebar({ session, activePage, activeNavKey, onNavigate, onLo
                     key={item.page}
                     type="button"
                     onClick={() => onNavigate(item.page)}
+                    title={collapsed ? item.label : undefined}
                     className={`relative flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left text-[13px] font-medium transition ${
-                      active ? 'bg-indigo-50 text-indigo-600' : 'text-slate-500 hover:bg-slate-50 hover:text-slate-900'
+                      active
+                        ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-500/15 dark:text-indigo-300'
+                        : 'text-[var(--app-text-muted)] hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]'
                     }`}
                   >
                     {active ? <span className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-sm bg-indigo-600" /> : null}
                     <i className={`${item.icon} w-[22px] text-center text-[17px]`} />
-                    <span>{item.label}</span>
-                    {item.badge ? (
+                    {!collapsed ? <span>{item.label}</span> : null}
+                    {item.badge && !collapsed ? (
                       <span className="ml-auto rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-semibold text-indigo-600">
                         {item.badge}
                       </span>
@@ -62,19 +111,42 @@ export function AppSidebar({ session, activePage, activeNavKey, onNavigate, onLo
         ))}
       </nav>
 
-      <div className="border-t border-slate-100 px-3.5 py-3">
-        <div className="flex items-center gap-2.5 rounded-[8px] px-2.5 py-2 hover:bg-slate-50">
+      <div className="border-t border-[var(--app-border)] px-3.5 py-3">
+        <div className={`flex items-center gap-2.5 rounded-[8px] px-2.5 py-2 ${collapsed ? 'justify-center' : ''}`}>
           <div className={`flex h-8 w-8 items-center justify-center rounded-[8px] text-[13px] font-bold text-white ${avatarTone}`}>
             {session.user.name[0]}
           </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-[12px] font-semibold text-slate-800">{session.user.name}</div>
-            <div className="text-[11px] text-slate-400">{roleLabel(session.user.role)}</div>
-          </div>
-          <button type="button" onClick={onLogout} className="text-base text-slate-400 transition hover:text-slate-700" title="로그아웃">
-            <i className="ri-logout-box-r-line" />
-          </button>
+          {!collapsed ? (
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[12px] font-semibold text-[var(--app-text)]">{session.user.name}</div>
+              <div className="text-[11px] text-[var(--app-text-muted)]">{roleLabel(session.user.role)}</div>
+            </div>
+          ) : null}
+          {!collapsed ? (
+            <button type="button" onClick={onLogout} className="text-base text-[var(--app-text-muted)] transition hover:text-[var(--app-text)]" title="로그아웃">
+              <i className="ri-logout-box-r-line" />
+            </button>
+          ) : null}
         </div>
+        {!collapsed ? (
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onToggleDock}
+              className="flex-1 rounded-xl border border-[var(--app-border)] px-3 py-2 text-[12px] font-semibold text-[var(--app-text)] transition hover:bg-[var(--app-surface-soft)]"
+            >
+              {dock === 'left' ? '오른쪽 고정' : '왼쪽 고정'}
+            </button>
+            <button
+              type="button"
+              onClick={onToggleTheme}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--app-border)] text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]"
+              title={theme === 'light' ? '다크 모드' : '라이트 모드'}
+            >
+              <i className={theme === 'light' ? 'ri-moon-line' : 'ri-sun-line'} />
+            </button>
+          </div>
+        ) : null}
       </div>
     </aside>
   );

--- a/frontend/src/features/lms/config.ts
+++ b/frontend/src/features/lms/config.ts
@@ -19,10 +19,10 @@ export function defaultPageForRole(session: LoginResponse | null): LmsPageId {
 
 export function pageTitle(page: LmsPageId, role: UserRole): string {
   const titles: Record<LmsPageId, string> = {
-    dashboard: '홈',
-    courses: '강의 목록',
-    'lecture-watch': '강의 시청',
-    'my-courses': '내 강의 관리',
+    dashboard: '대시보드',
+    courses: '강의 상세',
+    'lecture-watch': '영상 시청',
+    'my-courses': '내 강의',
     'course-create': '강의 워크스페이스',
     'lecture-studio': '강의 제작 스튜디오',
     shortform: '숏폼 제작',
@@ -41,7 +41,7 @@ export function pageTitle(page: LmsPageId, role: UserRole): string {
   };
 
   if (page === 'dashboard' && role === 'INSTRUCTOR') {
-    return '강의 홈';
+    return '대시보드';
   }
 
   return titles[page];
@@ -50,10 +50,10 @@ export function pageTitle(page: LmsPageId, role: UserRole): string {
 export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
   const groups: LmsNavGroup[] = [
     {
-      label: '주요 메뉴',
+      label: '핵심',
       items: [
-        { page: 'dashboard', icon: 'ri-home-4-line', label: '홈' },
-        { page: 'courses', icon: 'ri-book-2-line', label: '강의 목록', aliases: ['lecture-watch'] },
+        { page: 'dashboard', icon: 'ri-dashboard-3-line', label: '대시보드' },
+        { page: 'my-courses', icon: 'ri-book-open-line', label: '내 강의', aliases: ['courses', 'lecture-watch'] },
       ],
     },
   ];
@@ -75,7 +75,7 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
       {
         label: '제작 도구',
         items: [
-          { page: 'my-courses', icon: 'ri-folder-user-line', label: '내 강의 관리', badge: 'NEW' },
+          { page: 'my-courses', icon: 'ri-folder-user-line', label: '내 강의', badge: 'NEW', aliases: ['courses', 'lecture-watch'] },
           { page: 'course-create', icon: 'ri-add-circle-line', label: '강의 워크스페이스', badge: 'NEW' },
           { page: 'lecture-studio', icon: 'ri-layout-masonry-line', label: '강의 제작 스튜디오', badge: 'NEW' },
           { page: 'shortform', icon: 'ri-scissors-cut-line', label: '숏폼 제작' },
@@ -99,7 +99,7 @@ export function navGroupsForRole(role: UserRole): LmsNavGroup[] {
       {
         label: '운영 관리',
         items: [
-          { page: 'my-courses', icon: 'ri-folder-user-line', label: '내 강의 관리' },
+          { page: 'my-courses', icon: 'ri-folder-user-line', label: '내 강의', aliases: ['courses', 'lecture-watch'] },
           { page: 'admin-users', icon: 'ri-user-settings-line', label: '사용자 관리', aliases: ['admin-user-detail'] },
         ],
       },

--- a/frontend/src/features/lms/pages/LectureWatchPage.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPage.tsx
@@ -1,47 +1,133 @@
-import type { CourseDetail, LectureDetail } from '@myway/shared';
-import { CourseExploreDetailPanel } from '../components/CourseExploreDetailPanel';
+import { useMemo, useState } from 'react';
+import type { CourseCard, CourseDetail, LectureDetail } from '@myway/shared';
+import { CourseSessionTimeline } from '../components/CourseSessionTimeline';
+import { LectureSideChatPanel } from '../components/LectureSideChatPanel';
+import { StatePanel } from '../components/StatePanel';
 
 type LectureWatchPageProps = {
+  courses: CourseCard[];
   selectedCourse: CourseDetail | null;
   highlightedLecture: LectureDetail | null;
   selectedLectureId: string;
   canManageCurrent: boolean;
+  sessionToken?: string | null;
+  onSelectCourse: (courseId: string) => void;
   onSelectLecture: (lectureId: string) => void;
-  onNavigate: (page: 'courses' | 'lecture-watch' | 'shortform' | 'ai-chat' | 'course-create' | 'lecture-studio' | 'media-pipeline') => void;
+  onNavigate: (page: 'courses' | 'lecture-watch' | 'my-courses' | 'shortform' | 'ai-chat' | 'course-create' | 'lecture-studio' | 'media-pipeline') => void;
 };
 
+type RightTab = 'sessions' | 'categories' | 'chat';
+
+function formatDuration(minutes: number): string {
+  if (minutes < 60) {
+    return `${minutes}분`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remain = minutes % 60;
+  return remain > 0 ? `${hours}시간 ${remain}분` : `${hours}시간`;
+}
+
+function getRelatedCourses(courses: CourseCard[], selectedCourse: CourseDetail | null): CourseCard[] {
+  if (!selectedCourse) {
+    return [];
+  }
+
+  const selectedTags = new Set(selectedCourse.tags);
+  return courses
+    .filter((course) => course.id !== selectedCourse.id)
+    .sort((left, right) => {
+      const leftScore = left.category === selectedCourse.category ? 2 : 0;
+      const rightScore = right.category === selectedCourse.category ? 2 : 0;
+      const leftTags = left.tags.filter((tag) => selectedTags.has(tag)).length;
+      const rightTags = right.tags.filter((tag) => selectedTags.has(tag)).length;
+      return rightScore + rightTags - (leftScore + leftTags);
+    })
+    .slice(0, 4);
+}
+
 export function LectureWatchPage({
+  courses,
   selectedCourse,
   highlightedLecture,
   selectedLectureId,
   canManageCurrent,
+  sessionToken,
+  onSelectCourse,
   onSelectLecture,
   onNavigate,
 }: LectureWatchPageProps) {
+  const [activePanelTab, setActivePanelTab] = useState<RightTab>('sessions');
+  const [selectedRelatedFilter, setSelectedRelatedFilter] = useState<string>('전체');
+  const currentLecture = useMemo(() => {
+    if (!selectedCourse) {
+      return highlightedLecture;
+    }
+
+    return selectedCourse.lectures.find((lecture) => lecture.id === selectedLectureId) ?? highlightedLecture ?? selectedCourse.lectures[0] ?? null;
+  }, [highlightedLecture, selectedCourse, selectedLectureId]);
+
+  const relatedCourses = useMemo(() => getRelatedCourses(courses, selectedCourse), [courses, selectedCourse]);
+  const relatedFilters = useMemo(() => {
+    if (!selectedCourse) {
+      return ['전체'];
+    }
+
+    return ['전체', selectedCourse.category, ...selectedCourse.tags].filter((value, index, array) => array.indexOf(value) === index);
+  }, [selectedCourse]);
+  const filteredRelatedCourses = useMemo(() => {
+    if (!selectedCourse || selectedRelatedFilter === '전체') {
+      return relatedCourses;
+    }
+
+    return relatedCourses.filter(
+      (course) => course.category === selectedRelatedFilter || course.tags.includes(selectedRelatedFilter),
+    );
+  }, [relatedCourses, selectedCourse, selectedRelatedFilter]);
+  const upcomingLectures = useMemo(() => {
+    if (!selectedCourse || !currentLecture) {
+      return [];
+    }
+
+    const currentIndex = selectedCourse.lectures.findIndex((lecture) => lecture.id === currentLecture.id);
+    return selectedCourse.lectures.slice(Math.max(currentIndex + 1, 0), currentIndex + 5);
+  }, [currentLecture, selectedCourse]);
+
+  if (!selectedCourse) {
+    return (
+      <StatePanel
+        icon="ri-play-circle-line"
+        tone="indigo"
+        title="시청할 강의를 먼저 선택하세요."
+        description="내 강의에서 코스를 고르면 상세/진도율 화면을 지나 시청 페이지로 들어갈 수 있습니다."
+      />
+    );
+  }
+
   return (
     <div className="space-y-5">
-      <section className="overflow-hidden rounded-3xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm">
+      <section className="overflow-hidden rounded-[28px] border border-[var(--app-border)] bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-soft">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div>
+          <div className="min-w-0 flex-1">
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
               <i className="ri-play-circle-line" />
-              강의 시청
+              영상 시청
             </div>
             <h1 className="mt-3 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[30px]">
-              강의는 여기서 보고, 상세는 한 단계 뒤로
+              상세는 한 단계 뒤, 시청은 지금 바로
             </h1>
             <p className="mt-2 max-w-2xl text-[13px] leading-6 text-white/75">
-              시청 화면은 재생, 메모, 다음 차시 이동에 집중하고, 강의 소개와 공지는 상세 페이지에서 이어서 볼 수 있게 분리했습니다.
+              화면은 재생과 다음 차시 이동에 집중하고, 우측 패널에서 차시 목록, 카테고리, 챗봇을 탭으로 전환합니다.
             </p>
           </div>
           <div className="grid gap-3 sm:grid-cols-3">
             <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
               <div className="font-semibold text-white">선택 강의</div>
-              <div className="mt-1">{selectedCourse?.title ?? '강의 미선택'}</div>
+              <div className="mt-1">{selectedCourse.title}</div>
             </div>
             <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
               <div className="font-semibold text-white">현재 차시</div>
-              <div className="mt-1">{highlightedLecture?.title ?? '차시 미선택'}</div>
+              <div className="mt-1">{currentLecture?.title ?? '차시 미선택'}</div>
             </div>
             <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
               <div className="font-semibold text-white">역할</div>
@@ -51,17 +137,223 @@ export function LectureWatchPage({
         </div>
       </section>
 
-      <CourseExploreDetailPanel
-        course={selectedCourse}
-        highlightedLecture={highlightedLecture}
-        selectedLectureId={selectedLectureId}
-        viewMode="watch"
-        activeTab="강의"
-        canManageCurrent={canManageCurrent}
-        onSelectLecture={onSelectLecture}
-        onTabChange={() => undefined}
-        onNavigate={onNavigate}
-      />
+      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.35fr)_minmax(360px,0.65fr)]">
+        <article className="overflow-hidden rounded-[28px] border border-[var(--app-border)] bg-[var(--app-surface)] shadow-soft">
+          <div className="border-b border-[var(--app-border)] px-5 py-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-[12px] font-semibold text-indigo-600">내 강의 / 영상 시청</div>
+                <h2 className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{selectedCourse.title}</h2>
+                <p className="mt-2 text-[13px] leading-6 text-[var(--app-text-muted)]">
+                  {selectedCourse.category} · {selectedCourse.difficulty} · {selectedCourse.lecture_count}차시 · {selectedCourse.progress_percent}% 진행
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => onNavigate('courses')}
+                  className="rounded-full border border-[var(--app-border)] bg-[var(--app-surface)] px-4 py-2 text-[12px] font-semibold text-[var(--app-text)] transition hover:bg-[var(--app-surface-soft)]"
+                >
+                  상세/진도율
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onNavigate('my-courses')}
+                  className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                >
+                  내 강의
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="p-5">
+            <div className="overflow-hidden rounded-[24px] border border-[var(--app-border)] bg-black">
+              {currentLecture?.video_url ? (
+                <video className="aspect-video w-full bg-black" controls preload="metadata" src={currentLecture.video_url} />
+              ) : (
+                <div className="flex aspect-video items-center justify-center bg-[linear-gradient(135deg,#020617_0%,#111827_50%,#1e293b_100%)] text-white">
+                  <div className="text-center">
+                    <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full border border-white/10 bg-white/10 text-[30px] text-white/90">
+                      <i className="ri-play-circle-fill" />
+                    </div>
+                    <div className="mt-4 text-[15px] font-semibold">재생 가능한 영상이 없습니다.</div>
+                    <div className="mt-1 text-[12px] text-white/65">이 차시는 텍스트/자료 기반으로 확인할 수 있습니다.</div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+              <div className="rounded-[24px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-5">
+                <div className="text-[12px] font-semibold text-indigo-600">현재 차시</div>
+                <div className="mt-1 text-[18px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{currentLecture?.title ?? '차시를 선택하세요'}</div>
+                <p className="mt-3 text-[13px] leading-7 text-[var(--app-text-muted)]">
+                  {currentLecture?.transcript_excerpt ?? '선택한 차시의 핵심 내용과 메모를 이곳에서 확인합니다.'}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onNavigate('courses')}
+                    className="rounded-full border border-[var(--app-border)] bg-[var(--app-surface)] px-4 py-2 text-[12px] font-semibold text-[var(--app-text)] transition hover:bg-[var(--app-surface-soft)]"
+                  >
+                    강의 상세로
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onNavigate('shortform')}
+                    className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                  >
+                    숏폼 만들기
+                  </button>
+                  {canManageCurrent ? (
+                    <button
+                      type="button"
+                      onClick={() => onNavigate('media-pipeline')}
+                      className="rounded-full border border-indigo-200 bg-indigo-50 px-4 py-2 text-[12px] font-semibold text-indigo-700 transition hover:bg-indigo-100"
+                    >
+                      업로드/전사 관리
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="rounded-[24px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-5">
+                <div className="text-[12px] font-semibold text-[var(--app-text-muted)]">진도율</div>
+                <div className="mt-2 flex items-end justify-between gap-3">
+                  <div className="text-[30px] font-extrabold tracking-[-0.05em] text-[var(--app-text)]">{selectedCourse.progress_percent}%</div>
+                  <div className="text-right text-[11px] text-[var(--app-text-muted)]">
+                    <div>{selectedCourse.completed_lectures}/{selectedCourse.lecture_count}차시</div>
+                    <div>{formatDuration(selectedCourse.total_duration_minutes)}</div>
+                  </div>
+                </div>
+                <div className="mt-4 h-2 overflow-hidden rounded-full bg-white/80">
+                  <div className="h-full rounded-full bg-indigo-500" style={{ width: `${Math.max(selectedCourse.progress_percent, 8)}%` }} />
+                </div>
+                <div className="mt-3 text-[12px] leading-6 text-[var(--app-text-muted)]">
+                  {upcomingLectures.length > 0 ? `다음 차시는 ${upcomingLectures[0].title}입니다.` : '다음 차시가 없습니다.'}
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <aside className="overflow-hidden rounded-[28px] border border-[var(--app-border)] bg-[var(--app-surface)] shadow-soft">
+          <div className="border-b border-[var(--app-border)] px-4 py-4">
+            <div className="flex gap-2">
+              {[
+                { key: 'sessions', label: '차시 목록', icon: 'ri-list-check-2' },
+                { key: 'categories', label: '카테고리', icon: 'ri-grid-line' },
+                { key: 'chat', label: '챗봇', icon: 'ri-robot-line' },
+              ].map((tab) => {
+                const active = activePanelTab === tab.key;
+                return (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => setActivePanelTab(tab.key as RightTab)}
+                    className={`flex flex-1 items-center justify-center gap-2 rounded-2xl px-3 py-2.5 text-[12px] font-semibold transition ${
+                      active
+                        ? 'bg-indigo-600 text-white shadow-sm'
+                        : 'border border-[var(--app-border)] bg-[var(--app-surface-soft)] text-[var(--app-text-muted)] hover:text-[var(--app-text)]'
+                    }`}
+                  >
+                    <i className={tab.icon} />
+                    {tab.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="p-4">
+            {activePanelTab === 'sessions' ? (
+              <div className="space-y-4">
+                <div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
+                  <div className="text-[12px] font-semibold text-indigo-600">다음 차시 선택</div>
+                  <div className="mt-1 text-[14px] font-bold text-[var(--app-text)]">현재 강의의 차시 목록을 바로 전환합니다.</div>
+                  <p className="mt-2 text-[12px] leading-6 text-[var(--app-text-muted)]">
+                    원하는 주차를 눌러 선택하고, 이어서 영상 시청과 챗봇 질문으로 연결할 수 있습니다.
+                  </p>
+                </div>
+                <CourseSessionTimeline course={selectedCourse} selectedLectureId={selectedLectureId} onSelectLecture={onSelectLecture} />
+              </div>
+            ) : null}
+
+            {activePanelTab === 'categories' ? (
+              <div className="space-y-4">
+                <div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
+                  <div className="text-[12px] font-semibold text-indigo-600">강의 카테고리</div>
+                  <div className="mt-1 text-[16px] font-bold text-[var(--app-text)]">{selectedCourse.category}</div>
+                  <p className="mt-2 text-[12px] leading-6 text-[var(--app-text-muted)]">
+                    {selectedCourse.difficulty} · {selectedCourse.lecture_count}차시 · {selectedCourse.student_count}명 수강
+                  </p>
+                </div>
+
+                <div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
+                  <div className="text-[12px] font-semibold text-[var(--app-text-muted)]">선택 가능 카테고리</div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {relatedFilters.map((filter) => {
+                      const active = selectedRelatedFilter === filter;
+                      return (
+                        <button
+                          key={filter}
+                          type="button"
+                          onClick={() => setSelectedRelatedFilter(filter)}
+                          className={`rounded-full px-3 py-1.5 text-[11px] font-semibold transition ${
+                            active ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-50'
+                          }`}
+                        >
+                          {filter === '전체' ? filter : `#${filter}`}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
+                  <div className="text-[12px] font-semibold text-[var(--app-text-muted)]">추천 강의</div>
+                  <div className="mt-3 space-y-2">
+                    {filteredRelatedCourses.length > 0 ? (
+                      filteredRelatedCourses.map((course) => (
+                        <button
+                          key={course.id}
+                          type="button"
+                          onClick={() => {
+                            onSelectCourse(course.id);
+                            onNavigate('courses');
+                          }}
+                          className="flex w-full items-center gap-3 rounded-2xl border border-white/60 bg-white px-3 py-3 text-left transition hover:border-indigo-200 hover:bg-indigo-50"
+                        >
+                          <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-2xl bg-indigo-50 text-[16px] text-indigo-600">
+                            <i className="ri-play-circle-line" />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[13px] font-semibold text-[var(--app-text)]">{course.title}</div>
+                            <div className="mt-0.5 text-[11px] text-[var(--app-text-muted)]">
+                              {course.category} · {course.progress_percent}% 진행
+                            </div>
+                          </div>
+                          </button>
+                      ))
+                    ) : (
+                      <StatePanel
+                        compact
+                        icon="ri-compass-3-line"
+                        tone="slate"
+                        title="비슷한 강의를 찾지 못했습니다."
+                          description="현재 선택한 강의와 연결할 다른 코스를 다음 단계에서 추천할 수 있습니다."
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            {activePanelTab === 'chat' ? <LectureSideChatPanel highlightedLecture={currentLecture} sessionToken={sessionToken} /> : null}
+          </div>
+        </aside>
+      </section>
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/MyCoursesPage.tsx
+++ b/frontend/src/features/lms/pages/MyCoursesPage.tsx
@@ -7,13 +7,13 @@ type MyCoursesPageProps = {
   courses: CourseCard[];
   selectedCourse: CourseDetail | null;
   onSelectCourse: (courseId: string) => void;
-  onNavigate: (page: 'my-courses' | 'course-create' | 'lecture-studio' | 'courses') => void;
+  onNavigate: (page: 'my-courses' | 'course-create' | 'lecture-studio' | 'courses' | 'lecture-watch') => void;
 };
 
 export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse, onNavigate }: MyCoursesPageProps) {
   const [managedCourses, setManagedCourses] = useState<CourseCard[]>([]);
   const [loading, setLoading] = useState(true);
-  const [notice, setNotice] = useState('내가 개설한 강의만 모아서 보고, 바로 개설 워크플로우나 제작 스튜디오로 이어갑니다.');
+  const [notice, setNotice] = useState('내가 수강 중인 강의를 먼저 보고, 선택하면 상세와 진도율 화면으로 이어집니다.');
 
   useEffect(() => {
     let active = true;
@@ -37,28 +37,32 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
     };
   }, [session.session_token]);
 
-  const currentCourses = managedCourses.length > 0
+  const enrolledCourses = courses.filter((course) => course.enrolled);
+  const instructorCourses = managedCourses.length > 0
     ? managedCourses
     : courses.filter((course) => session.user.role === 'ADMIN' || course.instructor_id === session.user.id);
+  const currentCourses = session.user.role === 'STUDENT' ? enrolledCourses : instructorCourses;
+  const primaryCourse = selectedCourse ?? currentCourses[0] ?? null;
 
   const stats = useMemo(
     () => ({
       total: currentCourses.length,
       published: currentCourses.filter((course) => course.is_published).length,
       totalLectures: currentCourses.reduce((sum, course) => sum + course.lecture_count, 0),
+      inProgress: currentCourses.filter((course) => course.progress_percent > 0 && course.progress_percent < 100).length,
     }),
     [currentCourses],
   );
 
   return (
     <div className="space-y-5">
-      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 px-6 py-6 text-white shadow-sm">
+      <section className="rounded-3xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
             <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-indigo-200">My Courses</div>
-            <h2 className="mt-2 text-[24px] font-extrabold tracking-[-0.04em]">내 강의 관리</h2>
+            <h2 className="mt-2 text-[24px] font-extrabold tracking-[-0.04em]">내 강의</h2>
             <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-300">
-              내가 개설한 강의를 한곳에서 확인하고, 바로 개설 워크플로우나 제작 스튜디오로 이동할 수 있습니다.
+              수강 중인 강의와 관리 중인 강의를 한곳에서 확인하고, 선택하면 강의 상세와 진도율 화면으로 이동합니다.
             </p>
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
@@ -68,7 +72,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-3">
+      <section className="grid gap-4 md:grid-cols-4">
         <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
           <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{stats.total}</div>
           <div className="mt-1 text-[12px] text-slate-500">관리 강의 수</div>
@@ -81,28 +85,71 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
           <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{stats.totalLectures}</div>
           <div className="mt-1 text-[12px] text-slate-500">총 차시 수</div>
         </article>
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{stats.inProgress}</div>
+          <div className="mt-1 text-[12px] text-slate-500">진행 중 강의</div>
+        </article>
       </section>
 
       <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h3 className="text-[15px] font-bold text-slate-900">내가 개설한 강의</h3>
+            <h3 className="text-[15px] font-bold text-slate-900">{session.user.role === 'STUDENT' ? '수강 중인 강의' : '관리 중인 강의'}</h3>
             <p className="mt-1 text-[12px] text-slate-500">{notice}</p>
           </div>
           <button
             type="button"
-            onClick={() => onNavigate('course-create')}
+            onClick={() => onNavigate(session.user.role === 'STUDENT' ? 'dashboard' : 'course-create')}
             className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
           >
-            새 강의 개설
+            {session.user.role === 'STUDENT' ? '대시보드로 이동' : '새 강의 개설'}
           </button>
         </div>
+
+        {primaryCourse ? (
+          <div className="mt-4 rounded-3xl border border-indigo-100 bg-indigo-50 px-5 py-5">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="min-w-0 flex-1">
+                <div className="text-[12px] font-semibold text-indigo-600">선택 강의 미리보기</div>
+                <div className="mt-1 text-[18px] font-extrabold tracking-[-0.03em] text-slate-900">{primaryCourse.title}</div>
+                <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-600">
+                  {primaryCourse.category} · {primaryCourse.lecture_count}차시 · {primaryCourse.progress_percent}% 진행
+                </p>
+                <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
+                  <div className="h-2 rounded-full bg-indigo-500" style={{ width: `${Math.max(primaryCourse.progress_percent, 8)}%` }} />
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    onSelectCourse(primaryCourse.id);
+                    onNavigate('courses');
+                  }}
+                  className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                >
+                  상세/진도율 보기
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onSelectCourse(primaryCourse.id);
+                    onNavigate('lecture-watch');
+                  }}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
+                >
+                  차시 선택하기
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
 
         {loading ? (
           <div className="mt-4 rounded-2xl bg-slate-50 px-4 py-5 text-sm text-slate-500">내 강의 목록을 불러오는 중입니다.</div>
         ) : currentCourses.length === 0 ? (
           <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-sm text-slate-500">
-            아직 관리 중인 강의가 없습니다. 강의 개설 워크플로우에서 새 강의를 시작해 주세요.
+            아직 수강하거나 관리 중인 강의가 없습니다. 대시보드에서 탐색을 시작해 주세요.
           </div>
         ) : (
           <div className="mt-4 grid gap-4 xl:grid-cols-2">
@@ -119,7 +166,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                     <div>
                       <div className="text-[14px] font-bold text-slate-900">{course.title}</div>
                       <div className="mt-1 text-[12px] text-slate-500">
-                        {course.category} · {course.difficulty} · {course.lecture_count}차시
+                        {course.category} · {course.difficulty} · {course.lecture_count}차시 · {course.progress_percent}% 진행
                       </div>
                     </div>
                     <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${course.is_published ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'}`}>
@@ -134,21 +181,21 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                       type="button"
                       onClick={() => {
                         onSelectCourse(course.id);
-                        onNavigate('course-create');
+                        onNavigate('courses');
                       }}
                       className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                     >
-                      개설 워크플로우
+                      상세/진도율
                     </button>
                     <button
                       type="button"
                       onClick={() => {
                         onSelectCourse(course.id);
-                        onNavigate('lecture-studio');
+                        onNavigate('lecture-watch');
                       }}
                       className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
                     >
-                      제작 스튜디오
+                      시청하기
                     </button>
                   </div>
                 </article>

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -111,10 +111,13 @@ export function RolePageRouter({
       case 'lecture-watch':
         return (
           <LectureWatchPage
+            courses={courseCards}
             selectedCourse={selectedCourse}
             highlightedLecture={highlightedLecture}
             selectedLectureId={selectedLectureId}
             canManageCurrent={true}
+            sessionToken={sessionToken}
+            onSelectCourse={onSelectCourse}
             onSelectLecture={onSelectLecture}
             onNavigate={onNavigate}
           />
@@ -301,10 +304,13 @@ export function RolePageRouter({
   if (page === 'lecture-watch') {
     return (
       <LectureWatchPage
+        courses={courseCards}
         selectedCourse={selectedCourse}
         highlightedLecture={highlightedLecture}
         selectedLectureId={selectedLectureId}
         canManageCurrent={false}
+        sessionToken={sessionToken}
+        onSelectCourse={onSelectCourse}
         onSelectLecture={onSelectLecture}
         onNavigate={onNavigate}
       />

--- a/frontend/src/features/lms/types.ts
+++ b/frontend/src/features/lms/types.ts
@@ -50,6 +50,10 @@ export type LmsNavGroup = {
   items: LmsNavItem[];
 };
 
+export type ThemeMode = 'light' | 'dark';
+
+export type SidebarDock = 'left' | 'right';
+
 export type LmsDashboardProps = {
   busy: boolean;
   canEnrollCurrent: boolean;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -8,15 +8,73 @@
 @layer base {
   :root {
     color-scheme: light;
+    --app-bg: #f8f9fb;
+    --app-surface: #ffffff;
+    --app-surface-soft: #f1f5f9;
+    --app-border: #e2e8f0;
+    --app-text: #0f172a;
+    --app-text-muted: #64748b;
+  }
+
+  :root[data-theme='dark'] {
+    color-scheme: dark;
+    --app-bg: #020617;
+    --app-surface: #0f172a;
+    --app-surface-soft: #111827;
+    --app-border: #334155;
+    --app-text: #e2e8f0;
+    --app-text-muted: #94a3b8;
+  }
+
+  :root[data-theme='dark'] .bg-white {
+    background-color: var(--app-surface) !important;
+  }
+
+  :root[data-theme='dark'] .bg-slate-50 {
+    background-color: var(--app-surface-soft) !important;
+  }
+
+  :root[data-theme='dark'] .bg-slate-100 {
+    background-color: rgba(148, 163, 184, 0.14) !important;
+  }
+
+  :root[data-theme='dark'] .bg-indigo-50 {
+    background-color: rgba(99, 102, 241, 0.16) !important;
+  }
+
+  :root[data-theme='dark'] .bg-indigo-100 {
+    background-color: rgba(99, 102, 241, 0.22) !important;
+  }
+
+  :root[data-theme='dark'] .border-slate-200 {
+    border-color: var(--app-border) !important;
+  }
+
+  :root[data-theme='dark'] .border-indigo-100 {
+    border-color: rgba(99, 102, 241, 0.3) !important;
+  }
+
+  :root[data-theme='dark'] .text-slate-900,
+  :root[data-theme='dark'] .text-slate-800,
+  :root[data-theme='dark'] .text-slate-700 {
+    color: var(--app-text) !important;
+  }
+
+  :root[data-theme='dark'] .text-slate-600,
+  :root[data-theme='dark'] .text-slate-500,
+  :root[data-theme='dark'] .text-slate-400 {
+    color: var(--app-text-muted) !important;
   }
 
   html {
     font-family: 'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    background: #f8f9fb;
+    background: var(--app-bg);
   }
 
   body {
-    @apply m-0 min-h-screen bg-[#f8f9fb] text-slate-900 antialiased;
+    @apply m-0 min-h-screen antialiased;
+    background: var(--app-bg);
+    color: var(--app-text);
     font-family: 'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
 

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{ts,tsx,js,jsx}',


### PR DESCRIPTION
﻿# 변경 요약
사이드바와 시청 화면을 레퍼런스 중심 정보 구조로 다시 정리했습니다. 접기/펼치기, 좌우 도킹, 테마 전환, 내 강의 흐름, 시청 우측 탭 전환을 모두 연결했습니다.

## 배경
기존 화면은 탐색과 시청, 설정 조작이 한 화면에서 분리되지 않아 사용자가 다음 행동을 읽기 어려웠습니다. 메인 탐색, 강의 상세/진도율, 영상 시청을 분리하고, 시청 화면의 보조 패널을 탭 구조로 정리할 필요가 있었습니다.

## 변경 내용
- 사이드바 접기/펼치기와 좌우 고정 선택을 추가했습니다.
- 라이트/다크 테마 전환을 공용 쉘에서 처리했습니다.
- 로고 클릭 시 대시보드로 이동하도록 했습니다.
- 사이드바 메뉴를 `대시보드 / 내 강의` 중심으로 재구성했습니다.
- `내 강의 -> 상세/진도율 -> 차시 시청` 흐름을 분리했습니다.
- 영상 시청 페이지 우측 패널에 `차시 목록 / 카테고리 / 챗봇` 탭 전환을 넣었습니다.
- 레퍼런스 이미지 기준의 카드형 목록과 시청 레이아웃을 반영했습니다.

## 연결 이슈
- Closes #166
- Fixes #166

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
