### PR TITLE
[CI] auto-pr-review 동시 실행 제어 및 타임아웃 추가

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -15,10 +15,15 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: auto-pr-review-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review:
     name: auto-pr-review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## 작업 배경
- `auto-pr-review` 워크플로우도 연속 푸시/동시 이벤트에서 중복 실행이 발생할 수 있습니다.
- 외부 API 지연이나 액션 지연 시 무제한 대기를 피하기 위한 시간 상한이 필요했습니다.

## 변경 사항
- `.github/workflows/auto-pr-review.yml`
- `concurrency` 추가
  - group: `auto-pr-review-${{ github.workflow }}-${{ github.ref }}`
  - `cancel-in-progress: true`
- `review` job에 `timeout-minutes: 10` 추가

## 기대 효과
- 동일 ref 기준 중복 리뷰 작업 자동 취소
- 비정상 장기 실행 방지로 CI 대기열 안정화

## 검증
- 워크플로우 정의 외 애플리케이션 코드 변경 없음
- PR 체크 통과 여부로 최종 확인 예정