### PR TITLE
[CI] branch-protection-checks 동시 실행 제어 및 타임아웃 추가

### DIFF
--- a/.github/workflows/branch-protection-checks.yml
+++ b/.github/workflows/branch-protection-checks.yml
@@ -10,10 +10,15 @@ on:
       - main
       - dev
 
+concurrency:
+  group: branch-protection-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   repo-structure:
     name: repo-structure
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -64,6 +69,7 @@ jobs:
   docs-integrity:
     name: docs-integrity
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -119,6 +125,7 @@ jobs:
   utf8-check:
     name: utf8-check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -155,6 +162,7 @@ jobs:
   ci-checks:
     name: ci-checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -186,6 +194,7 @@ jobs:
   cd-checks:
     name: cd-checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## 작업 배경
- `branch-protection-checks`는 다수 job이 병렬 실행되어 연속 푸시 시 중복 실행 비용이 커질 수 있습니다.
- 외부 환경 지연 시 job이 장시간 대기할 가능성이 있어 실행 상한이 필요했습니다.

## 변경 사항
- `.github/workflows/branch-protection-checks.yml`
- `concurrency` 추가
  - group: `branch-protection-checks-${{ github.workflow }}-${{ github.ref }}`
  - `cancel-in-progress: true`
- 각 job에 `timeout-minutes: 10` 추가
  - `repo-structure`, `docs-integrity`, `utf8-check`, `ci-checks`, `cd-checks`

## 기대 효과
- 동일 ref의 중복 체크 실행 자동 취소
- 비정상 장기 실행 방지로 피드백 지연 감소

## 검증
- 워크플로우 정의 외 애플리케이션 런타임 코드 변경 없음
- PR 체크 통과 여부로 최종 확인 예정