### PR TITLE
[백엔드 전환] Shortform retry 상태기계/콜백 버전가드 고도화

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -87,7 +87,70 @@ public class ShortformController {
 
     @PostMapping("/{shortformId}/export/retry")
     public ResponseEntity<ApiResponse<Map<String, Object>>> retry(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String shortformId) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.success(Map.of("id", shortformId, "export_status", "PROCESSING"), "숏폼 export job이 다시 시작되었습니다."));
+        SessionView s = require(auth);
+        if (s == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+
+        Map<String, Object> updated = featureStore.retryShortformExport(s.user().id(), shortformId);
+        if (updated == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("SHORTFORM_NOT_FOUND", "숏폼을 찾을 수 없습니다."));
+        }
+        if ("FORBIDDEN".equals(updated.get("error"))) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "본인 숏폼만 다시 내보낼 수 있습니다."));
+        }
+
+        String status = String.valueOf(updated.getOrDefault("export_status", "PROCESSING"));
+        if ("FAILED_PERMANENT".equals(status)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.success(updated, "최대 재시도 횟수를 초과했습니다."));
+        }
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.success(updated, "숏폼 export job이 다시 시작되었습니다."));
+    }
+
+    public record ExportCallbackRequest(
+            String shortform_id,
+            String video_id,
+            String status,
+            String video_url,
+            String error_message,
+            Long event_version
+    ) {}
+
+    @PostMapping("/export/callback")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> exportCallback(@RequestBody ExportCallbackRequest body) {
+        if (body == null) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("INVALID_BODY", "요청 본문이 올바르지 않습니다."));
+        }
+        String shortformId = body.shortform_id() != null && !body.shortform_id().isBlank()
+                ? body.shortform_id().trim()
+                : (body.video_id() != null ? body.video_id().trim() : "");
+        if (shortformId.isBlank()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_ID_REQUIRED", "shortform_id가 필요합니다."));
+        }
+
+        long eventVersion = body.event_version() != null ? body.event_version() : 1L;
+        String status = body.status() != null ? body.status() : "COMPLETED";
+
+        Map<String, Object> updated = featureStore.applyShortformExportCallback(
+                shortformId,
+                status,
+                eventVersion,
+                body.video_url(),
+                body.error_message()
+        );
+
+        if (updated == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("SHORTFORM_NOT_FOUND", "숏폼을 찾을 수 없습니다."));
+        }
+
+        if (Boolean.TRUE.equals(updated.get("callback_ignored"))) {
+            return ResponseEntity.ok(ApiResponse.success(updated, "오래된 callback 이벤트를 무시했습니다."));
+        }
+
+        if ("FAILED_PERMANENT".equals(updated.get("export_status"))) {
+            return ResponseEntity.ok(ApiResponse.success(updated, "숏폼 export가 영구 실패 상태로 전환되었습니다."));
+        }
+        if ("FAILED".equals(updated.get("export_status"))) {
+            return ResponseEntity.ok(ApiResponse.success(updated, "숏폼 export가 실패했습니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.success(updated, "숏폼 export가 완료되었습니다."));
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -20,6 +20,7 @@ public class FeatureStoreService {
     private static final String SHORTFORM_EXTRACTION_SCOPE = "shortform_extraction";
     private static final String SHORTFORM_VIDEO_SCOPE = "shortform_video";
     private static final String CUSTOM_COURSE_SCOPE = "custom_course";
+    private static final int SHORTFORM_MAX_RETRY = 3;
 
     private final FeatureJdbcStore store;
 
@@ -150,8 +151,13 @@ public class FeatureStoreService {
         video.put("user_id", userId);
         video.put("title", payload.getOrDefault("title", "untitled"));
         video.put("description", payload.getOrDefault("description", ""));
-        video.put("export_status", "COMPLETED");
         video.put("video_url", "https://example.com/shortform/" + id + ".mp4");
+        video.put("export_status", "COMPLETED");
+        video.put("retry_count", 0);
+        video.put("last_event_version", 0L);
+        video.put("export_result_url", video.get("video_url"));
+        video.put("error_message", null);
+        video.put("updated_at", Instant.now().toString());
 
         store.upsertKv(SHORTFORM_VIDEO_SCOPE, id, video);
         store.insertEvent(SHORTFORM_VIDEO_SCOPE + "_library", userId, id, video);
@@ -161,6 +167,67 @@ public class FeatureStoreService {
 
     public Map<String, Object> shortformVideo(String id) {
         return store.getKv(SHORTFORM_VIDEO_SCOPE, id);
+    }
+
+    public Map<String, Object> retryShortformExport(String userId, String shortformId) {
+        Map<String, Object> video = store.getKv(SHORTFORM_VIDEO_SCOPE, shortformId);
+        if (video == null) {
+            return null;
+        }
+        if (!userId.equals(String.valueOf(video.getOrDefault("user_id", "")))) {
+            return Map.of("error", "FORBIDDEN");
+        }
+
+        int retryCount = asInt(video.get("retry_count"));
+        if (retryCount >= SHORTFORM_MAX_RETRY) {
+            video.put("export_status", "FAILED_PERMANENT");
+            video.put("updated_at", Instant.now().toString());
+            store.upsertKv(SHORTFORM_VIDEO_SCOPE, shortformId, video);
+            return video;
+        }
+
+        video.put("retry_count", retryCount + 1);
+        video.put("export_status", "PROCESSING");
+        video.put("error_message", null);
+        video.put("updated_at", Instant.now().toString());
+        store.upsertKv(SHORTFORM_VIDEO_SCOPE, shortformId, video);
+        return video;
+    }
+
+    public Map<String, Object> applyShortformExportCallback(String shortformId, String status, long eventVersion, String videoUrl, String errorMessage) {
+        Map<String, Object> video = store.getKv(SHORTFORM_VIDEO_SCOPE, shortformId);
+        if (video == null) {
+            return null;
+        }
+
+        long currentVersion = asLong(video.get("last_event_version"));
+        if (eventVersion <= currentVersion) {
+            video.put("callback_ignored", true);
+            return video;
+        }
+
+        video.put("last_event_version", eventVersion);
+        video.put("updated_at", Instant.now().toString());
+
+        if ("FAILED".equalsIgnoreCase(status)) {
+            int retryCount = asInt(video.get("retry_count"));
+            if (retryCount >= SHORTFORM_MAX_RETRY) {
+                video.put("export_status", "FAILED_PERMANENT");
+            } else {
+                video.put("export_status", "FAILED");
+            }
+            video.put("error_message", errorMessage != null ? errorMessage : "export callback failure");
+        } else {
+            video.put("export_status", "COMPLETED");
+            if (videoUrl != null && !videoUrl.isBlank()) {
+                video.put("video_url", videoUrl);
+                video.put("export_result_url", videoUrl);
+            }
+            video.put("error_message", null);
+        }
+
+        store.upsertKv(SHORTFORM_VIDEO_SCOPE, shortformId, video);
+        return video;
     }
 
     public List<Map<String, Object>> shortformLibrary(String userId) {
@@ -198,5 +265,33 @@ public class FeatureStoreService {
 
     public List<Map<String, Object>> communityCustomCourses(String courseId) {
         return store.listEventsByScope(CUSTOM_COURSE_SCOPE + "_community");
+    }
+
+    private int asInt(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        if (value instanceof Number n) {
+            return n.intValue();
+        }
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (Exception ignored) {
+            return 0;
+        }
+    }
+
+    private long asLong(Object value) {
+        if (value == null) {
+            return 0L;
+        }
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+        try {
+            return Long.parseLong(String.valueOf(value));
+        } catch (Exception ignored) {
+            return 0L;
+        }
     }
 }

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformRetryStateIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformRetryStateIntegrationTest.java
@@ -1,0 +1,86 @@
+﻿package com.myway.backendspring.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ShortformRetryStateIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void retryAndCallback_shouldTransitionStates_andIgnoreStaleEvents() throws Exception {
+        String token = loginAndGetToken();
+        String auth = "Bearer " + token;
+
+        String compose = mockMvc.perform(post("/api/v1/shortform/compose")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"retry-test\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String shortformId = objectMapper.readTree(compose).path("data").path("id").asText();
+        assertThat(shortformId).isNotBlank();
+
+        String retry = mockMvc.perform(post("/api/v1/shortform/" + shortformId + "/export/retry")
+                        .header("Authorization", auth))
+                .andExpect(status().isAccepted())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode retryRoot = objectMapper.readTree(retry);
+        assertThat(retryRoot.path("data").path("export_status").asText()).isEqualTo("PROCESSING");
+
+        String failedCb = mockMvc.perform(post("/api/v1/shortform/export/callback")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shortform_id\":\"" + shortformId + "\",\"status\":\"FAILED\",\"error_message\":\"boom\",\"event_version\":2}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode failedRoot = objectMapper.readTree(failedCb);
+        assertThat(failedRoot.path("data").path("export_status").asText()).isEqualTo("FAILED");
+
+        String staleCb = mockMvc.perform(post("/api/v1/shortform/export/callback")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shortform_id\":\"" + shortformId + "\",\"status\":\"COMPLETED\",\"video_url\":\"https://old\",\"event_version\":1}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode staleRoot = objectMapper.readTree(staleCb);
+        assertThat(staleRoot.path("message").asText()).contains("무시");
+
+        String okCb = mockMvc.perform(post("/api/v1/shortform/export/callback")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shortform_id\":\"" + shortformId + "\",\"status\":\"COMPLETED\",\"video_url\":\"https://new\",\"event_version\":3}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode okRoot = objectMapper.readTree(okCb);
+        assertThat(okRoot.path("data").path("export_status").asText()).isEqualTo("COMPLETED");
+        assertThat(okRoot.path("data").path("video_url").asText()).isEqualTo("https://new");
+    }
+
+    private String loginAndGetToken() throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"usr_std_001\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+}


### PR DESCRIPTION
﻿## 📌 개요
- `dev` 최신화 이후 Phase 3 후속 작업으로 shortform export 재시도 상태기계를 고도화했습니다.
- 핵심은 재시도 제한, stale callback 차단(event_version), callback 기반 상태 전이 반영입니다.

## ✅ 주요 변경 사항
### 1) retry 상태기계 강화
- `/api/v1/shortform/{shortformId}/export/retry`가 실제 저장 상태를 갱신하도록 변경
- 재시도 횟수(`retry_count`)를 기반으로 최대치 초과 시 `FAILED_PERMANENT` 전이
- 본인 소유가 아닌 숏폼 retry 요청 차단(`FORBIDDEN`)

### 2) callback 엔드포인트 추가
- `/api/v1/shortform/export/callback` 추가
- `event_version`을 사용해 stale callback(이전 버전 이벤트) 무시
- callback 상태값(`FAILED`/`COMPLETED`)에 따라 저장 상태 반영

### 3) 상태 필드 확장
- `FeatureStoreService`에서 shortform 영상 레코드에
  - `retry_count`
  - `last_event_version`
  - `export_result_url`
  - `error_message`
  - `updated_at`
  필드 관리 추가

### 4) 통합 테스트 추가
- `ShortformRetryStateIntegrationTest`
  - compose → retry → failed callback → stale callback 무시 → completed callback 전이 시나리오 검증

## 🧪 검증 메모
- 이 환경에서 Maven(`mvn`)이 없어 테스트 실제 실행은 못 했습니다.
- 테스트 코드는 추가되어 Maven 환경에서 바로 실행 가능합니다.

## 📎 후속 작업
1. CI/로컬 Maven에서 `mvn test` 실행 결과 확인
2. retry 정책(최대 횟수/백오프)을 설정값으로 외부화
3. callback 인증(secret/token) 및 감사로그 강화
