### PR TITLE
[CI] Node 24 전환 대응을 위한 Actions 버전 업데이트

### DIFF
--- a/.github/workflows/backend-spring-tests.yml
+++ b/.github/workflows/backend-spring-tests.yml
@@ -14,10 +14,10 @@ jobs:
         working-directory: backend-spring
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'


### PR DESCRIPTION
## 작업 배경
- GitHub Actions 실행 로그에서 Node.js 20 deprecation 경고가 발생하고 있었습니다.
- 2026-06-02 이후 기본 런타임이 Node.js 24로 전환될 예정이어서 선제 대응이 필요했습니다.

## 변경 사항
- `.github/workflows/backend-spring-tests.yml`
- `actions/checkout` 버전: `v4` -> `v5`
- `actions/setup-java` 버전: `v4` -> `v5`

## 기대 효과
- 백엔드 스프링 테스트 워크플로우의 Node.js 24 전환 호환성 확보
- 향후 Node.js 20 제거 시 CI 불안정 리스크 감소

## 검증
- 워크플로우 정의 변경만 포함되어 애플리케이션 런타임 로직 영향은 없습니다.
- PR 체크에서 `backend-spring-tests` 포함 전체 통과를 확인했습니다.