### PR TITLE
[CI] backend-spring-tests 동시 실행 제어 및 타임아웃 추가

### DIFF
--- a/.github/workflows/backend-spring-tests.yml
+++ b/.github/workflows/backend-spring-tests.yml
@@ -6,9 +6,14 @@ on:
   push:
     branches: [ dev ]
 
+concurrency:
+  group: backend-spring-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-backend-spring:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: backend-spring


### PR DESCRIPTION
## 작업 배경
- 동일 브랜치에 연속 푸시가 발생하면 `backend-spring-tests`가 중복 실행되어 대기열이 길어질 수 있습니다.
- 외부 환경 이슈 시 테스트 잡이 과도하게 지연될 수 있어 실행 상한 시간이 필요했습니다.

## 변경 사항
- `.github/workflows/backend-spring-tests.yml`
- `concurrency` 추가
  - group: `backend-spring-tests-${{ github.workflow }}-${{ github.ref }}`
  - `cancel-in-progress: true`
- `test-backend-spring` 잡에 `timeout-minutes: 15` 추가

## 기대 효과
- 동일 ref의 이전 실행 자동 취소로 CI 자원 사용 최적화
- 비정상 장기 실행 방지로 피드백 지연 감소

## 검증
- 워크플로우 정의 변경 외 애플리케이션 런타임 코드 변경 없음
- PR 체크 통과 여부로 최종 확인 예정