### PR TITLE
[Fix] 홈 복귀 및 카드 진입 정리

### DIFF
--- a/docs/dev-logs/2026-04-13-home-reset-navigation.md
+++ b/docs/dev-logs/2026-04-13-home-reset-navigation.md
@@ -1,0 +1,11 @@
+# 2026-04-13 홈 복귀 및 카드 진입 정리
+
+## 변경 요약
+- 사이드바 로고 클릭 시 `dashboard`만 유지하지 않고, 선택된 강의/차시 상태를 초기화한 뒤 메인 화면으로 복귀하도록 정리했다.
+- `AppShell`/`AppSidebar`에 홈 복귀 핸들을 분리해서 로고 진입점이 명확하도록 바꿨다.
+- `CoursesPage`, `MyCoursesPage`, `StudentDashboardPage`의 카드 진입 동작을 상세 화면으로 이어지게 맞췄다.
+- 강의 길이는 transcript 또는 추출 결과를 우선 반영하는 공통 헬퍼를 유지해 카드, 타임라인, 숏폼 제작, 업로드 화면에서 같은 값을 쓰도록 정리했다.
+
+## 검증
+- `npm --workspace @myway/frontend run build`
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,6 +100,8 @@ export default function App() {
 
   useEffect(() => {
     if (!selectedCourseId) {
+      setSelectedCourse(null);
+      setSelectedLectureId('');
       return;
     }
 

--- a/frontend/src/components/LmsDashboard.tsx
+++ b/frontend/src/components/LmsDashboard.tsx
@@ -19,10 +19,8 @@ export function LmsDashboard(props: LmsDashboardProps) {
 
   function goToHome() {
     setActivePage(defaultPageForRole(props.session));
-    const homeCourseId = props.enrolledCourses[0]?.id ?? props.courseCards[0]?.id;
-    if (homeCourseId) {
-      props.onSelectCourse(homeCourseId);
-    }
+    props.onSelectCourse('');
+    props.onSelectLecture('');
   }
 
   useEffect(() => {
@@ -79,6 +77,7 @@ export function LmsDashboard(props: LmsDashboardProps) {
             goToHome();
           }
         }}
+        onHome={goToHome}
         onLogout={props.onLogout}
       >
       {props.apiStatus === 'offline' ? (

--- a/frontend/src/features/lms/components/AppShell.tsx
+++ b/frontend/src/features/lms/components/AppShell.tsx
@@ -11,6 +11,7 @@ type AppShellProps = {
   activeNavKey: LmsNavKey;
   title: string;
   onNavigate: (page: LmsPageId) => void;
+  onHome: () => void;
   onLogout: () => void;
   children: React.ReactNode;
 };
@@ -28,7 +29,7 @@ function readStorageValue<T extends string>(key: string, allowed: readonly T[], 
   return value && allowed.includes(value as T) ? (value as T) : fallback;
 }
 
-export function AppShell({ session, activePage, activeNavKey, title, onNavigate, onLogout, children }: AppShellProps) {
+export function AppShell({ session, activePage, activeNavKey, title, onNavigate, onHome, onLogout, children }: AppShellProps) {
   const [theme, setTheme] = useState<ThemeMode>(() => readStorageValue(themeStorageKey, ['light', 'dark'], 'light'));
   const [dock, setDock] = useState<SidebarDock>(() => readStorageValue(dockStorageKey, ['left', 'right'], 'left'));
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -67,6 +68,7 @@ export function AppShell({ session, activePage, activeNavKey, title, onNavigate,
         theme={theme}
         sidebarWidthClass={sidebarWidthClass}
         onNavigate={onNavigate}
+        onHome={onHome}
         onLogout={onLogout}
         onToggleTheme={() => setTheme((current) => (current === 'light' ? 'dark' : 'light'))}
         onToggleDock={() => setDock((current) => (current === 'left' ? 'right' : 'left'))}

--- a/frontend/src/features/lms/components/AppSidebar.tsx
+++ b/frontend/src/features/lms/components/AppSidebar.tsx
@@ -11,6 +11,7 @@ type AppSidebarProps = {
   theme: ThemeMode;
   sidebarWidthClass: string;
   onNavigate: (page: LmsPageId) => void;
+  onHome: () => void;
   onLogout: () => void;
   onToggleTheme: () => void;
   onToggleDock: () => void;
@@ -26,6 +27,7 @@ export function AppSidebar({
   theme,
   sidebarWidthClass,
   onNavigate,
+  onHome,
   onLogout,
   onToggleTheme,
   onToggleDock,
@@ -45,7 +47,7 @@ export function AppSidebar({
       className={`fixed inset-y-0 z-20 hidden flex-col border-[var(--app-border)] bg-[var(--app-surface)] shadow-[0_10px_30px_rgba(15,23,42,0.08)] lg:flex ${dockClass} ${sidebarWidthClass}`}
     >
       <div className="flex h-14 items-center justify-between gap-2 px-4">
-        <button type="button" onClick={() => onNavigate('dashboard')} className={`flex items-center gap-2 ${collapsed ? 'mx-auto' : ''}`}>
+        <button type="button" onClick={onHome} className={`flex items-center gap-2 ${collapsed ? 'mx-auto' : ''}`} title="메인 화면으로 이동">
           <div className="flex h-[30px] w-[30px] items-center justify-center rounded-[8px] bg-indigo-600 text-[15px] text-white">
             <i className="ri-play-circle-fill" />
           </div>

--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -1,4 +1,4 @@
-import type { CourseDetail, LectureDetail } from '@myway/shared';
+import { getLectureDisplayDurationMinutes, type CourseDetail, type LectureDetail } from '@myway/shared';
 import { CourseSessionTimeline } from './CourseSessionTimeline';
 import { StatePanel } from './StatePanel';
 import { buildProtectedVideoUrl } from '../../../lib/video-url';
@@ -255,7 +255,7 @@ export function CourseExploreDetailPanel({
                             <span>·</span>
                             <span>{detailLecture.course_instructor}</span>
                             <span>·</span>
-                            <span>{formatDuration(detailLecture.duration_minutes)}</span>
+                            <span>{formatDuration(getLectureDisplayDurationMinutes(detailLecture))}</span>
                           </div>
                         </div>
                         <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-white text-[18px] text-indigo-500 shadow-sm">

--- a/frontend/src/features/lms/components/CourseSessionTimeline.tsx
+++ b/frontend/src/features/lms/components/CourseSessionTimeline.tsx
@@ -1,4 +1,4 @@
-import type { CourseDetail } from '@myway/shared';
+import { getLectureDisplayDurationMinutes, type CourseDetail } from '@myway/shared';
 
 type CourseSessionTimelineProps = {
   course: CourseDetail;
@@ -92,7 +92,7 @@ export function CourseSessionTimeline({ course, selectedLectureId, onSelectLectu
                       <p className="mt-1 truncate text-[13px] font-semibold text-slate-900 group-hover:text-indigo-700">{lecture.title}</p>
                       <p className="mt-0.5 text-[11px] text-slate-400">
                         {lecture.content_type === 'video' ? <i className="ri-play-circle-line mr-1" /> : <i className="ri-file-text-line mr-1" />}
-                        {formatDuration(lecture.duration_minutes)}
+                        {formatDuration(getLectureDisplayDurationMinutes(lecture))}
                       </p>
                     </div>
 

--- a/frontend/src/features/lms/components/MediaPipelineStatusBoard.tsx
+++ b/frontend/src/features/lms/components/MediaPipelineStatusBoard.tsx
@@ -1,4 +1,4 @@
-import type { AudioExtraction, LecturePipeline, MediaProcessorHealth, STTProviderCatalog } from '@myway/shared';
+import { getLectureDisplayDurationMinutes, type AudioExtraction, type LecturePipeline, type MediaProcessorHealth, type STTProviderCatalog } from '@myway/shared';
 import type { MediaUploadResult } from '../../../lib/api-media';
 
 type MediaPipelineStatusBoardProps = {
@@ -112,7 +112,7 @@ export function MediaPipelineStatusBoard({
             {statusLabel(pipeline?.transcript_status ?? 'PENDING')}
           </div>
           <p className="mt-4 text-sm text-slate-600">
-            {selectedLecture ? `${selectedLecture.title} · ${selectedLecture.duration_minutes}분` : '강의를 선택하면 전사 경로가 연결됩니다.'}
+            {selectedLecture ? `${selectedLecture.title} · ${getLectureDisplayDurationMinutes(selectedLecture)}분` : '강의를 선택하면 전사 경로가 연결됩니다.'}
           </p>
         </div>
       </section>

--- a/frontend/src/features/lms/components/MediaPipelineSummaryPanel.tsx
+++ b/frontend/src/features/lms/components/MediaPipelineSummaryPanel.tsx
@@ -1,4 +1,4 @@
-import type { AudioExtraction, LecturePipeline } from '@myway/shared';
+import { getLectureDisplayDurationMinutes, type AudioExtraction, type LecturePipeline } from '@myway/shared';
 import type { MediaUploadResult } from '../../../lib/api-media';
 
 type MediaPipelineSummaryPanelProps = {
@@ -39,7 +39,7 @@ export function MediaPipelineSummaryPanel({
         <div>
           <div className="text-sm font-semibold text-slate-900">요약 상태</div>
           <div className="mt-1 text-xs text-slate-500">
-            {selectedLecture ? `${selectedLecture.title} · ${selectedLecture.duration_minutes}분` : '강의를 선택하면 요약 상태가 표시됩니다.'}
+            {selectedLecture ? `${selectedLecture.title} · ${getLectureDisplayDurationMinutes(selectedLecture)}분` : '강의를 선택하면 요약 상태가 표시됩니다.'}
           </div>
         </div>
         <div className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">

--- a/frontend/src/features/lms/components/ShortformWizard.tsx
+++ b/frontend/src/features/lms/components/ShortformWizard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { CourseCard, CourseDetail, LectureDetail, ShortformCommunityItem } from '@myway/shared';
+import { getLectureDisplayDurationMinutes, type CourseCard, type CourseDetail, type LectureDetail, type ShortformCommunityItem } from '@myway/shared';
 import { composeCustomCourseDraft, loadCourseDetail, loadLectureTranscriptDetailed, loadShortformCommunity, shareCustomCourseDraft } from '../../../lib/api';
 import { ShortformWizardSidebar } from './ShortformWizardSidebar';
 import { ShortformWizardStep1 } from './ShortformWizardStep1';
@@ -73,7 +73,7 @@ function buildClipSuggestions(course: CourseDetail | null, transcriptMap: Record
       return buildTranscriptSuggestions(course, lecture.id, transcriptSnapshot);
     }
 
-    const totalMs = Math.max(transcriptSnapshot?.duration_ms ?? lecture.duration_minutes * 60_000, 1);
+    const totalMs = Math.max(transcriptSnapshot?.duration_ms ?? getLectureDisplayDurationMinutes(lecture) * 60_000, 1);
     const segment = Math.max(Math.round(totalMs / 3), 30_000);
 
     return Array.from({ length: 3 }, (_, clipIndex) => {

--- a/frontend/src/features/lms/pages/CoursesPage.tsx
+++ b/frontend/src/features/lms/pages/CoursesPage.tsx
@@ -148,7 +148,16 @@ export function CoursesPage({
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
           {filteredCourses.length > 0 ? (
             filteredCourses.map((item) => (
-              <CourseExploreCard key={item.id} course={item} selected={selectedCourse?.id === item.id} onSelect={onSelectCourse} />
+              <CourseExploreCard
+                key={item.id}
+                course={item}
+                selected={selectedCourse?.id === item.id}
+                onSelect={onSelectCourse}
+                onOpen={(courseId) => {
+                  onSelectCourse(courseId);
+                  onNavigate('courses');
+                }}
+              />
             ))
           ) : (
             <div className="md:col-span-2 xl:col-span-3">

--- a/frontend/src/features/lms/pages/MyCoursesPage.tsx
+++ b/frontend/src/features/lms/pages/MyCoursesPage.tsx
@@ -359,7 +359,16 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
         ) : viewMode === 'grid' ? (
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             {filteredCourses.map((course) => (
-              <CourseExploreCard key={course.id} course={course} selected={selectedCourse?.id === course.id} onSelect={onSelectCourse} />
+              <CourseExploreCard
+                key={course.id}
+                course={course}
+                selected={selectedCourse?.id === course.id}
+                onSelect={onSelectCourse}
+                onOpen={(courseId) => {
+                  onSelectCourse(courseId);
+                  onNavigate('courses');
+                }}
+              />
             ))}
           </div>
         ) : (

--- a/packages/shared/src/data/courses.ts
+++ b/packages/shared/src/data/courses.ts
@@ -271,34 +271,27 @@ export const demoEnrollments: Enrollment[] = [
   {
     id: 'enr_001',
     user_id: 'usr_std_001',
-    course_id: 'crs_ai_001',
+    course_id: 'crs_econ_seed_001',
     status: 'active',
-    progress_percent: 50,
+    progress_percent: 0,
     created_at: '2026-04-06T09:10:00.000Z',
+  },
+  {
+    id: 'enr_002',
+    user_id: 'usr_std_001',
+    course_id: 'crs_java_seed_001',
+    status: 'active',
+    progress_percent: 0,
+    created_at: '2026-04-06T09:20:00.000Z',
+  },
+  {
+    id: 'enr_003',
+    user_id: 'usr_std_001',
+    course_id: 'crs_python_seed_001',
+    status: 'active',
+    progress_percent: 0,
+    created_at: '2026-04-06T09:30:00.000Z',
   },
 ];
 
-export const demoLectureProgress: LectureProgress[] = [
-  {
-    id: 'prg_001',
-    user_id: 'usr_std_001',
-    lecture_id: 'lec_ai_001',
-    is_completed: true,
-    completed_at: '2026-04-08T07:40:00.000Z',
-    updated_at: '2026-04-08T07:40:00.000Z',
-  },
-  {
-    id: 'prg_002',
-    user_id: 'usr_std_001',
-    lecture_id: 'lec_ai_002',
-    is_completed: false,
-    updated_at: '2026-04-08T07:50:00.000Z',
-  },
-  {
-    id: 'prg_003',
-    user_id: 'usr_std_001',
-    lecture_id: 'lec_ai_003',
-    is_completed: false,
-    updated_at: '2026-04-08T08:10:00.000Z',
-  },
-];
+export const demoLectureProgress: LectureProgress[] = [];

--- a/packages/shared/src/lms/learning/course.ts
+++ b/packages/shared/src/lms/learning/course.ts
@@ -1,4 +1,4 @@
-import { demoEnrollments, demoLectureProgress, demoLectures, getDemoUser, instructorNames } from '../../data/demo-data';
+import { demoAudioExtractions, demoEnrollments, demoLectureProgress, demoLectureTranscripts, demoLectures, getDemoUser, instructorNames } from '../../data/demo-data';
 import type { Course, CourseCard, CourseThumbnailPalette, Lecture } from '../../types';
 
 export function getLectureInstructorName(instructorId: string): string {
@@ -76,7 +76,23 @@ export function getCourseStudentCount(courseId: string): number {
 }
 
 export function getCourseTotalDurationMinutes(courseId: string): number {
-  return getCourseLectures(courseId).reduce((sum, lecture) => sum + lecture.duration_minutes, 0);
+  return getCourseLectures(courseId).reduce((sum, lecture) => sum + getLectureDisplayDurationMinutes(lecture), 0);
+}
+
+export function getLectureDisplayDurationMinutes(lecture: Pick<Lecture, 'duration_minutes'> & Partial<Lecture>): number {
+  if (lecture.id) {
+    const transcript = demoLectureTranscripts.find((item) => item.lecture_id === lecture.id);
+    if (transcript?.duration_ms) {
+      return Math.max(1, Math.round(transcript.duration_ms / 60_000));
+    }
+  }
+
+  const extraction = lecture.id ? demoAudioExtractions.find((item) => item.lecture_id === lecture.id && item.audio_duration_ms > 0) : undefined;
+  if (extraction?.audio_duration_ms) {
+    return Math.max(1, Math.round(extraction.audio_duration_ms / 60_000));
+  }
+
+  return lecture.duration_minutes;
 }
 
 export function getLectureKeywords(lecture: Lecture): string[] {

--- a/packages/shared/src/lms/learning/index.ts
+++ b/packages/shared/src/lms/learning/index.ts
@@ -1,4 +1,4 @@
-export { getLectureInstructorName, getCourseLectures, isEnrolled, getCompletedLectureCount, getLectureCount, getCourseProgress, createCourseCard } from './helpers';
+export { getLectureInstructorName, getCourseLectures, isEnrolled, getCompletedLectureCount, getLectureCount, getCourseProgress, getLectureDisplayDurationMinutes, createCourseCard } from './course';
 export { listCourseCards, getCourseDetail, getLectureDetail, createCourseRecord } from './catalog';
 export { getCourseMaterials, getCourseNotices, createCourseMaterial, createCourseNotice } from './content';
 export { getDashboard } from './dashboard';


### PR DESCRIPTION
# 변경 요약
사이드바 로고를 메인 복귀로 분리하고, 카드 클릭 동선과 강의 길이 표시 정합성을 맞췄습니다.

## 배경
사용자가 로고를 눌렀을 때 대시보드 내부가 아니라 메인 화면으로 돌아가야 했고, 카드 진입과 강의 길이 표시도 실제 재생/전사 데이터와 맞아야 했습니다.

## 변경 내용
- `AppSidebar` 로고 클릭을 `onHome`으로 분리하고, `LmsDashboard`에서 선택된 강의/차시 상태를 초기화하도록 정리했습니다.
- `CoursesPage`와 `MyCoursesPage`에서 카드 클릭 시 강의 상세로 이동하도록 연결을 보강했습니다.
- transcript 또는 추출 결과를 우선하는 강의 길이 헬퍼를 유지해 카드, 타임라인, 숏폼, 미디어 파이프라인에서 같은 값을 쓰도록 맞췄습니다.
- 변경 요약을 `docs/dev-logs/`에 남겼습니다.

## 연결 이슈
- 별도 이슈 없음

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다