### PR TITLE
[CI] 관리자 오케스트레이션: 워크플로우 권한 하드닝 및 운영 가이드 보강

### DIFF
--- a/.github/workflows/backend-spring-tests.yml
+++ b/.github/workflows/backend-spring-tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ dev ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: backend-spring-tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [주요 화면](#주요-화면)
 - [실행 방법](#실행-방법)
 - [스크립트](#스크립트)
+- [CI 운영](#ci-운영)
 - [문서](#문서)
 - [설계 방향](#설계-방향)
 
@@ -161,6 +162,12 @@ npm run build
 | `npm run build` | 프론트엔드 + 백엔드 빌드 |
 | `npm run verify` | 의존성, 타입, 빌드 검증 |
 | `npm run check:media-processor` | 미디어 프로세서 타입 체크 |
+
+## CI 운영
+
+- 수동 실행: GitHub Actions에서 `backend-spring-tests` 워크플로우를 `Run workflow`로 직접 실행할 수 있습니다(`workflow_dispatch`).
+- 동시 실행 제어: 같은 브랜치/워크플로우 조합으로 새 실행이 시작되면 기존 실행은 자동 취소됩니다(`concurrency`, `cancel-in-progress: true`).
+- 타임아웃: `backend-spring-tests` 잡은 15분 제한이며, 초과 시 실패 처리됩니다(`timeout-minutes: 15`).
 
 ## 문서
 

--- a/backend-spring/README.md
+++ b/backend-spring/README.md
@@ -18,7 +18,9 @@
 
 ## CI
 - GitHub Actions workflow: `.github/workflows/backend-spring-tests.yml`
-- trigger: push/pull_request to `dev`
+- trigger: push/pull_request to `dev`, `workflow_dispatch`(수동 실행)
+- concurrency: 동일 브랜치에서 새 실행 시작 시 이전 실행 자동 취소(`cancel-in-progress: true`)
+- timeout: job 기준 15분(`timeout-minutes: 15`)
 
 ## Implemented Endpoints
 - GET `/`


### PR DESCRIPTION
## 작업 방식
- 관리자 오케스트레이션으로 병렬 작업을 배분해 진행했습니다.
  - 트랙 A: 워크플로우 하드닝(권한/안정성)
  - 트랙 B: 운영 문서화

## 변경 사항
- `.github/workflows/backend-spring-tests.yml`
  - `permissions` 명시: `contents: read`
- `README.md`
  - 목차에 `CI 운영` 추가
  - `workflow_dispatch`, `concurrency`, `timeout` 운영 요약 추가
- `backend-spring/README.md`
  - CI 섹션에 수동 실행/동시 실행 제어/타임아웃 정책 반영

## 기대 효과
- 워크플로우 권한 최소화 원칙 명시로 보안/감사 가독성 개선
- 운영자가 CI 재실행/중복 실행 취소/시간 제한 정책을 문서에서 즉시 확인 가능

## 검증
- 워크플로우/문서 변경만 포함(애플리케이션 런타임 로직 변경 없음)
- PR 체크 통과 여부로 최종 확인 예정