### PR TITLE
[스펙] Spring 백엔드 3차 이식 spec/plan/tasks 추가

### DIFF
--- a/specs/003-spring-phase3/contracts/README.md
+++ b/specs/003-spring-phase3/contracts/README.md
@@ -1,0 +1,30 @@
+﻿# API Contract Notes
+
+## Envelope
+All responses must follow:
+
+```json
+{
+  "success": true,
+  "data": {},
+  "error": null,
+  "message": "optional"
+}
+```
+
+## Auth Failure
+
+```json
+{
+  "success": false,
+  "data": null,
+  "error": {"code": "UNAUTHENTICATED", "message": "로그인이 필요합니다."},
+  "message": "로그인이 필요합니다."
+}
+```
+
+## Priority Endpoint Groups
+- `/api/v1/ai/*`
+- `/api/v1/media/*`
+- `/api/v1/shortform/*`
+- `/api/v1/custom-courses/*`

--- a/specs/003-spring-phase3/data-model.md
+++ b/specs/003-spring-phase3/data-model.md
@@ -1,0 +1,44 @@
+﻿# Data Model
+
+## Entities
+
+### AiRuntimeSetting
+- key: string (PK)
+- value: string/json
+- updated_at: timestamp
+
+### MediaJob
+- id: string (PK)
+- lecture_id: string
+- status: enum(PENDING, PROCESSING, COMPLETED, FAILED)
+- retry_count: int
+- last_error: string?
+- version: long
+- updated_at: timestamp
+
+### TranscriptDocument
+- id: string (PK)
+- lecture_id: string (unique)
+- segments_json: json text
+- source: string
+- updated_at: timestamp
+
+### ShortformExportJob
+- id: string (PK)
+- shortform_id: string
+- status: enum(PENDING, PROCESSING, COMPLETED, FAILED, FAILED_PERMANENT)
+- retry_count: int
+- last_event_version: long
+- result_url: string?
+- error_message: string?
+- updated_at: timestamp
+
+### CustomCourseRecord
+- id: string (PK)
+- owner_id: string
+- course_id: string
+- title: string
+- description: string
+- clips_json: json text
+- visibility: string
+- updated_at: timestamp

