### PR TITLE
[백엔드 전환] Retry 정책 외부화 + callback 인증 강화

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -4,6 +4,7 @@ import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.feature.FeatureStoreService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,10 +17,16 @@ import java.util.Map;
 public class ShortformController {
     private final SessionService sessionService;
     private final FeatureStoreService featureStore;
+    private final String callbackToken;
 
-    public ShortformController(SessionService sessionService, FeatureStoreService featureStore) {
+    public ShortformController(
+            SessionService sessionService,
+            FeatureStoreService featureStore,
+            @Value("${myway.shortform.callback.token:dev-shortform-callback-token}") String callbackToken
+    ) {
         this.sessionService = sessionService;
         this.featureStore = featureStore;
+        this.callbackToken = callbackToken;
     }
 
     private SessionView require(String auth) { return sessionService.me(auth); }
@@ -115,7 +122,13 @@ public class ShortformController {
     ) {}
 
     @PostMapping("/export/callback")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> exportCallback(@RequestBody ExportCallbackRequest body) {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> exportCallback(
+            @RequestHeader(value = "X-Callback-Token", required = false) String token,
+            @RequestBody ExportCallbackRequest body
+    ) {
+        if (token == null || token.isBlank() || !token.equals(callbackToken)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "유효한 callback token이 필요합니다."));
+        }
         if (body == null) {
             return ResponseEntity.badRequest().body(ApiResponse.failure("INVALID_BODY", "요청 본문이 올바르지 않습니다."));
         }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -1,6 +1,7 @@
 package com.myway.backendspring.feature;
 
 import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -20,12 +21,15 @@ public class FeatureStoreService {
     private static final String SHORTFORM_EXTRACTION_SCOPE = "shortform_extraction";
     private static final String SHORTFORM_VIDEO_SCOPE = "shortform_video";
     private static final String CUSTOM_COURSE_SCOPE = "custom_course";
-    private static final int SHORTFORM_MAX_RETRY = 3;
-
     private final FeatureJdbcStore store;
+    private final int shortformMaxRetry;
 
-    public FeatureStoreService(FeatureJdbcStore store) {
+    public FeatureStoreService(
+            FeatureJdbcStore store,
+            @Value("${myway.shortform.retry.max-attempts:3}") int shortformMaxRetry
+    ) {
         this.store = store;
+        this.shortformMaxRetry = Math.max(1, shortformMaxRetry);
         ensureDefaults();
     }
 
@@ -179,7 +183,7 @@ public class FeatureStoreService {
         }
 
         int retryCount = asInt(video.get("retry_count"));
-        if (retryCount >= SHORTFORM_MAX_RETRY) {
+        if (retryCount >= shortformMaxRetry) {
             video.put("export_status", "FAILED_PERMANENT");
             video.put("updated_at", Instant.now().toString());
             store.upsertKv(SHORTFORM_VIDEO_SCOPE, shortformId, video);
@@ -211,7 +215,7 @@ public class FeatureStoreService {
 
         if ("FAILED".equalsIgnoreCase(status)) {
             int retryCount = asInt(video.get("retry_count"));
-            if (retryCount >= SHORTFORM_MAX_RETRY) {
+            if (retryCount >= shortformMaxRetry) {
                 video.put("export_status", "FAILED_PERMANENT");
             } else {
                 video.put("export_status", "FAILED");

--- a/backend-spring/src/main/resources/application.properties
+++ b/backend-spring/src/main/resources/application.properties
@@ -5,3 +5,5 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.sql.init.mode=always
 spring.h2.console.enabled=true
+myway.shortform.retry.max-attempts=3
+myway.shortform.callback.token=dev-shortform-callback-token

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformRetryStateIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformRetryStateIntegrationTest.java
@@ -47,6 +47,7 @@ class ShortformRetryStateIntegrationTest {
         assertThat(retryRoot.path("data").path("export_status").asText()).isEqualTo("PROCESSING");
 
         String failedCb = mockMvc.perform(post("/api/v1/shortform/export/callback")
+                        .header("X-Callback-Token", "dev-shortform-callback-token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"shortform_id\":\"" + shortformId + "\",\"status\":\"FAILED\",\"error_message\":\"boom\",\"event_version\":2}"))
                 .andExpect(status().isOk())
@@ -56,6 +57,7 @@ class ShortformRetryStateIntegrationTest {
         assertThat(failedRoot.path("data").path("export_status").asText()).isEqualTo("FAILED");
 
         String staleCb = mockMvc.perform(post("/api/v1/shortform/export/callback")
+                        .header("X-Callback-Token", "dev-shortform-callback-token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"shortform_id\":\"" + shortformId + "\",\"status\":\"COMPLETED\",\"video_url\":\"https://old\",\"event_version\":1}"))
                 .andExpect(status().isOk())
@@ -65,6 +67,7 @@ class ShortformRetryStateIntegrationTest {
         assertThat(staleRoot.path("message").asText()).contains("무시");
 
         String okCb = mockMvc.perform(post("/api/v1/shortform/export/callback")
+                        .header("X-Callback-Token", "dev-shortform-callback-token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"shortform_id\":\"" + shortformId + "\",\"status\":\"COMPLETED\",\"video_url\":\"https://new\",\"event_version\":3}"))
                 .andExpect(status().isOk())
@@ -73,6 +76,11 @@ class ShortformRetryStateIntegrationTest {
         JsonNode okRoot = objectMapper.readTree(okCb);
         assertThat(okRoot.path("data").path("export_status").asText()).isEqualTo("COMPLETED");
         assertThat(okRoot.path("data").path("video_url").asText()).isEqualTo("https://new");
+
+        mockMvc.perform(post("/api/v1/shortform/export/callback")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shortform_id\":\"" + shortformId + "\",\"status\":\"COMPLETED\",\"event_version\":4}"))
+                .andExpect(status().isForbidden());
     }
 
     private String loginAndGetToken() throws Exception {


### PR DESCRIPTION
﻿## 📌 개요
- `dev` 최신화 후 다음 작업으로 shortform retry 정책을 설정값으로 외부화하고, callback 엔드포인트 인증을 강화했습니다.

## ✅ 변경 사항
### 1) retry 정책 외부화
- `myway.shortform.retry.max-attempts` 설정 추가
- `FeatureStoreService`가 설정값을 주입받아 retry 한도 적용

### 2) callback 인증 강화
- `myway.shortform.callback.token` 설정 추가
- `/api/v1/shortform/export/callback`에 `X-Callback-Token` 검증 추가
- 토큰 누락/불일치 시 `403 FORBIDDEN` 응답

### 3) 테스트 보강
- `ShortformRetryStateIntegrationTest`에서 callback 호출 시 토큰 헤더 적용
- 토큰 없는 callback 호출이 `403` 반환하는 시나리오 추가

## 🧪 검증 메모
- 이 환경에서는 `mvn` 미설치로 테스트 실행은 수행하지 못했습니다.

## 📎 후속 작업
1. CI/로컬 Maven 환경에서 `mvn test` 실행 확인
2. callback 토큰을 환경별 시크릿으로 분리 관리
3. retry/backoff 정책 세분화(지수 백오프 등)
