### PR TITLE
[CI] backend-spring-tests 수동 실행 트리거 추가

### DIFF
--- a/.github/workflows/backend-spring-tests.yml
+++ b/.github/workflows/backend-spring-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ dev ]
   push:
     branches: [ dev ]
+  workflow_dispatch:
 
 concurrency:
   group: backend-spring-tests-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 작업 배경
- PR/Push 이벤트 외에도 긴급 점검이나 재검증을 위해 백엔드 테스트 워크플로우를 수동 실행할 수 있어야 합니다.
- 특히 CI 환경 이슈 확인 시 코드 변경 없이 재실행 가능한 진입점이 필요했습니다.

## 변경 사항
- `.github/workflows/backend-spring-tests.yml`
- `on` 섹션에 `workflow_dispatch` 추가

## 기대 효과
- GitHub Actions UI에서 필요 시 즉시 수동 실행 가능
- 운영/장애 대응 시 검증 리드타임 단축

## 검증
- 기존 `pull_request`/`push` 동작은 유지되며 트리거만 확장됨
- PR 체크 통과 여부로 최종 확인 예정