--- a/specs/003-spring-phase3/plan.md
+++ b/specs/003-spring-phase3/plan.md
@@ -1,0 +1,91 @@
+﻿# Implementation Plan: Spring Backend Phase 3 Persistence & Pipeline
+
+**Branch**: `feature/spec-phase3-backend-migration` | **Date**: 2026-04-30 | **Spec**: `specs/003-spring-phase3/spec.md`
+**Input**: Feature specification from `/specs/003-spring-phase3/spec.md`
+
+## Summary
+
+Spring 2차에서 인메모리로 구현한 `ai/media/shortform/custom-courses` 영역을 durable 저장소 기반으로 전환하고, shortform export 재시도 상태기계를 정식화하며, API 계약 테스트를 도입한다.
+
+## Technical Context
+
+**Language/Version**: Java 21  
+**Primary Dependencies**: Spring Boot Web, Spring Validation, (추가) Spring Data JDBC/JPA, Testcontainers or H2 for tests  
+**Storage**: Durable SQL storage (우선 H2 + JDBC abstraction, 운영 바인딩 호환)  
+**Testing**: JUnit 5 + Spring Boot Test + MockMvc  
+**Target Platform**: Windows/Linux JVM runtime  
+**Project Type**: Backend web-service  
+**Performance Goals**: 주요 조회 API p95 250ms 이하(로컬 기준)  
+**Constraints**: 응답 포맷/에러코드 하위호환 유지, 인증 semantics 유지  
+**Scale/Scope**: Phase 3 범위는 `ai/media/shortform/custom-courses` + contract tests
+
+## Constitution Check
+
+- API Contract First: 충족 (계약 테스트를 구현 산출물에 포함)
+- Migration Safety: 충족 (기존 경로 유지, 저장소만 전환)
+- Verify Before Claim: 충족 (테스트 커맨드와 결과 필수)
+- Role-Based Orchestration: 충족 (backend 중심, QA 계약 테스트 분리)
+- Simplicity/Reversibility: 충족 (단계별 전환, feature toggle 가능)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-spring-phase3/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+backend-spring/
+├── src/main/java/com/myway/backendspring/
+│   ├── api/
+│   ├── auth/
+│   ├── common/
+│   ├── config/
+│   ├── domain/
+│   └── persistence/        # 신규
+└── src/test/java/com/myway/backendspring/
+    ├── contract/           # 신규
+    └── integration/        # 신규
+```
+
+**Structure Decision**: 기존 Spring 구조를 유지하고 persistence/test 레이어를 추가한다.
+
+## Phase 0: Research
+
+- 저장소 선택지 비교: JDBC vs JPA vs MyBatis (단순성/이식성/테스트성 기준)
+- shortform export 상태기계 모델링 (`PENDING/PROCESSING/FAILED/FAILED_PERMANENT/COMPLETED`)
+- 콜백 idempotency/versioning 전략 정리
+
+## Phase 1: Design
+
+- 데이터 모델 정의 (`MediaJob`, `TranscriptDocument`, `ShortformExportJob`, `AiRuntimeSetting`)
+- repository 인터페이스와 서비스 레이어 경계 확정
+- 계약 테스트 assertion 표준화
+
+## Phase 2: Implementation
+
+- persistence schema + repository 구현
+- 기존 `FeatureStoreService` 호출부를 durable service로 교체
+- retry/callback 상태전이 로직 구현
+- contract tests + auth regression tests 추가
+
+## Phase 3: Verification
+
+- 단위/통합/계약 테스트 실행
+- 핵심 엔드포인트 수동 smoke
+- 문서(README/운영노트) 반영
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Durable storage layer 추가 | 인메모리 상태 소실 방지 | 메모리 캐시만으로는 재시작 복구 불가 |

--- a/specs/003-spring-phase3/quickstart.md
+++ b/specs/003-spring-phase3/quickstart.md
@@ -1,0 +1,33 @@
+﻿# Quickstart
+
+## 1) Build & Run
+
+```powershell
+cd backend-spring
+mvn spring-boot:run
+```
+
+## 2) Verify Health
+
+```powershell
+curl http://127.0.0.1:8787/api/v1/health
+```
+
+## 3) Run Tests
+
+```powershell
+cd backend-spring
+mvn test
+```
+
+## 4) Contract Test Focus
+
+- ai/media/shortform/custom-courses endpoints return envelope format.
+- unauthorized requests return `401` and `UNAUTHENTICATED`.
+
+## 5) Retry Flow Manual Check
+
+1. Create shortform export failure state.
+2. Call retry endpoint.
+3. Deliver callback with incremented event version.
+4. Confirm terminal status behavior at retry limit.

--- a/specs/003-spring-phase3/research.md
+++ b/specs/003-spring-phase3/research.md
@@ -1,0 +1,25 @@
+﻿# Research Notes
+
+## Storage Strategy
+
+- 선택: Spring JDBC 기반 단순 repository + SQL schema.
+- 이유: 현재 단계는 빠른 마이그레이션이 목적이며 JPA 복잡도보다 명시적 SQL 관리가 유리.
+- 대안 기각: JPA는 학습/튜닝 비용이 추가되고 현재 데이터 구조가 단순해 과함.
+
+## Callback Idempotency Strategy
+
+- 각 callback 이벤트에 `event_version` 또는 `event_time`을 저장.
+- 저장된 최신 버전보다 낮거나 같은 이벤트는 무시.
+- 상태 전이는 허용된 방향으로만 진행 (역행 금지).
+
+## Retry Policy
+
+- 최대 재시도 횟수: 3회 (초기값, 설정화 가능)
+- 전이: `FAILED -> PROCESSING` (retry) / `PROCESSING -> FAILED|COMPLETED`
+- 재시도 한계 초과 시 `FAILED_PERMANENT`.
+
+## Contract Test Scope
+
+- Envelope: `success`, `data`, `error`, `message`
+- Auth: 미인증 호출 시 `401` + `UNAUTHENTICATED`
+- 주요 엔드포인트: ai/media/shortform/custom-courses CRUD/액션 경로

--- a/specs/003-spring-phase3/spec.md
+++ b/specs/003-spring-phase3/spec.md
@@ -1,0 +1,94 @@
+﻿# Feature Specification: Spring Backend Phase 3 Persistence & Pipeline
+
+**Feature Branch**: `003-spring-phase3`  
+**Created**: 2026-04-30  
+**Status**: Draft  
+**Input**: User description: "Spring 3차 이식: media/shortform/ai/custom-courses 인메모리 구현을 실제 저장소 기반으로 교체하고, 비동기 콜백/재시도 정책과 계약 테스트를 추가한다"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Persistent Media and AI State (Priority: P1)
+
+백엔드 운영자는 서버 재시작 이후에도 미디어 추출 상태, 트랜스크립트, AI 설정이 유지되어야 한다.
+
+**Why this priority**: 현재 인메모리 구조는 재시작 시 상태가 소실되어 운영 신뢰성이 없다.
+
+**Independent Test**: 미디어 추출/AI 설정 저장 후 서버 재기동, 동일 데이터 재조회 성공 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** 사용자가 `/api/v1/media/extract-audio`를 호출해 추출 상태가 생성됨, **When** 서버가 재시작됨, **Then** `/api/v1/media/pipeline/{lectureId}`에서 기존 상태를 조회할 수 있어야 한다.
+2. **Given** 관리자가 `/api/v1/ai/settings`를 갱신함, **When** 서버가 재시작됨, **Then** `/api/v1/ai/settings`에 마지막 설정이 유지되어야 한다.
+
+---
+
+### User Story 2 - Reliable Shortform Export Retry Flow (Priority: P2)
+
+콘텐츠 운영자는 숏폼 export 실패 시 재시도 정책에 따라 자동/수동 복구할 수 있어야 한다.
+
+**Why this priority**: 현재 숏폼 export는 성공 경로 위주 구현이며 실패 복구 정책이 약하다.
+
+**Independent Test**: 실패 콜백 주입 후 재시도 API 호출 시 상태 전이가 정의대로 진행되는지 검증.
+
+**Acceptance Scenarios**:
+
+1. **Given** 숏폼 export 상태가 `FAILED`, **When** `/api/v1/shortform/{id}/export/retry` 호출, **Then** 상태가 `PROCESSING`으로 전이되고 재시도 횟수가 증가해야 한다.
+2. **Given** `PROCESSING` 상태에서 콜백 실패 이벤트 수신, **When** 최대 재시도 횟수 초과, **Then** 최종 상태는 `FAILED_PERMANENT`로 기록되어야 한다.
+
+---
+
+### User Story 3 - Contract Guard for Spring APIs (Priority: P3)
+
+프론트엔드 개발자는 Spring API가 기존 계약을 깨지 않는지 자동으로 확인하고 싶다.
+
+**Why this priority**: 빠른 이식 과정에서 응답 스키마/에러 코드 회귀 위험이 높다.
+
+**Independent Test**: 계약 테스트 실행 시 핵심 엔드포인트의 필수 필드와 상태코드가 보장되는지 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** API 계약 테스트가 실행됨, **When** `/api/v1/media/*` 응답을 검증함, **Then** `success/data/error/message` 포맷 불일치가 있으면 실패해야 한다.
+2. **Given** 인증 필요 엔드포인트를 토큰 없이 호출함, **When** 응답을 검증함, **Then** `401`과 `UNAUTHENTICATED` 에러 코드가 일치해야 한다.
+
+---
+
+### Edge Cases
+
+- 저장소 연결 실패(DB down) 시 읽기 전용 폴백 응답 정책은 어떻게 동작하는가?
+- 동일 shortform에 대해 중복 retry 요청이 동시에 들어오면 상태 경쟁 조건을 어떻게 처리하는가?
+- 오래된 콜백(지연 도착)이 최신 상태를 덮어쓰지 않도록 어떻게 보장하는가?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST persist media extraction, transcript, pipeline state in durable storage.
+- **FR-002**: System MUST persist AI settings and provider selection with last-write-wins semantics.
+- **FR-003**: System MUST implement shortform export retry state machine with bounded retry count.
+- **FR-004**: System MUST reject stale callback updates based on monotonic event timestamp or version.
+- **FR-005**: System MUST provide contract tests for ai/media/shortform/custom-courses major endpoints.
+- **FR-006**: System MUST preserve current auth failure semantics (`401`, `UNAUTHENTICATED`).
+- **FR-007**: System MUST keep API envelope format consistent (`success/data/error/message`).
+
+### Key Entities *(include if feature involves data)*
+
+- **MediaJob**: lecture-level extraction job with status, retry metadata, callback trace.
+- **TranscriptDocument**: lecture transcript with segments and provenance metadata.
+- **ShortformExportJob**: shortform export execution record with state transitions.
+- **AiRuntimeSetting**: configurable AI provider/model/rate-limit policy persisted across restarts.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 서버 재시작 후 media/ai 상태 복원 성공률 100% (테스트 데이터 기준).
+- **SC-002**: shortform retry 상태 전이 테스트 케이스 100% 통과.
+- **SC-003**: 계약 테스트에서 핵심 엔드포인트(최소 20개 assertion) 100% 통과.
+- **SC-004**: 인증 누락 요청에 대해 정의된 에러 응답 회귀 0건.
+
+## Assumptions
+
+- 현재 3차 범위에서는 새로운 UI 변경 없이 백엔드 API 안정화에 집중한다.
+- 저장소는 Spring 환경에서 접근 가능한 단일 durable store(D1/JDBC 호환)를 사용한다.
+- 콜백 인증 메커니즘(secret/token)은 기존 정책을 유지하고 확장한다.
+- 운영 트래픽은 중간 규모이며 강한 분산 락 대신 낙관적 동시성으로 처리 가능하다.

--- a/specs/003-spring-phase3/tasks.md
+++ b/specs/003-spring-phase3/tasks.md
@@ -1,0 +1,62 @@
+﻿# Tasks: Spring Backend Phase 3 Persistence & Pipeline
+
+**Input**: Design documents from `/specs/003-spring-phase3/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 Create `backend-spring/src/main/java/com/myway/backendspring/persistence/` package skeleton
+- [ ] T002 Add persistence dependencies and test dependencies in `backend-spring/pom.xml`
+- [ ] T003 [P] Create migration/schema bootstrap files in `backend-spring/src/main/resources/`
+
+## Phase 2: Foundational (Blocking)
+
+- [ ] T004 Implement `AiRuntimeSettingRepository` and entity mappings
+- [ ] T005 [P] Implement `MediaJobRepository` and entity mappings
+- [ ] T006 [P] Implement `TranscriptRepository` and entity mappings
+- [ ] T007 [P] Implement `ShortformExportJobRepository` and entity mappings
+- [ ] T008 Add optimistic versioning/idempotency guard for callbacks
+
+## Phase 3: User Story 1 - Persistent Media and AI State (P1)
+
+**Independent Test**: restart-like test scenario with persisted state reload
+
+- [ ] T009 [US1] Replace in-memory AI settings read/write in `AiController` with persistent service
+- [ ] T010 [US1] Replace media transcript/pipeline state storage in `MediaController` with persistent service
+- [ ] T011 [US1] Add integration test for restart persistence in `backend-spring/src/test/java/.../integration/`
+
+## Phase 4: User Story 2 - Reliable Shortform Retry Flow (P2)
+
+**Independent Test**: failed export → retry → callback transitions
+
+- [ ] T012 [US2] Implement shortform export state machine service
+- [ ] T013 [US2] Apply retry-count cap and terminal `FAILED_PERMANENT` transition
+- [ ] T014 [US2] Update `ShortformController` retry/callback endpoints to use state machine
+- [ ] T015 [US2] Add integration tests for retry and stale callback rejection
+
+## Phase 5: User Story 3 - Contract Guard for Spring APIs (P3)
+
+**Independent Test**: contract suite validates envelope/auth semantics
+
+- [ ] T016 [US3] Create contract test base for API envelope assertions
+- [ ] T017 [US3] Add contract tests for `/api/v1/ai/*` endpoints
+- [ ] T018 [US3] Add contract tests for `/api/v1/media/*` endpoints
+- [ ] T019 [US3] Add contract tests for `/api/v1/shortform/*` and `/api/v1/custom-courses/*`
+- [ ] T020 [US3] Add auth regression tests (`401`, `UNAUTHENTICATED`)
+
+## Phase 6: Polish
+
+- [ ] T021 Update `backend-spring/README.md` with persistence architecture and retry policy
+- [ ] T022 [P] Add troubleshooting notes for callback/version conflicts
+- [ ] T023 Run full verification and capture outputs in PR body
+
+## Dependencies & Execution Order
+
+- T001-T003 → T004-T008 → (US1/US2/US3 in priority order)
+- US2 depends on T007 and T008 completion
+- US3 depends on API behavior stabilization from US1/US2
+
+## Parallel Opportunities
+
+- T005/T006/T007 can run in parallel after T001/T002
+- T017/T018/T019 can run in parallel after contract base(T016)


### PR DESCRIPTION
﻿## 📌 개요
- Spring 백엔드 3차 이식 작업을 실행하기 위한 Spec-Driven 산출물 세트를 추가했습니다.
- 대상 범위는 `ai/media/shortform/custom-courses`의 인메모리 구현을 durable 저장소 기반으로 교체하고, 콜백/재시도 정책 및 계약 테스트를 강화하는 것입니다.

## ✅ 포함 문서
- `specs/003-spring-phase3/spec.md`
- `specs/003-spring-phase3/plan.md`
- `specs/003-spring-phase3/tasks.md`
- `specs/003-spring-phase3/research.md`
- `specs/003-spring-phase3/data-model.md`
- `specs/003-spring-phase3/quickstart.md`
- `specs/003-spring-phase3/contracts/README.md`

## 🧩 핵심 내용
- 사용자 시나리오 P1/P2/P3 분리
- 저장소 전환 전략, 콜백 idempotency, retry 상태기계 정의
- 계약 테스트 대상과 검증 기준(응답 envelope/auth semantics) 명시
- 실행 가능한 작업 단위(Task ID)로 분해

## 📎 후속 작업
1. 본 스펙 기준으로 실제 구현 브랜치 착수
2. persistence 레이어 및 상태기계 구현
3. 계약/통합 테스트 추가 후 검증 결과 첨부
