### PR TITLE
[인프라] backend-spring CI 테스트 + JAVA_HOME 설정 스크립트 추가

### DIFF
--- a/.github/workflows/backend-spring-tests.yml
+++ b/.github/workflows/backend-spring-tests.yml
@@ -1,0 +1,27 @@
+﻿name: backend-spring-tests
+
+on:
+  pull_request:
+    branches: [ dev ]
+  push:
+    branches: [ dev ]
+
+jobs:
+  test-backend-spring:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend-spring
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Run tests (Maven Wrapper)
+        run: ./mvnw test

--- a/.github/workflows/backend-spring-tests.yml
+++ b/.github/workflows/backend-spring-tests.yml
@@ -23,5 +23,8 @@ jobs:
           java-version: '21'
           cache: maven
 
+      - name: Grant execute permission for Maven Wrapper
+        run: chmod +x mvnw
+
       - name: Run tests (Maven Wrapper)
         run: ./mvnw test

--- a/backend-spring/README.md
+++ b/backend-spring/README.md
@@ -10,6 +10,16 @@
 - Test: `mvnw.cmd test`
 - Package: `mvnw.cmd -DskipTests package`
 
+## JAVA_HOME Setup (Windows)
+- one-time setup script:
+  - `powershell -ExecutionPolicy Bypass -File ..\\scripts\\setup\\set-java-home.ps1 -JavaHome "C:\\Program Files\\Java\\jdk-21"`
+- then reopen terminal and validate:
+  - `mvnw.cmd -v`
+
+## CI
+- GitHub Actions workflow: `.github/workflows/backend-spring-tests.yml`
+- trigger: push/pull_request to `dev`
+
 ## Implemented Endpoints
 - GET `/`
 - GET `/api/v1/health`

--- a/backend-spring/src/main/java/com/myway/backendspring/BackendSpringApplication.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/BackendSpringApplication.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring;
+package com.myway.backendspring;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/AuthController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AuthController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.DemoUser;
 import com.myway.backendspring.auth.DemoUsers;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/CoursesController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/CoursesController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/CustomCoursesController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/CustomCoursesController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/DashboardController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/DashboardController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/EnrollmentsController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/EnrollmentsController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/LecturesController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/LecturesController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.common.ApiResponse;
 import org.springframework.http.HttpStatus;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/RootController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/RootController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.common.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/api/SmartController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/SmartController.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.api;
+package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;

