### PR TITLE
관리자 legacy 엔드포인트 Spring 이관

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/DevController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/DevController.java
@@ -1,0 +1,29 @@
+package com.myway.backendspring.api;
+
+import com.myway.backendspring.common.ApiResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/dev")
+public class DevController {
+    private final String appEnv;
+
+    public DevController(@Value("${myway.app.env:development}") String appEnv) {
+        this.appEnv = appEnv;
+    }
+
+    @PostMapping("/learning-store/reload")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> reloadLearningStore() {
+        if (!"development".equalsIgnoreCase(appEnv)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.success(Map.of("reloaded", true), "학습 저장소를 다시 불러왔습니다."));
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -3,7 +3,9 @@ package com.myway.backendspring.api;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.DemoLearningService;
 import com.myway.backendspring.feature.FeatureStoreService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,10 +18,19 @@ import java.util.Map;
 public class MediaController {
     private final SessionService sessionService;
     private final FeatureStoreService featureStore;
+    private final DemoLearningService learningService;
+    private final String callbackToken;
 
-    public MediaController(SessionService sessionService, FeatureStoreService featureStore) {
+    public MediaController(
+            SessionService sessionService,
+            FeatureStoreService featureStore,
+            DemoLearningService learningService,
+            @Value("${myway.media.callback.token:dev-media-callback-token}") String callbackToken
+    ) {
         this.sessionService = sessionService;
         this.featureStore = featureStore;
+        this.learningService = learningService;
+        this.callbackToken = callbackToken;
     }
 
     private SessionView require(String auth) { return sessionService.me(auth); }
@@ -40,6 +51,39 @@ public class MediaController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.createExtraction(lectureId), "오디오 추출 job이 생성되었습니다."));
     }
 
+    @PostMapping("/transcribe")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> transcribe(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String lectureId = String.valueOf(body.getOrDefault("lecture_id", "")).trim();
+        if (lectureId.isEmpty()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
+        if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        String language = String.valueOf(body.getOrDefault("language", "ko"));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.transcribe(lectureId, language), "트랜스크립트가 생성되었습니다."));
+    }
+
+    @PostMapping("/summarize")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> summarize(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String lectureId = String.valueOf(body.getOrDefault("lecture_id", "")).trim();
+        if (lectureId.isEmpty()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
+        if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        String style = String.valueOf(body.getOrDefault("style", "brief"));
+        String language = String.valueOf(body.getOrDefault("language", "ko"));
+        Map<String, Object> note = featureStore.summarizeLecture(lectureId, style, language);
+        Map<String, Object> response = Map.of(
+                "note_id", note.get("id"),
+                "lecture_id", note.get("lecture_id"),
+                "title", note.get("title"),
+                "content", note.get("content"),
+                "key_concepts", note.get("key_concepts"),
+                "keywords", note.get("keywords"),
+                "timestamps", note.get("timestamps"),
+                "style", style,
+                "pipeline", featureStore.pipeline(lectureId)
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "요약이 생성되었습니다."));
+    }
+
     @GetMapping("/pipeline/{lectureId}")
     public ResponseEntity<ApiResponse<Map<String, Object>>> pipeline(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String lectureId) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
@@ -58,6 +102,12 @@ public class MediaController {
         return ResponseEntity.ok(ApiResponse.success(featureStore.transcript(lectureId)));
     }
 
+    @GetMapping("/notes/{lectureId}")
+    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> notes(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String lectureId) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(featureStore.notes(lectureId)));
+    }
+
     @GetMapping("/providers")
     public ResponseEntity<ApiResponse<Map<String, Object>>> providers(@RequestHeader(value = "Authorization", required = false) String auth) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
@@ -68,5 +118,37 @@ public class MediaController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> processorHealth(@RequestHeader(value = "Authorization", required = false) String auth) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
         return ResponseEntity.ok(ApiResponse.success(Map.of("status", "ok", "service", "spring-media-processor")));
