### PR TITLE
[백엔드 전환] Spring 3차 구현: durable store + contract tests

### DIFF
--- a/backend-spring/pom.xml
+++ b/backend-spring/pom.xml
@@ -28,6 +28,15 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -1,30 +1,60 @@
-﻿package com.myway.backendspring.feature;
+package com.myway.backendspring.feature;
 
+import com.myway.backendspring.persistence.FeatureJdbcStore;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 public class FeatureStoreService {
-    private final Map<String, Object> aiSettings = new ConcurrentHashMap<>();
-    private final Map<String, Map<String, Object>> transcriptsByLecture = new ConcurrentHashMap<>();
-    private final Map<String, List<Map<String, Object>>> extractionsByLecture = new ConcurrentHashMap<>();
-    private final Map<String, Map<String, Object>> pipelineByLecture = new ConcurrentHashMap<>();
+    private static final String AI_SETTINGS_SCOPE = "ai_settings";
+    private static final String AI_SETTINGS_ID = "global";
+    private static final String TRANSCRIPT_SCOPE = "media_transcript";
+    private static final String EXTRACTION_SCOPE = "media_extraction";
+    private static final String PIPELINE_SCOPE = "media_pipeline";
+    private static final String SHORTFORM_EXTRACTION_SCOPE = "shortform_extraction";
+    private static final String SHORTFORM_VIDEO_SCOPE = "shortform_video";
+    private static final String CUSTOM_COURSE_SCOPE = "custom_course";
 
-    private final Map<String, Map<String, Object>> shortformExtractions = new ConcurrentHashMap<>();
-    private final Map<String, Map<String, Object>> shortformVideos = new ConcurrentHashMap<>();
-    private final Map<String, List<Map<String, Object>>> shortformLibraryByUser = new ConcurrentHashMap<>();
-    private final List<Map<String, Object>> shortformCommunity = Collections.synchronizedList(new ArrayList<>());
+    private final FeatureJdbcStore store;
 
-    private final Map<String, Map<String, Object>> customCourses = new ConcurrentHashMap<>();
-    private final Map<String, List<String>> customCourseIdsByUser = new ConcurrentHashMap<>();
+    public FeatureStoreService(FeatureJdbcStore store) {
+        this.store = store;
+        ensureDefaults();
+    }
 
-    public FeatureStoreService() {
-        aiSettings.put("daily_limit", 100);
-        aiSettings.put("provider", "demo");
-        aiSettings.put("model", "demo-v1");
+    private void ensureDefaults() {
+        Map<String, Object> settings = store.getKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID);
+        if (settings == null) {
+            store.upsertKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID, new HashMap<>(Map.of(
+                    "daily_limit", 100,
+                    "provider", "demo",
+                    "model", "demo-v1"
+            )));
+            return;
+        }
+
+        boolean changed = false;
+        if (!settings.containsKey("daily_limit")) {
+            settings.put("daily_limit", 100);
+            changed = true;
+        }
+        if (!settings.containsKey("provider")) {
+            settings.put("provider", "demo");
+            changed = true;
+        }
+        if (!settings.containsKey("model")) {
+            settings.put("model", "demo-v1");
+            changed = true;
+        }
+        if (changed) {
+            store.upsertKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID, settings);
+        }
     }
 
     public Map<String, Object> aiInsights() {
@@ -40,16 +70,21 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> aiSettings() {
-        return aiSettings;
+        Map<String, Object> settings = store.getKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID);
+        return settings != null ? settings : Map.of();
     }
 
     public Map<String, Object> updateAiSettings(Map<String, Object> patch) {
-        if (patch != null) aiSettings.putAll(patch);
-        return aiSettings;
+        Map<String, Object> settings = new HashMap<>(aiSettings());
+        if (patch != null) {
+            settings.putAll(patch);
+        }
+        store.upsertKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID, settings);
+        return settings;
     }
 
     public Map<String, Object> aiProviders() {
-        return Map.of("providers", List.of("demo", "ollama", "gemini"), "current", aiSettings.getOrDefault("provider", "demo"));
+        return Map.of("providers", List.of("demo", "ollama", "gemini"), "current", aiSettings().getOrDefault("provider", "demo"));
     }
 
     public Map<String, Object> mediaUpload(String lectureId, String fileName) {
@@ -58,33 +93,37 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> createExtraction(String lectureId) {
+        String id = UUID.randomUUID().toString();
         Map<String, Object> item = new HashMap<>();
-        item.put("id", UUID.randomUUID().toString());
+        item.put("id", id);
         item.put("lecture_id", lectureId);
         item.put("status", "COMPLETED");
         item.put("created_at", Instant.now().toString());
-        extractionsByLecture.computeIfAbsent(lectureId, k -> Collections.synchronizedList(new ArrayList<>())).add(item);
 
-        transcriptsByLecture.put(lectureId, Map.of(
+        store.insertEvent(EXTRACTION_SCOPE, lectureId, id, item);
+
+        Map<String, Object> transcript = Map.of(
                 "lecture_id", lectureId,
                 "segments", List.of(Map.of("start_ms", 0, "end_ms", 10000, "text", "자동 생성된 샘플 트랜스크립트")),
                 "updated_at", Instant.now().toString()
-        ));
-        pipelineByLecture.put(lectureId, Map.of("lecture_id", lectureId, "status", "READY", "updated_at", Instant.now().toString()));
+        );
+        store.upsertKv(TRANSCRIPT_SCOPE, lectureId, transcript);
+        store.upsertKv(PIPELINE_SCOPE, lectureId, Map.of("lecture_id", lectureId, "status", "READY", "updated_at", Instant.now().toString()));
 
         return item;
     }
 
     public Map<String, Object> transcript(String lectureId) {
-        return transcriptsByLecture.getOrDefault(lectureId, null);
+        return store.getKv(TRANSCRIPT_SCOPE, lectureId);
     }
 
     public List<Map<String, Object>> extractions(String lectureId) {
-        return extractionsByLecture.getOrDefault(lectureId, List.of());
+        return store.listEventsByOwner(EXTRACTION_SCOPE, lectureId);
     }
 
     public Map<String, Object> pipeline(String lectureId) {
-        return pipelineByLecture.getOrDefault(lectureId, Map.of("lecture_id", lectureId, "status", "EMPTY"));
+        Map<String, Object> row = store.getKv(PIPELINE_SCOPE, lectureId);
+        return row != null ? row : Map.of("lecture_id", lectureId, "status", "EMPTY");
     }
 
     public Map<String, Object> createShortformExtraction(String userId, Map<String, Object> payload) {
@@ -95,12 +134,13 @@ public class FeatureStoreService {
         data.put("course_id", payload.getOrDefault("course_id", "crs_java_01"));
         data.put("mode", payload.getOrDefault("mode", "cross"));
         data.put("candidates", List.of(Map.of("id", "cand-1", "selected", true), Map.of("id", "cand-2", "selected", false)));
-        shortformExtractions.put(id, data);
+
+        store.upsertKv(SHORTFORM_EXTRACTION_SCOPE, id, data);
         return data;
     }
 
     public Map<String, Object> getShortformExtraction(String id) {
-        return shortformExtractions.get(id);
+        return store.getKv(SHORTFORM_EXTRACTION_SCOPE, id);
     }
 
     public Map<String, Object> composeShortform(String userId, Map<String, Object> payload) {
@@ -112,22 +152,23 @@ public class FeatureStoreService {
         video.put("description", payload.getOrDefault("description", ""));
         video.put("export_status", "COMPLETED");
         video.put("video_url", "https://example.com/shortform/" + id + ".mp4");
-        shortformVideos.put(id, video);
-        shortformLibraryByUser.computeIfAbsent(userId, k -> Collections.synchronizedList(new ArrayList<>())).add(video);
-        shortformCommunity.add(video);
+
+        store.upsertKv(SHORTFORM_VIDEO_SCOPE, id, video);
+        store.insertEvent(SHORTFORM_VIDEO_SCOPE + "_library", userId, id, video);
+        store.insertEvent(SHORTFORM_VIDEO_SCOPE + "_community", "all", id, video);
         return video;
     }
 
     public Map<String, Object> shortformVideo(String id) {
-        return shortformVideos.get(id);
+        return store.getKv(SHORTFORM_VIDEO_SCOPE, id);
     }
 
     public List<Map<String, Object>> shortformLibrary(String userId) {
-        return shortformLibraryByUser.getOrDefault(userId, List.of());
+        return store.listEventsByOwner(SHORTFORM_VIDEO_SCOPE + "_library", userId);
     }
 
     public List<Map<String, Object>> shortformCommunity(String courseId) {
-        return shortformCommunity;
+        return store.listEventsByScope(SHORTFORM_VIDEO_SCOPE + "_community");
     }
 
     public Map<String, Object> customCompose(String userId, Map<String, Object> payload) {
@@ -140,26 +181,22 @@ public class FeatureStoreService {
         cc.put("description", payload.getOrDefault("description", ""));
         cc.put("clips", payload.getOrDefault("clips", List.of()));
         cc.put("shares", new ArrayList<>());
-        customCourses.put(id, cc);
-        customCourseIdsByUser.computeIfAbsent(userId, k -> Collections.synchronizedList(new ArrayList<>())).add(id);
+
+        store.upsertKv(CUSTOM_COURSE_SCOPE, id, cc);
+        store.insertEvent(CUSTOM_COURSE_SCOPE + "_my", userId, id, cc);
+        store.insertEvent(CUSTOM_COURSE_SCOPE + "_community", "all", id, cc);
         return cc;
     }
 
     public List<Map<String, Object>> myCustomCourses(String userId) {
-        List<String> ids = customCourseIdsByUser.getOrDefault(userId, List.of());
-        List<Map<String, Object>> out = new ArrayList<>();
-        for (String id : ids) {
-            Map<String, Object> row = customCourses.get(id);
-            if (row != null) out.add(row);
-        }
-        return out;
+        return store.listEventsByOwner(CUSTOM_COURSE_SCOPE + "_my", userId);
     }
 
     public Map<String, Object> customCourse(String id) {
-        return customCourses.get(id);
+        return store.getKv(CUSTOM_COURSE_SCOPE, id);
     }
 
     public List<Map<String, Object>> communityCustomCourses(String courseId) {
-        return new ArrayList<>(customCourses.values());
+        return store.listEventsByScope(CUSTOM_COURSE_SCOPE + "_community");
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/persistence/FeatureJdbcStore.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/persistence/FeatureJdbcStore.java
@@ -1,0 +1,96 @@
+package com.myway.backendspring.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class FeatureJdbcStore {
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    public FeatureJdbcStore(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public void upsertKv(String scope, String id, Map<String, Object> payload) {
+        String json = toJson(payload);
+        jdbcTemplate.update(
+                """
+                MERGE INTO kv_store(scope, id, payload, updated_at)
+                KEY(scope, id)
+                VALUES(?, ?, ?, CURRENT_TIMESTAMP)
+                """,
+                scope, id, json
+        );
+    }
+
+    public Map<String, Object> getKv(String scope, String id) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "SELECT payload FROM kv_store WHERE scope = ? AND id = ?",
+                    (rs, rowNum) -> fromJsonMap(rs.getString("payload")),
+                    scope, id
+            );
+        } catch (DataAccessException ex) {
+            return null;
+        }
+    }
+
+    public List<Map<String, Object>> listKvByScope(String scope) {
+        return jdbcTemplate.query(
+                "SELECT payload FROM kv_store WHERE scope = ? ORDER BY updated_at DESC",
+                (rs, rowNum) -> fromJsonMap(rs.getString("payload")),
+                scope
+        );
+    }
+
+    public void insertEvent(String scope, String ownerId, String id, Map<String, Object> payload) {
+        jdbcTemplate.update(
+                "INSERT INTO scoped_events(scope, owner_id, id, payload, created_at) VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                scope, ownerId, id, toJson(payload)
+        );
+    }
+
+    public List<Map<String, Object>> listEventsByOwner(String scope, String ownerId) {
+        return jdbcTemplate.query(
+                "SELECT payload FROM scoped_events WHERE scope = ? AND owner_id = ? ORDER BY created_at DESC",
+                (rs, rowNum) -> fromJsonMap(rs.getString("payload")),
+                scope, ownerId
+        );
+    }
+
+    public List<Map<String, Object>> listEventsByScope(String scope) {
+        return jdbcTemplate.query(
+                "SELECT payload FROM scoped_events WHERE scope = ? ORDER BY created_at DESC",
+                (rs, rowNum) -> fromJsonMap(rs.getString("payload")),
+                scope
+        );
+    }
+
+    private String toJson(Map<String, Object> payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to serialize payload", e);
+        }
+    }
+
+    private Map<String, Object> fromJsonMap(String payload) {
+        try {
+            Map<String, Object> parsed = objectMapper.readValue(payload, MAP_TYPE);
+            return parsed != null ? parsed : Collections.emptyMap();
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to deserialize payload", e);
+        }
+    }
+}

--- a/backend-spring/src/main/resources/application.properties
+++ b/backend-spring/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-﻿server.port=8787
+server.port=8787
+spring.datasource.url=jdbc:h2:file:./data/myway-feature-store;MODE=PostgreSQL;DATABASE_TO_UPPER=false;AUTO_SERVER=TRUE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.sql.init.mode=always
+spring.h2.console.enabled=true

--- a/backend-spring/src/main/resources/schema.sql
+++ b/backend-spring/src/main/resources/schema.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS kv_store (
+  scope VARCHAR(64) NOT NULL,
+  id VARCHAR(128) NOT NULL,
+  payload CLOB NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (scope, id)
+);
+
+CREATE TABLE IF NOT EXISTS scoped_events (
+  scope VARCHAR(64) NOT NULL,
+  owner_id VARCHAR(128) NOT NULL,
+  id VARCHAR(128) NOT NULL,
+  payload CLOB NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (scope, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scoped_events_owner ON scoped_events(scope, owner_id, created_at DESC);

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/ResponseEnvelopeContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/ResponseEnvelopeContractTest.java
@@ -1,0 +1,71 @@
+package com.myway.backendspring.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ResponseEnvelopeContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void representativeEndpoints_shouldReturnSuccessEnvelope_whenAuthenticated() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken();
+
+        assertSuccessEnvelope(mockMvc.perform(get("/api/v1/ai/insights").header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(get("/api/v1/media/providers").header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(get("/api/v1/shortform/library").header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(get("/api/v1/custom-courses/my").header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+    }
+
+    private String loginAndGetToken() throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"usr_std_001\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode root = objectMapper.readTree(response);
+        return root.path("data").path("session_token").asText();
+    }
+
+    private void assertSuccessEnvelope(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        assertThat(root.path("success").asBoolean()).isTrue();
+        assertThat(root.get("data")).isNotNull();
+        assertThat(root.get("data").isNull()).isFalse();
+        assertThat(root.path("error").isNull()).isTrue();
+        assertThat(root.has("message")).isTrue();
+    }
+}

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AuthSemanticsIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AuthSemanticsIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.myway.backendspring.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthSemanticsIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void representativeEndpoints_shouldReturn401AndUnauthenticated_whenMissingAuthorization() throws Exception {
+        assertUnauthenticated(mockMvc.perform(get("/api/v1/ai/insights"))
+                .andExpect(status().isUnauthorized())
+                .andReturn());
+
+        assertUnauthenticated(mockMvc.perform(get("/api/v1/media/providers"))
+                .andExpect(status().isUnauthorized())
+                .andReturn());
+
+        assertUnauthenticated(mockMvc.perform(get("/api/v1/shortform/library"))
+                .andExpect(status().isUnauthorized())
+                .andReturn());
+
+        assertUnauthenticated(mockMvc.perform(get("/api/v1/custom-courses/my"))
+                .andExpect(status().isUnauthorized())
+                .andReturn());
+    }
+
+    private void assertUnauthenticated(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        assertThat(root.path("success").asBoolean()).isFalse();
+        assertThat(root.path("data").isNull()).isTrue();
+        assertThat(root.path("error").path("code").asText()).isEqualTo("UNAUTHENTICATED");
+        assertThat(root.path("error").path("message").asText()).isNotBlank();
+        assertThat(root.path("message").asText()).isNotBlank();
+    }
+}


### PR DESCRIPTION
﻿## 📌 개요
- `dev` 최신화 후, 관리자 오케스트레이션(역할 분배)으로 Spring 3차 구현 작업을 진행했습니다.
- 목표: 인메모리 상태 저장을 durable 저장소(H2/JDBC)로 전환하고, API 계약/인증 회귀를 테스트로 고정.

## 👥 오케스트레이션 배분
- Worker A (Backend): persistence 레이어 구축 + `FeatureStoreService` DB 전환
- Worker B (QA): 계약 테스트 및 인증 시맨틱 회귀 테스트 추가
- Orchestrator (Main): 통합 검토, 테스트 계약 불일치 수정, 브랜치/커밋/푸시/PR 처리

## ✅ 주요 변경 사항
### 1) Durable 저장소 전환
- `spring-boot-starter-jdbc`, `h2` 의존성 추가
- `schema.sql` 추가 (`kv_store`, `scoped_events`)
- `FeatureJdbcStore` 추가: JSON payload upsert/get/list 지원
- `FeatureStoreService` 인메모리 로직을 JDBC 기반으로 교체

### 2) 애플리케이션 설정
- `application.properties`에 H2 datasource 및 schema init 설정 추가

### 3) 계약/인증 테스트 추가
- `ResponseEnvelopeContractTest`
  - 대표 엔드포인트(ai/media/shortform/custom-courses) 응답 envelope 검증
- `AuthSemanticsIntegrationTest`
  - 미인증 호출 시 `401` + `UNAUTHENTICATED` 검증

### 4) 통합 수정
- 계약 테스트의 로그인 요청/토큰 필드를 현재 API 계약(`userId`, `session_token`)에 맞게 수정

## 🧪 검증 상태
- 이 환경에서는 `mvn` 미설치로 테스트 실행은 수행하지 못했습니다.
- 테스트 코드는 추가 완료되어, Maven 환경에서 즉시 실행 가능 상태입니다.

## 📎 후속 작업
1. CI 또는 로컬 Maven 환경에서 `mvn test` 실행 및 결과 반영
2. H2 파일 기반 저장소를 운영 저장소로 치환(D1/JDBC target)
3. shortform retry 상태기계(`FAILED_PERMANENT` 등) 상세 전이 규칙 고도화
