### PR TITLE
[CI] Auto PR Review 워크플로우 github-script v8 전환

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Leave automated review
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -137,3 +137,4 @@ jobs:
               event: 'COMMENT',
               body,
             });
+


### PR DESCRIPTION
## 작업 배경
- CI 워크플로우 전반의 Node.js 24 전환 대응을 진행하면서 `auto-pr-review`에 `actions/github-script@v7`이 남아 있었습니다.
- 향후 런타임 전환 시 경고/호환성 이슈를 줄이기 위해 동일 기준으로 버전 정리가 필요했습니다.

## 변경 사항
- `.github/workflows/auto-pr-review.yml`
  - `actions/github-script` 버전: `v7` -> `v8`

## 기대 효과
- Auto PR Review 워크플로우의 최신 런타임 호환성 강화
- 워크플로우 버전 정책 일관성 유지

## 검증
- 워크플로우 정의 외 애플리케이션 런타임 코드 변경 없음
- PR 체크 결과로 최종 확인 예정