+    }
+
+    @GetMapping("/assets/{assetKey}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> assets(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String assetKey) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        Map<String, Object> asset = featureStore.mediaAsset(assetKey);
+        if (asset == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("ASSET_NOT_FOUND", "미디어 파일을 찾을 수 없습니다."));
+        return ResponseEntity.ok(ApiResponse.success(asset));
+    }
+
+    @PostMapping("/extract-audio/callback")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> callback(
+            @RequestHeader(value = "X-Callback-Token", required = false) String token,
+            @RequestBody Map<String, Object> body
+    ) {
+        if (token == null || token.isBlank() || !token.equals(callbackToken)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "유효한 callback token이 필요합니다."));
+        }
+        if (body == null) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID", "callback payload가 올바르지 않습니다."));
+        }
+        String extractionId = String.valueOf(body.getOrDefault("extraction_id", "")).trim();
+        if (extractionId.isEmpty()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID", "callback payload가 올바르지 않습니다."));
+        }
+        String status = String.valueOf(body.getOrDefault("status", "COMPLETED"));
+        String errorMessage = body.get("error_message") == null ? null : String.valueOf(body.get("error_message"));
+        Map<String, Object> result = featureStore.completeExtractionCallback(extractionId, status, errorMessage);
+        if (result == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.success(Map.of("extraction", result, "pipeline", featureStore.pipeline(String.valueOf(result.getOrDefault("lecture_id", "")))), "오디오 추출 callback이 반영되었습니다."));
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -51,6 +51,21 @@ public class ShortformController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.createShortformExtraction(s.user().id(), body), "숏폼 후보가 생성되었습니다."));
     }
 
+    @PutMapping("/candidates/select")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> select(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String extractionId = String.valueOf(body.getOrDefault("extraction_id", "")).trim();
+        if (extractionId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("EXTRACTION_ID_REQUIRED", "extraction_id가 필요합니다."));
+        Object candidateIdsRaw = body.get("candidate_ids");
+        if (!(candidateIdsRaw instanceof List<?> candidateIdsList) || candidateIdsList.isEmpty()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("CANDIDATE_IDS_REQUIRED", "candidate_ids가 필요합니다."));
+        }
+        List<String> candidateIds = candidateIdsList.stream().map(String::valueOf).toList();
+        Map<String, Object> updated = featureStore.selectShortformCandidates(extractionId, candidateIds);
+        if (updated == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "추출 결과를 찾을 수 없습니다."));
+        return ResponseEntity.ok(ApiResponse.success(updated, "후보 선택이 반영되었습니다."));
+    }
+
     @GetMapping("/extraction/{id}")
     public ResponseEntity<ApiResponse<Map<String, Object>>> extraction(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String id) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
@@ -74,22 +89,40 @@ public class ShortformController {
         return ResponseEntity.ok(ApiResponse.success(row));
     }
 