--- a/backend-spring/src/main/java/com/myway/backendspring/auth/DemoUser.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/auth/DemoUser.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.auth;
+package com.myway.backendspring.auth;
 
 public record DemoUser(
         String id,

--- a/backend-spring/src/main/java/com/myway/backendspring/auth/DemoUsers.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/auth/DemoUsers.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.auth;
+package com.myway.backendspring.auth;
 
 import java.util.List;
 import java.util.Map;

--- a/backend-spring/src/main/java/com/myway/backendspring/auth/SessionService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/auth/SessionService.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.auth;
+package com.myway.backendspring.auth;
 
 import org.springframework.stereotype.Service;
 

--- a/backend-spring/src/main/java/com/myway/backendspring/auth/SessionView.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/auth/SessionView.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.auth;
+package com.myway.backendspring.auth;
 
 import java.util.List;
 

--- a/backend-spring/src/main/java/com/myway/backendspring/common/ApiError.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/common/ApiError.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.common;
+package com.myway.backendspring.common;
 
 public record ApiError(String code, String message) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/common/ApiResponse.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/common/ApiResponse.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.common;
+package com.myway.backendspring.common;
 
 public record ApiResponse<T>(boolean success, T data, ApiError error, String message) {
     public static <T> ApiResponse<T> success(T data, String message) {

--- a/backend-spring/src/main/java/com/myway/backendspring/config/CorsConfig.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/config/CorsConfig.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.config;
+package com.myway.backendspring.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/CourseCard.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/CourseCard.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 public record CourseCard(String id, String title, String instructor_id, int progress_percent) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/CourseDetail.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/CourseDetail.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 public record CourseDetail(String id, String title, String instructor_id, java.util.List<LectureItem> lectures, int progress_percent) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DashboardView.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DashboardView.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 public record DashboardView(java.util.List<CourseCard> courses, int enrolled_count, int completed_lectures) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 import org.springframework.stereotype.Service;
 

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/EnrollmentItem.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/EnrollmentItem.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 public record EnrollmentItem(String id, String user_id, String course_id) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/LectureItem.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/LectureItem.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 public record LectureItem(String id, String course_id, String title, int duration_minutes) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/MaterialItem.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/MaterialItem.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 public record MaterialItem(String id, String course_id, String title, String summary, String file_name) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/NoticeItem.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/NoticeItem.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 public record NoticeItem(String id, String course_id, String title, String content, boolean pinned) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/SmartChatResult.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/SmartChatResult.java
@@ -1,3 +1,3 @@
-﻿package com.myway.backendspring.domain;
+package com.myway.backendspring.domain;
 
 public record SmartChatResult(String answer, java.util.List<String> references) {}

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformRetryStateIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformRetryStateIntegrationTest.java
@@ -1,4 +1,4 @@
-﻿package com.myway.backendspring.integration;
+package com.myway.backendspring.integration;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformRetryStateIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformRetryStateIntegrationTest.java
@@ -64,7 +64,7 @@ class ShortformRetryStateIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
 
         JsonNode staleRoot = objectMapper.readTree(staleCb);
-        assertThat(staleRoot.path("message").asText()).contains("무시");
+        assertThat(staleRoot.path("data").path("callback_ignored").asBoolean()).isTrue();
 
         String okCb = mockMvc.perform(post("/api/v1/shortform/export/callback")
                         .header("X-Callback-Token", "dev-shortform-callback-token")

--- a/scripts/setup/set-java-home.ps1
+++ b/scripts/setup/set-java-home.ps1
@@ -1,0 +1,25 @@
+﻿param(
+  [Parameter(Mandatory=$true)]
+  [string]$JavaHome
+)
+
+$resolved = Resolve-Path -LiteralPath $JavaHome -ErrorAction Stop
+$javaExe = Join-Path $resolved.Path "bin\\java.exe"
+
+if (-not (Test-Path -LiteralPath $javaExe)) {
+  Write-Error "java.exe not found under '$($resolved.Path)\\bin'."
+  exit 1
+}
+
+[Environment]::SetEnvironmentVariable("JAVA_HOME", $resolved.Path, "User")
+
+$currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$javaBin = Join-Path $resolved.Path "bin"
+
+if ($currentPath -notlike "*$javaBin*") {
+  $newPath = if ([string]::IsNullOrWhiteSpace($currentPath)) { $javaBin } else { "$currentPath;$javaBin" }
+  [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+}
+
+Write-Host "JAVA_HOME set to: $($resolved.Path)"
+Write-Host "Reopen terminal and run: cd backend-spring; .\\mvnw.cmd -v"


### PR DESCRIPTION
﻿## 📌 개요
- `dev` 최신화 후 다음 작업으로 backend-spring의 실행 안정성을 높이기 위해 CI 테스트 워크플로우와 로컬 JAVA_HOME 설정 스크립트를 추가했습니다.

## ✅ 변경 사항
### 1) GitHub Actions 테스트 자동화
- `.github/workflows/backend-spring-tests.yml` 추가
- `dev` 브랜치 대상 push / pull_request 시 자동 실행
- Java 21 + Maven cache + `./mvnw test` 수행

### 2) 로컬 JAVA_HOME 설정 자동화
- `scripts/setup/set-java-home.ps1` 추가
- 사용자 환경변수 `JAVA_HOME` 및 `Path`에 Java bin 등록
- 설정 후 `mvnw.cmd -v` 검증 가이드 출력

### 3) 문서 반영
- `backend-spring/README.md`에
  - 로컬 JAVA_HOME 설정 방법
  - CI 워크플로우 위치/동작
  - wrapper 기반 실행 흐름 정리

## 📎 후속 작업
1. PR 병합 후 Actions 실행 결과 확인
2. 필요 시 backend-spring 테스트를 matrix(OS/JDK)로 확장
3. JAVA_HOME 스크립트에 관리자 권한 모드(시스템 범위) 옵션 추가 검토
