### PR TITLE
legacy 엔드포인트 Spring 이관

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
@@ -3,11 +3,13 @@ package com.myway.backendspring.api;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.DemoLearningService;
 import com.myway.backendspring.feature.FeatureStoreService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -15,10 +17,12 @@ import java.util.Map;
 public class AiController {
     private final SessionService sessionService;
     private final FeatureStoreService featureStore;
+    private final DemoLearningService learningService;
 
-    public AiController(SessionService sessionService, FeatureStoreService featureStore) {
+    public AiController(SessionService sessionService, FeatureStoreService featureStore, DemoLearningService learningService) {
         this.sessionService = sessionService;
         this.featureStore = featureStore;
+        this.learningService = learningService;
     }
 
     private SessionView require(String auth) { return sessionService.me(auth); }
@@ -53,6 +57,11 @@ public class AiController {
         return ResponseEntity.ok(ApiResponse.success(featureStore.updateAiSettings(body), "설정이 저장되었습니다."));
     }
 
+    @PutMapping("/settings")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> putSettings(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        return updateSettings(auth, body);
+    }
+
     @GetMapping("/providers")
     public ResponseEntity<ApiResponse<Map<String, Object>>> providers(@RequestHeader(value = "Authorization", required = false) String auth) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
@@ -63,5 +72,100 @@ public class AiController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> rag(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
         return ResponseEntity.ok(ApiResponse.success(Map.of("answer", "RAG 샘플 응답", "query", body.getOrDefault("query", ""), "hits", java.util.List.of())));
+    }
+
+    @PostMapping("/intent")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> intent(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String message = text(body, "message");
+        if (message.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("MESSAGE_REQUIRED", "message가 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(Map.of(
+                "intent", "recommendation",
+                "confidence", 0.82,
+                "action", "show_recommendations",
+                "reason", "Spring demo intent classifier",
+                "lecture_id", textOrNull(body, "lecture_id"),
+                "provider", "demo",
+                "model", "demo-intent-v1"
+        ), "인텐트가 분류되었습니다."));
+    }
+
+    @PostMapping("/search")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> search(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String query = text(body, "query");
+        if (query.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("QUERY_REQUIRED", "query가 필요합니다."));
+        ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLecture(body);
+        if (lectureError != null) return lectureError;
+        return ResponseEntity.ok(ApiResponse.success(Map.of(
+                "query", query,
+                "hits", List.of(Map.of("id", "hit-1", "title", "Spring Boot 시작", "score", 0.91)),
+                "provider", "demo",
+                "model", "demo-search-v1"
+        ), "검색 결과를 조회했습니다."));
+    }
+
+    @PostMapping("/answer")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> answer(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String question = text(body, "question");
+        if (question.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("QUESTION_REQUIRED", "question가 필요합니다."));
+        ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLecture(body);
+        if (lectureError != null) return lectureError;
+        return ResponseEntity.ok(ApiResponse.success(Map.of(
+                "answer", "[Spring AI 응답] " + question,
+                "sources", List.of("lecture:lec_java_01"),
+                "lecture_id", textOrNull(body, "lecture_id"),
+                "provider", "demo",
+                "model", "demo-answer-v1"
+        ), "답변을 생성했습니다."));
+    }
+
+    @PostMapping("/summary")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> summary(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String lectureId = text(body, "lecture_id");
+        if (lectureId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
+        if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        return ResponseEntity.ok(ApiResponse.success(Map.of(
+                "lecture_id", lectureId,
+                "content", "Spring 백엔드에서 생성한 강의 요약입니다.",
+                "style", text(body, "style").isBlank() ? "brief" : text(body, "style"),
+                "language", text(body, "language").isBlank() ? "ko" : text(body, "language"),
+                "provider", "demo",
+                "model", "demo-summary-v1"
+        ), "요약이 생성되었습니다."));
+    }
+
+    @PostMapping("/quiz")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> quiz(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String lectureId = text(body, "lecture_id");
+        if (lectureId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
+        if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        return ResponseEntity.ok(ApiResponse.success(Map.of(
+                "lecture_id", lectureId,
+                "questions", List.of(Map.of("id", "q-1", "question", "Spring Boot의 장점은?", "answer", "빠른 REST API 개발")),
+                "provider", "demo",
+                "model", "demo-quiz-v1"
+        ), "퀴즈가 생성되었습니다."));
+    }
+
+    private ResponseEntity<ApiResponse<Map<String, Object>>> validateLecture(Map<String, Object> body) {
+        String lectureId = text(body, "lecture_id");
+        if (!lectureId.isBlank() && learningService.getLecture(lectureId) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        return null;
+    }
+
+    private String text(Map<String, Object> body, String key) {
+        if (body == null || body.get(key) == null) return "";
+        return String.valueOf(body.get(key)).trim();
+    }
+
+    private Object textOrNull(Map<String, Object> body, String key) {
+        String value = text(body, key);
+        return value.isBlank() ? null : value;
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/CoursesController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/CoursesController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -23,11 +24,41 @@ public class CoursesController {
 
     public record MaterialInput(String title, String summary, String file_name) {}
     public record NoticeInput(String title, String content, Boolean pinned) {}
+    public record CourseCreateInput(String title, String description, String category, String difficulty, List<String> lecture_titles) {}
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CourseDetail>> create(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody CourseCreateInput body) {
+        SessionView session = sessionService.me(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!canManageCourses(session.user().role())) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "강의를 개설할 권한이 없습니다."));
+        if (body == null || isBlank(body.title()) || isBlank(body.description()) || isBlank(body.category()) || isBlank(body.difficulty())) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("COURSE_CREATE_FIELDS_REQUIRED", "강의 제목, 설명, 카테고리, 난이도가 필요합니다."));
+        }
+
+        List<String> lectureTitles = new ArrayList<>();
+        if (body.lecture_titles() != null) {
+            for (String lectureTitle : body.lecture_titles()) {
+                if (!isBlank(lectureTitle)) {
+                    lectureTitles.add(lectureTitle.trim());
+                }
+            }
+        }
+        CourseDetail created = learningService.createCourse(session.user().id(), body.title().trim(), lectureTitles);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(created, "새 강의가 개설되었습니다."));
+    }
 
     @GetMapping
     public ApiResponse<List<CourseCard>> list(@RequestHeader(value = "Authorization", required = false) String auth) {
         String userId = sessionService.me(auth) != null ? sessionService.me(auth).user().id() : "guest";
         return ApiResponse.success(learningService.listCourseCards(userId));
+    }
+
+    @GetMapping("/manage")
+    public ResponseEntity<ApiResponse<List<CourseCard>>> manage(@RequestHeader(value = "Authorization", required = false) String auth) {
+        SessionView session = sessionService.me(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!canManageCourses(session.user().role())) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "강의 관리 페이지를 사용할 권한이 없습니다."));
+        return ResponseEntity.ok(ApiResponse.success(learningService.listManagedCourseCards(session.user().id(), session.user().role()), "내 강의 목록을 조회했습니다."));
     }
 
     @GetMapping("/{courseId}")
