### PR TITLE
[Fix] 대시보드 챗/스크립트 길이 정합성 수정

### DIFF
--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -409,7 +409,7 @@ export function RolePageRouter({
       description="숏폼, 커뮤니티, AI 채팅은 동일한 UI 체계에 맞춰 이어서 붙일 수 있게 정리한 상태입니다."
       actions={[
         { label: '대시보드로 이동', onClick: () => onNavigate('dashboard') },
-        { label: '숏폼으로 이동', onClick: () => onNavigate('shortform') },
+        { label: '내 숏폼 보기', onClick: () => onNavigate('my-shortforms') },
       ]}
     />
   );

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -403,10 +403,10 @@ export function RolePageRouter({
   }
 
   return (
-      <RolePageFallback
-        icon="ri-robot-line"
-        title="학습 도구 연결 준비 중"
-        description="숏폼, 커뮤니티, AI 채팅은 동일한 UI 체계에 맞춰 이어서 붙일 수 있게 정리한 상태입니다."
+    <RolePageFallback
+      icon="ri-robot-line"
+      title="학습 도구 연결 준비 중"
+      description="숏폼, 커뮤니티, AI 채팅은 동일한 UI 체계에 맞춰 이어서 붙일 수 있게 정리한 상태입니다."
       actions={[
         { label: '대시보드로 이동', onClick: () => onNavigate('dashboard') },
         { label: '숏폼으로 이동', onClick: () => onNavigate('shortform') },


### PR DESCRIPTION
# 변경 요약
대시보드의 챗봇/스크립트/강의 길이 표시를 실제 전사 및 영상 길이에 맞춰 정리하고, 관련 fallback 진입 동선을 보정했습니다.

## 배경
배포 버전에서 실제 영상 길이와 화면에 표시되는 구간이 어긋나고, 일부 진입점은 버튼은 있지만 이어지는 화면이 분산되어 있었습니다.

## 변경 내용
- 대시보드와 시청 화면의 챗봇/스크립트/길이 표시 기준을 transcript 기반으로 맞췄습니다.
- 실제 영상 길이를 기준으로 숏폼 후보 구간을 계산하도록 정리했습니다.
- fallback 진입 동선을 일부 보정해 막다른 화면을 줄였습니다.
- 관련 문서를 `docs/dev-logs/`에 남겼습니다.

## 연결 이슈
- Closes #172
- Fixes #172

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다