### PR TITLE
[CI] 워크플로우 Actions v5 전환 및 인코딩 정규화

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Leave automated review
         uses: actions/github-script@v7

--- a/.github/workflows/backend-spring-tests.yml
+++ b/.github/workflows/backend-spring-tests.yml
@@ -1,4 +1,4 @@
-﻿name: backend-spring-tests
+name: backend-spring-tests
 
 on:
   pull_request:

--- a/.github/workflows/branch-protection-checks.yml
+++ b/.github/workflows/branch-protection-checks.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check branch scoped directories
         run: |
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check agent guide size
         run: |
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Verify UTF-8 text files
         run: |
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check root scripts
         run: |
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check deploy readiness
         run: |


### PR DESCRIPTION
## 작업 배경
- 일부 워크플로우가 `actions/checkout@v4`를 사용 중이어서 Node.js 24 전환 시점 경고/호환성 리스크가 있었습니다.
- 이전 작업에서 `backend-spring-tests`만 우선 반영되어, 나머지 워크플로우도 일관성 있게 정리할 필요가 있었습니다.

## 변경 사항
- `.github/workflows/auto-pr-review.yml`
  - `actions/checkout` 버전: `v4` -> `v5`
- `.github/workflows/branch-protection-checks.yml`
  - `actions/checkout` 버전: `v4` -> `v5` (전체 job 반영)
- `.github/workflows/backend-spring-tests.yml`
  - 내용 변경 없이 UTF-8(BOM 없음) 인코딩 정규화

## 기대 효과
- GitHub Actions Node.js 24 전환 대응 일관성 확보
- 워크플로우 실행 경고 및 향후 호환성 이슈 가능성 감소

## 검증
- `.github/workflows` 내 `actions/checkout@v4`, `actions/setup-java@v4` 잔존 없음 확인
- PR 생성 후 기본 보호 체크 통과 여부 확인 예정