@@ -79,5 +110,9 @@ public class CoursesController {
 
     private boolean isBlank(String value) {
         return value == null || value.trim().isEmpty();
+    }
+
+    private boolean canManageCourses(String role) {
+        return "admin".equals(role) || "instructor".equals(role);
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/LectureDraftsController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/LectureDraftsController.java
@@ -1,0 +1,118 @@
+package com.myway.backendspring.api;
+
+import com.myway.backendspring.auth.SessionService;
+import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.CourseDetail;
+import com.myway.backendspring.domain.DemoLearningService;
+import com.myway.backendspring.domain.LectureDraft;
+import com.myway.backendspring.domain.LectureDraftService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/lecture-drafts")
+public class LectureDraftsController {
+    private final SessionService sessionService;
+    private final DemoLearningService learningService;
+    private final LectureDraftService draftService;
+
+    public LectureDraftsController(SessionService sessionService, DemoLearningService learningService, LectureDraftService draftService) {
+        this.sessionService = sessionService;
+        this.learningService = learningService;
+        this.draftService = draftService;
+    }
+
+    public record DraftInput(String lecture_id, String title, String content) {}
+
+    @GetMapping("/course/{courseId}")
+    public ResponseEntity<ApiResponse<List<LectureDraft>>> list(@PathVariable String courseId, @RequestHeader(value = "Authorization", required = false) String auth) {
+        SessionView session = sessionService.me(auth);
+        ResponseEntity<ApiResponse<Object>> access = requireManageAccess(session, courseId, false);
+        if (access != null) return cast(access);
+        return ResponseEntity.ok(ApiResponse.success(draftService.listByCourse(courseId)));
+    }
+
+    @GetMapping("/course/{courseId}/{draftId}")
+    public ResponseEntity<ApiResponse<LectureDraft>> get(@PathVariable String courseId, @PathVariable String draftId, @RequestHeader(value = "Authorization", required = false) String auth) {
+        SessionView session = sessionService.me(auth);
+        ResponseEntity<ApiResponse<Object>> access = requireManageAccess(session, courseId, false);
+        if (access != null) return cast(access);
+        LectureDraft draft = draftService.get(courseId, draftId);
+        if (draft == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_DRAFT_NOT_FOUND", "강의 초안을 찾을 수 없습니다."));
+        return ResponseEntity.ok(ApiResponse.success(draft));
+    }
+
+    @PostMapping("/course/{courseId}")
+    public ResponseEntity<ApiResponse<LectureDraft>> create(@PathVariable String courseId, @RequestHeader(value = "Authorization", required = false) String auth, @RequestBody DraftInput body) {
+        SessionView session = sessionService.me(auth);
+        ResponseEntity<ApiResponse<Object>> access = requireManageAccess(session, courseId, true);
+        if (access != null) return cast(access);
+
+        CourseDetail detail = learningService.getCourseDetail(courseId, session.user().id());
+        String lectureId = body != null && !isBlank(body.lecture_id()) ? body.lecture_id().trim() : detail.lectures().getFirst().id();
+        if (learningService.getCourseLecture(courseId, lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "차시를 찾을 수 없습니다."));
+
+        LectureDraft draft = draftService.create(courseId, lectureId, valueOrDefault(body == null ? null : body.title(), "강의 초안"), valueOrDefault(body == null ? null : body.content(), ""));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(draft, "강의 초안이 저장되었습니다."));
+    }
+
+    @PutMapping("/course/{courseId}/{draftId}")
+    public ResponseEntity<ApiResponse<LectureDraft>> update(@PathVariable String courseId, @PathVariable String draftId, @RequestHeader(value = "Authorization", required = false) String auth, @RequestBody DraftInput body) {
+        SessionView session = sessionService.me(auth);
+        ResponseEntity<ApiResponse<Object>> access = requireManageAccess(session, courseId, true);
+        if (access != null) return cast(access);
+
+        LectureDraft existing = draftService.get(courseId, draftId);
+        if (existing == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_DRAFT_NOT_FOUND", "강의 초안을 찾을 수 없습니다."));
+
+        String lectureId = body != null && !isBlank(body.lecture_id()) ? body.lecture_id().trim() : existing.lecture_id();
+        if (learningService.getCourseLecture(courseId, lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "차시를 찾을 수 없습니다."));
+
+        LectureDraft updated = draftService.update(
+                courseId,
+                draftId,
+                lectureId,
+                valueOrDefault(body == null ? null : body.title(), existing.title()),
+                valueOrDefault(body == null ? null : body.content(), existing.content())
+        );
+        return ResponseEntity.ok(ApiResponse.success(updated, "강의 초안이 수정되었습니다."));
+    }
+
+    @PostMapping("/course/{courseId}/{draftId}/publish")
+    public ResponseEntity<ApiResponse<LectureDraft>> publish(@PathVariable String courseId, @PathVariable String draftId, @RequestHeader(value = "Authorization", required = false) String auth) {
+        SessionView session = sessionService.me(auth);
+        ResponseEntity<ApiResponse<Object>> access = requireManageAccess(session, courseId, true);
+        if (access != null) return cast(access);
+
+        LectureDraft published = draftService.publish(courseId, draftId);
+        if (published == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_DRAFT_NOT_FOUND", "강의 초안을 찾을 수 없습니다."));
+        return ResponseEntity.ok(ApiResponse.success(published, "강의 초안이 발행 준비 상태로 전환되었습니다."));
+    }
+
+    private ResponseEntity<ApiResponse<Object>> requireManageAccess(SessionView session, String courseId, boolean ownerOnly) {
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        CourseDetail detail = learningService.getCourseDetail(courseId, session.user().id());
+        if (detail == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("COURSE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        boolean canManage = "admin".equals(session.user().role()) || session.user().id().equals(detail.instructor_id());
+        boolean canReadDrafts = canManage || (!ownerOnly && "instructor".equals(session.user().role()));
+        if (!canReadDrafts) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "강의 초안에 접근할 권한이 없습니다."));
+        return null;
+    }
+
+    private String valueOrDefault(String value, String fallback) {
+        return isBlank(value) ? fallback : value.trim();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> ResponseEntity<ApiResponse<T>> cast(ResponseEntity<ApiResponse<Object>> response) {
+        return (ResponseEntity<ApiResponse<T>>) (ResponseEntity<?>) response;
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -38,6 +38,25 @@ public class DemoLearningService {
         return courses.values().stream().map(c -> new CourseCard(c.id(), c.title(), c.instructor_id(), progressPercent(userId, c.id()))).toList();
     }
 
+    public List<CourseCard> listManagedCourseCards(String userId, String role) {
+        return courses.values().stream()
+                .filter(c -> "admin".equals(role) || c.instructor_id().equals(userId))
+                .map(c -> new CourseCard(c.id(), c.title(), c.instructor_id(), progressPercent(userId, c.id())))
+                .toList();
+    }
+
+    public CourseDetail createCourse(String instructorId, String title, List<String> lectureTitles) {
+        String courseId = "crs_" + UUID.randomUUID();
+        List<String> titles = lectureTitles == null || lectureTitles.isEmpty() ? List.of(title) : lectureTitles;
+        List<LectureItem> lectures = new ArrayList<>();
+        for (int i = 0; i < titles.size(); i++) {
+            lectures.add(new LectureItem("lec_" + UUID.randomUUID(), courseId, titles.get(i), 25 + (i * 5)));
+        }
+        CourseDetail detail = new CourseDetail(courseId, title, instructorId, List.copyOf(lectures), 0);
+        courses.put(courseId, detail);
+        return detail;
+    }
+
     public CourseDetail getCourseDetail(String courseId, String userId) {
         CourseDetail base = courses.get(courseId);
         if (base == null) return null;
@@ -51,6 +70,10 @@ public class DemoLearningService {
 
     public LectureItem getLecture(String lectureId) {
         return courses.values().stream().flatMap(c -> c.lectures().stream()).filter(l -> l.id().equals(lectureId)).findFirst().orElse(null);
+    }
+
+    public LectureItem getCourseLecture(String courseId, String lectureId) {
+        return getCourseLectures(courseId).stream().filter(l -> l.id().equals(lectureId)).findFirst().orElse(null);
     }
 
     public DashboardView getDashboard(String userId) {

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/LectureDraft.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/LectureDraft.java
@@ -1,0 +1,10 @@
+package com.myway.backendspring.domain;
+
+public record LectureDraft(
+        String id,
+        String course_id,
+        String lecture_id,
+        String title,
+        String content,
+        String status
+) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/LectureDraftService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/LectureDraftService.java
@@ -1,0 +1,74 @@
+package com.myway.backendspring.domain;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class LectureDraftService {
+    private final ConcurrentHashMap<String, LectureDraft> drafts = new ConcurrentHashMap<>();
+
+    public List<LectureDraft> listByCourse(String courseId) {
+        return drafts.values().stream()
+                .filter(draft -> draft.course_id().equals(courseId))
+                .toList();
+    }
+
+    public LectureDraft get(String courseId, String draftId) {
+        LectureDraft draft = drafts.get(draftId);
+        if (draft == null || !draft.course_id().equals(courseId)) {
+            return null;
+        }
+        return draft;
+    }
+
+    public LectureDraft create(String courseId, String lectureId, String title, String content) {
+        LectureDraft draft = new LectureDraft(
+                UUID.randomUUID().toString(),
+                courseId,
+                lectureId,
+                title,
+                content,
+                "DRAFT"
+        );
+        drafts.put(draft.id(), draft);
+        return draft;
+    }
+
+    public LectureDraft update(String courseId, String draftId, String lectureId, String title, String content) {
+        LectureDraft existing = get(courseId, draftId);
+        if (existing == null) {
+            return null;
+        }
+        LectureDraft updated = new LectureDraft(
+                existing.id(),
+                existing.course_id(),
+                lectureId,
+                title,
+                content,
+                existing.status()
+        );
+        drafts.put(updated.id(), updated);
+        return updated;
+    }
+
+    public LectureDraft publish(String courseId, String draftId) {
+        LectureDraft existing = get(courseId, draftId);
+        if (existing == null) {
+            return null;
+        }
+        LectureDraft published = new LectureDraft(
+                existing.id(),
+                existing.course_id(),
+                existing.lecture_id(),
+                existing.title(),
+                existing.content(),
+                "READY_TO_PUBLISH"
+        );
+        drafts.put(published.id(), published);
+        return published;
+    }
+}

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/LegacyEndpointMigrationIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/LegacyEndpointMigrationIntegrationTest.java
@@ -1,0 +1,172 @@
+package com.myway.backendspring.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class LegacyEndpointMigrationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void courseCreateAndManage_shouldMatchLegacyInstructorSemantics() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        String createResponse = mockMvc.perform(post("/api/v1/courses")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "Legacy Migration Course",
+                                  "description": "Spring migration coverage",
+                                  "category": "backend",
+                                  "difficulty": "beginner",
+                                  "lecture_titles": ["Intro", "Contract"]
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode created = objectMapper.readTree(createResponse).path("data");
+        assertThat(created.path("id").asText()).isNotBlank();
+        assertThat(created.path("title").asText()).isEqualTo("Legacy Migration Course");
+        assertThat(created.path("lectures")).hasSize(2);
+
+        String manageResponse = mockMvc.perform(get("/api/v1/courses/manage")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode managed = objectMapper.readTree(manageResponse).path("data");
+        assertThat(managed).anySatisfy(course -> assertThat(course.path("id").asText()).isEqualTo(created.path("id").asText()));
+    }
+
+    @Test
+    void lectureDraftLifecycle_shouldCreateUpdateReadAndPublish() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        String createResponse = mockMvc.perform(post("/api/v1/lecture-drafts/course/crs_java_01")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"title\":\"Draft title\",\"content\":\"Draft body\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode draft = objectMapper.readTree(createResponse).path("data");
+        String draftId = draft.path("id").asText();
+        assertThat(draftId).isNotBlank();
+        assertThat(draft.path("status").asText()).isEqualTo("DRAFT");
+
+        String updateResponse = mockMvc.perform(put("/api/v1/lecture-drafts/course/crs_java_01/" + draftId)
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_02\",\"title\":\"Updated title\",\"content\":\"Updated body\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode updated = objectMapper.readTree(updateResponse).path("data");
+        assertThat(updated.path("lecture_id").asText()).isEqualTo("lec_java_02");
+        assertThat(updated.path("title").asText()).isEqualTo("Updated title");
+
+        String listResponse = mockMvc.perform(get("/api/v1/lecture-drafts/course/crs_java_01")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(listResponse).path("data")).hasSizeGreaterThanOrEqualTo(1);
+
+        String publishResponse = mockMvc.perform(post("/api/v1/lecture-drafts/course/crs_java_01/" + draftId + "/publish")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode published = objectMapper.readTree(publishResponse).path("data");
+        assertThat(published.path("status").asText()).isEqualTo("READY_TO_PUBLISH");
+    }
+
+    @Test
+    void aiSettings_shouldAcceptLegacyPutMethod() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_admin_001");
+
+        String response = mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"autoRecommend\":true,\"model\":\"spring\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode root = objectMapper.readTree(response);
+        assertThat(root.path("success").asBoolean()).isTrue();
+        assertThat(root.path("data").path("autoRecommend").asBoolean()).isTrue();
+    }
+
+    @Test
+    void aiCoreEndpoints_shouldReturnLegacyCompatibleSuccessShapes() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_std_001");
+
+        String intent = mockMvc.perform(post("/api/v1/ai/intent")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"다음 강의 추천해줘\",\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(intent).path("data").path("intent").asText()).isNotBlank();
+
+        String search = mockMvc.perform(post("/api/v1/ai/search")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"Spring\",\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(search).path("data").path("hits").isArray()).isTrue();
+
+        String answer = mockMvc.perform(post("/api/v1/ai/answer")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"question\":\"REST API가 뭐야?\",\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(answer).path("data").path("answer").asText()).isNotBlank();
+
+        String summary = mockMvc.perform(post("/api/v1/ai/summary")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"style\":\"brief\",\"language\":\"ko\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(summary).path("data").path("content").asText()).isNotBlank();
+
+        String quiz = mockMvc.perform(post("/api/v1/ai/quiz")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"count\":2}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(quiz).path("data").path("questions").isArray()).isTrue();
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+}


### PR DESCRIPTION
﻿# 변경 요약
legacy Hono 엔드포인트 중 Spring 이관이 누락된 API를 추가해 404/405를 해소했습니다.

## 배경
기본 백엔드가 Spring으로 전환된 상태에서 일부 프론트 경로가 legacy API 계약에 의존하고 있어, Spring 미구현 엔드포인트 호출 시 기능이 차단되었습니다.

## 변경 내용
- AI 엔드포인트 이관: `POST /api/v1/ai/intent|search|answer|summary|quiz`
- AI 설정 메서드 호환: `PUT /api/v1/ai/settings` 지원 추가
- 강의 API 이관: `POST /api/v1/courses`, `GET /api/v1/courses/manage`
- 강의 초안 API 신규 이관: `GET/POST/PUT /api/v1/lecture-drafts/course/...`, `POST .../publish`
- 통합 테스트 추가: legacy 계약 회귀 검증 테스트(`LegacyEndpointMigrationIntegrationTest`)

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- 기존 legacy 응답 envelope(`success/data/error/message`) 호환성 유지 여부
- AI/강의/초안 API의 인증 및 권한 처리(`UNAUTHENTICATED`, `FORBIDDEN`) 일관성
- 신규 통합 테스트가 누락 엔드포인트 회귀를 충분히 커버하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