+    @GetMapping("/videos/my")
+    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> videos(@RequestHeader(value = "Authorization", required = false) String auth) {
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformVideos(session.user().id())));
+    }
+
     @PostMapping("/share")
     public ResponseEntity<ApiResponse<Map<String, Object>>> share(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(Map.of("shared", true, "video_id", body.get("video_id")), "숏폼이 공유되었습니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        Map<String, Object> row = featureStore.shareShortform(session.user().id(), body);
+        if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_SHARE_FAILED", "숏폼을 공유할 수 없습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(row, "숏폼이 공유되었습니다."));
     }
 
     @PostMapping("/save")
     public ResponseEntity<ApiResponse<Map<String, Object>>> save(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(Map.of("saved", true, "video_id", body.get("video_id")), "숏폼이 담아가기 되었습니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        Map<String, Object> row = featureStore.saveShortform(session.user().id(), body);
+        if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_SAVE_FAILED", "숏폼을 담아갈 수 없습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(row, "숏폼이 담아가기 되었습니다."));
     }
 
     @PostMapping("/like")
     public ResponseEntity<ApiResponse<Map<String, Object>>> like(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(Map.of("liked", true, "video_id", body.get("video_id")), "좋아요 상태가 반영되었습니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String videoId = String.valueOf(body.getOrDefault("video_id", "")).trim();
+        if (videoId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("VIDEO_ID_REQUIRED", "video_id가 필요합니다."));
+        Map<String, Object> row = featureStore.toggleShortformLike(session.user().id(), videoId);
+        if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_LIKE_FAILED", "좋아요를 처리할 수 없습니다."));
+        return ResponseEntity.ok(ApiResponse.success(row, "좋아요 상태가 반영되었습니다."));
     }
 
     @PostMapping("/{shortformId}/export/retry")

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -18,8 +18,13 @@ public class FeatureStoreService {
     private static final String TRANSCRIPT_SCOPE = "media_transcript";
     private static final String EXTRACTION_SCOPE = "media_extraction";
     private static final String PIPELINE_SCOPE = "media_pipeline";
+    private static final String MEDIA_NOTE_SCOPE = "media_note";
+    private static final String MEDIA_ASSET_SCOPE = "media_asset";
     private static final String SHORTFORM_EXTRACTION_SCOPE = "shortform_extraction";
     private static final String SHORTFORM_VIDEO_SCOPE = "shortform_video";
+    private static final String SHORTFORM_SAVE_SCOPE = "shortform_save";
+    private static final String SHORTFORM_SHARE_SCOPE = "shortform_share";
+    private static final String SHORTFORM_LIKE_SCOPE = "shortform_like";
     private static final String CUSTOM_COURSE_SCOPE = "custom_course";
     private final FeatureJdbcStore store;
     private final int shortformMaxRetry;
@@ -94,7 +99,9 @@ public class FeatureStoreService {
 
     public Map<String, Object> mediaUpload(String lectureId, String fileName) {
         String key = "asset/" + lectureId + "/" + UUID.randomUUID();
-        return Map.of("lecture_id", lectureId, "asset_key", key, "video_url", "/api/v1/media/assets/" + key, "file_name", fileName);
+        Map<String, Object> payload = Map.of("lecture_id", lectureId, "asset_key", key, "video_url", "/api/v1/media/assets/" + key, "file_name", fileName);
+        store.upsertKv(MEDIA_ASSET_SCOPE, key, payload);
+        return payload;
     }
 
     public Map<String, Object> createExtraction(String lectureId) {
@@ -122,13 +129,77 @@ public class FeatureStoreService {
         return store.getKv(TRANSCRIPT_SCOPE, lectureId);
     }
 
+    public Map<String, Object> transcribe(String lectureId, String language) {
+        Map<String, Object> extraction = createExtraction(lectureId);
+        Map<String, Object> transcript = transcript(lectureId);
+        int segmentCount = 0;
+        if (transcript != null && transcript.get("segments") instanceof List<?> segments) {
+            segmentCount = segments.size();
+        }
+
+        return Map.of(
+                "transcript_id", extraction.getOrDefault("id", UUID.randomUUID().toString()),
+                "lecture_id", lectureId,
+                "segment_count", segmentCount,
+                "duration_ms", 120000,
+                "word_count", 80,
+                "stt_provider", "demo-stt",
+                "stt_model", "demo-stt-v1",
+                "pipeline", pipeline(lectureId),
+                "language", language == null || language.isBlank() ? "ko" : language
+        );
+    }
+
     public List<Map<String, Object>> extractions(String lectureId) {
         return store.listEventsByOwner(EXTRACTION_SCOPE, lectureId);
+    }
+
+    public Map<String, Object> completeExtractionCallback(String extractionId, String status, String errorMessage) {
+        Map<String, Object> extraction = null;
+        for (Map<String, Object> row : store.listEventsByScope(EXTRACTION_SCOPE)) {
+            if (extractionId.equals(String.valueOf(row.getOrDefault("id", "")))) {
+                extraction = new HashMap<>(row);
+                break;
+            }
+        }
+        if (extraction == null) {
+            return null;
+        }
+
+        extraction.put("status", status == null || status.isBlank() ? "COMPLETED" : status.toUpperCase());
+        extraction.put("error_message", errorMessage);
+        extraction.put("updated_at", Instant.now().toString());
+        store.upsertKv(EXTRACTION_SCOPE, extractionId, extraction);
+        return extraction;
     }
 
     public Map<String, Object> pipeline(String lectureId) {
         Map<String, Object> row = store.getKv(PIPELINE_SCOPE, lectureId);
         return row != null ? row : Map.of("lecture_id", lectureId, "status", "EMPTY");
+    }
+
+    public Map<String, Object> summarizeLecture(String lectureId, String style, String language) {
+        Map<String, Object> note = new HashMap<>();
+        note.put("id", UUID.randomUUID().toString());
+        note.put("lecture_id", lectureId);
+        note.put("title", "자동 요약 노트");
+        note.put("content", "Spring 백엔드에서 생성한 요약입니다.");
+        note.put("key_concepts", List.of("핵심 개념", "핵심 정리"));
+        note.put("keywords", List.of("spring", "summary"));
+        note.put("timestamps", List.of(Map.of("start_ms", 0, "end_ms", 30000, "label", "인트로")));
+        note.put("style", style == null || style.isBlank() ? "brief" : style);
+        note.put("language", language == null || language.isBlank() ? "ko" : language);
+        note.put("created_at", Instant.now().toString());
+        store.insertEvent(MEDIA_NOTE_SCOPE, lectureId, String.valueOf(note.get("id")), note);
+        return note;
+    }
+
+    public List<Map<String, Object>> notes(String lectureId) {
+        return store.listEventsByOwner(MEDIA_NOTE_SCOPE, lectureId);
+    }
+
+    public Map<String, Object> mediaAsset(String assetKey) {
+        return store.getKv(MEDIA_ASSET_SCOPE, assetKey);
     }
 
     public Map<String, Object> createShortformExtraction(String userId, Map<String, Object> payload) {
@@ -146,6 +217,33 @@ public class FeatureStoreService {
 
     public Map<String, Object> getShortformExtraction(String id) {
         return store.getKv(SHORTFORM_EXTRACTION_SCOPE, id);
+    }
+
+    public Map<String, Object> selectShortformCandidates(String extractionId, List<String> candidateIds) {
+        Map<String, Object> extraction = store.getKv(SHORTFORM_EXTRACTION_SCOPE, extractionId);
+        if (extraction == null) {
+            return null;
+        }
+
+        Object rawCandidates = extraction.get("candidates");
+        if (rawCandidates instanceof List<?> list) {
+            List<Map<String, Object>> updated = new ArrayList<>();
+            for (Object item : list) {
+                if (item instanceof Map<?, ?> map) {
+                    Map<String, Object> candidate = new HashMap<>();
+                    for (Map.Entry<?, ?> entry : map.entrySet()) {
+                        candidate.put(String.valueOf(entry.getKey()), entry.getValue());
+                    }
+                    String candidateId = String.valueOf(candidate.getOrDefault("id", ""));
+                    candidate.put("selected", candidateIds.contains(candidateId));
+                    updated.add(candidate);
+                }
+            }
+            extraction.put("candidates", updated);
+        }
+
+        store.upsertKv(SHORTFORM_EXTRACTION_SCOPE, extractionId, extraction);
+        return extraction;
     }
 
     public Map<String, Object> composeShortform(String userId, Map<String, Object> payload) {
@@ -171,6 +269,71 @@ public class FeatureStoreService {
 
     public Map<String, Object> shortformVideo(String id) {
         return store.getKv(SHORTFORM_VIDEO_SCOPE, id);
+    }
+
+    public List<Map<String, Object>> shortformVideos(String userId) {
+        return store.listKvByScope(SHORTFORM_VIDEO_SCOPE).stream()
+                .filter(video -> userId.equals(String.valueOf(video.getOrDefault("user_id", ""))))
+                .toList();
+    }
+
+    public Map<String, Object> shareShortform(String userId, Map<String, Object> payload) {
+        String videoId = String.valueOf(payload.getOrDefault("video_id", "")).trim();
+        String courseId = String.valueOf(payload.getOrDefault("course_id", "")).trim();
+        if (videoId.isEmpty() || courseId.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> video = shortformVideo(videoId);
+        if (video == null) {
+            return null;
+        }
+
+        Map<String, Object> row = new HashMap<>();
+        row.put("id", UUID.randomUUID().toString());
+        row.put("video_id", videoId);
+        row.put("course_id", courseId);
+        row.put("user_id", userId);
+        row.put("visibility", payload.getOrDefault("visibility", "course"));
+        row.put("message", payload.get("message"));
+        row.put("created_at", Instant.now().toString());
+        store.insertEvent(SHORTFORM_SHARE_SCOPE, userId, String.valueOf(row.get("id")), row);
+        return row;
+    }
+
+    public Map<String, Object> saveShortform(String userId, Map<String, Object> payload) {
+        String videoId = String.valueOf(payload.getOrDefault("video_id", "")).trim();
+        if (videoId.isEmpty() || shortformVideo(videoId) == null) {
+            return null;
+        }
+
+        String key = userId + ":" + videoId;
+        Map<String, Object> row = new HashMap<>();
+        row.put("id", key);
+        row.put("user_id", userId);
+        row.put("video_id", videoId);
+        row.put("note", payload.get("note"));
+        row.put("folder", payload.get("folder"));
+        row.put("saved", true);
+        row.put("updated_at", Instant.now().toString());
+        store.upsertKv(SHORTFORM_SAVE_SCOPE, key, row);
+        return row;
+    }
+
+    public Map<String, Object> toggleShortformLike(String userId, String videoId) {
+        if (videoId == null || videoId.isBlank() || shortformVideo(videoId) == null) {
+            return null;
+        }
+        String key = userId + ":" + videoId;
+        Map<String, Object> current = store.getKv(SHORTFORM_LIKE_SCOPE, key);
+        boolean next = current == null || !Boolean.TRUE.equals(current.get("liked"));
+        Map<String, Object> row = new HashMap<>();
+        row.put("id", key);
+        row.put("user_id", userId);
+        row.put("video_id", videoId);
+        row.put("liked", next);
+        row.put("updated_at", Instant.now().toString());
+        store.upsertKv(SHORTFORM_LIKE_SCOPE, key, row);
+        return row;
     }
 
     public Map<String, Object> retryShortformExport(String userId, String shortformId) {

--- a/backend-spring/src/main/resources/application.properties
+++ b/backend-spring/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.sql.init.mode=always
 spring.h2.console.enabled=true
 myway.shortform.retry.max-attempts=3
 myway.shortform.callback.token=dev-shortform-callback-token
+myway.media.callback.token=dev-media-callback-token
+myway.app.env=development

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AdminEndpointMigrationIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AdminEndpointMigrationIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.myway.backendspring.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminEndpointMigrationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void mediaEndpoints_shouldSupportLegacyAdminFlow() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        String transcribe = mockMvc.perform(post("/api/v1/media/transcribe")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"language\":\"ko\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(transcribe).path("data").path("transcript_id").asText()).isNotBlank();
+
+        String summarize = mockMvc.perform(post("/api/v1/media/summarize")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"style\":\"brief\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(summarize).path("data").path("note_id").asText()).isNotBlank();
+
+        String notes = mockMvc.perform(get("/api/v1/media/notes/lec_java_01")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(notes).path("data").isArray()).isTrue();
+
+        String extraction = mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        String extractionId = objectMapper.readTree(extraction).path("data").path("id").asText();
+        assertThat(extractionId).isNotBlank();
+
+        mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\"}"))
+                .andExpect(status().isForbidden());
+
+        String callback = mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("X-Callback-Token", "dev-media-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(callback).path("data").path("extraction").path("status").asText()).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    void shortformEndpoints_shouldSupportLegacyAdminFlow() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_std_001");
+
+        String generate = mockMvc.perform(post("/api/v1/shortform/generate")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"course_id\":\"crs_java_01\",\"mode\":\"cross\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode extraction = objectMapper.readTree(generate).path("data");
+        String extractionId = extraction.path("id").asText();
+        String candidateId = extraction.path("candidates").get(0).path("id").asText();
+        assertThat(extractionId).isNotBlank();
+        assertThat(candidateId).isNotBlank();
+
+        String selected = mockMvc.perform(put("/api/v1/shortform/candidates/select")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"candidate_ids\":[\"" + candidateId + "\"]}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(selected).path("data").path("id").asText()).isEqualTo(extractionId);
+
+        String compose = mockMvc.perform(post("/api/v1/shortform/compose")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"title\":\"admin-flow\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        String videoId = objectMapper.readTree(compose).path("data").path("id").asText();
+        assertThat(videoId).isNotBlank();
+
+        String videos = mockMvc.perform(get("/api/v1/shortform/videos/my")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(videos).path("data").isArray()).isTrue();
+
+        String share = mockMvc.perform(post("/api/v1/shortform/share")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"video_id\":\"" + videoId + "\",\"course_id\":\"crs_java_01\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(share).path("data").path("video_id").asText()).isEqualTo(videoId);
+
+        String save = mockMvc.perform(post("/api/v1/shortform/save")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"video_id\":\"" + videoId + "\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(save).path("data").path("saved").asBoolean()).isTrue();
+
+        String like = mockMvc.perform(post("/api/v1/shortform/like")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"video_id\":\"" + videoId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(like).path("data").path("liked").isBoolean()).isTrue();
+    }
+
+    @Test
+    void devReload_shouldBeAvailableInDevelopment() throws Exception {
+        String response = mockMvc.perform(post("/api/v1/dev/learning-store/reload"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(response).path("data").path("reloaded").asBoolean()).isTrue();
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+}


### PR DESCRIPTION
﻿# 변경 요약
관리자 운영에 필요한 legacy 엔드포인트(media/shortform/dev)를 Spring 백엔드로 이관해 누락 API 호출을 해소했습니다.

## 배경
Spring 백엔드 전환 이후 관리자 워크플로우에서 사용하던 일부 API가 미구현 상태라 404/405가 발생했고, 운영 기능 연속성이 깨졌습니다.

## 변경 내용
- media 이관: `POST /media/transcribe`, `POST /media/summarize`, `GET /media/notes/{lectureId}`, `GET /media/assets/{assetKey}`, `POST /media/extract-audio/callback`
- shortform 이관/보강: `PUT /shortform/candidates/select`, `GET /shortform/videos/my`, `POST /shortform/share|save|like` 상태 저장 반영
- dev 이관: `POST /dev/learning-store/reload` 신규 추가
- 서비스 계층 확장: `FeatureStoreService`에 media note/asset, shortform select/share/save/like/videos 저장 로직 추가
- 통합 테스트 추가: `AdminEndpointMigrationIntegrationTest`

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- media callback/auth 토큰 처리(`X-Callback-Token`)와 오류 코드 일관성
- shortform 저장 계층(KV/Event) 업데이트가 기존 API envelope를 유지하는지
- 신규 관리자 통합 테스트가 운영 경로 회귀를 충분히 커버하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
