### PR TITLE
관리자 오케스트레이션 후속 운영 동작 보강

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
@@ -29,32 +29,37 @@ public class AiController {
 
     @GetMapping("/insights")
     public ResponseEntity<ApiResponse<Map<String, Object>>> insights(@RequestHeader(value = "Authorization", required = false) String auth) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.aiInsights()));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(featureStore.aiInsights(session.user().id())));
     }
 
     @GetMapping("/logs")
     public ResponseEntity<ApiResponse<Map<String, Object>>> logs(@RequestHeader(value = "Authorization", required = false) String auth) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.aiLogs()));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(featureStore.aiLogs(session.user().id())));
     }
 
     @GetMapping("/recommendations")
     public ResponseEntity<ApiResponse<Map<String, Object>>> recs(@RequestHeader(value = "Authorization", required = false) String auth) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.aiRecommendations()));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(featureStore.aiRecommendations(session.user().id())));
     }
 
     @GetMapping("/settings")
     public ResponseEntity<ApiResponse<Map<String, Object>>> settings(@RequestHeader(value = "Authorization", required = false) String auth) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.aiSettings()));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(featureStore.aiSettings(session.user().id())));
     }
 
     @PostMapping("/settings")
     public ResponseEntity<ApiResponse<Map<String, Object>>> updateSettings(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.updateAiSettings(body), "설정이 저장되었습니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(featureStore.updateAiSettings(session.user().id(), body), "설정이 저장되었습니다."));
     }
 
     @PutMapping("/settings")
@@ -64,8 +69,9 @@ public class AiController {
 
     @GetMapping("/providers")
     public ResponseEntity<ApiResponse<Map<String, Object>>> providers(@RequestHeader(value = "Authorization", required = false) String auth) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.aiProviders()));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        return ResponseEntity.ok(ApiResponse.success(featureStore.aiProviders(session.user().id())));
     }
 
     @PostMapping("/rag")

--- a/backend-spring/src/main/java/com/myway/backendspring/api/DevController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/DevController.java
@@ -1,6 +1,7 @@
 package com.myway.backendspring.api;
 
 import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.LearningStoreAdminService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,9 +15,11 @@ import java.util.Map;
 @RequestMapping("/api/v1/dev")
 public class DevController {
     private final String appEnv;
+    private final LearningStoreAdminService learningStoreAdminService;
 
-    public DevController(@Value("${myway.app.env:development}") String appEnv) {
+    public DevController(@Value("${myway.app.env:production}") String appEnv, LearningStoreAdminService learningStoreAdminService) {
         this.appEnv = appEnv;
+        this.learningStoreAdminService = learningStoreAdminService;
     }
 
     @PostMapping("/learning-store/reload")
@@ -24,6 +27,6 @@ public class DevController {
         if (!"development".equalsIgnoreCase(appEnv)) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."));
         }
-        return ResponseEntity.ok(ApiResponse.success(Map.of("reloaded", true), "학습 저장소를 다시 불러왔습니다."));
+        return ResponseEntity.ok(ApiResponse.success(learningStoreAdminService.reload(), "학습 저장소를 다시 불러왔습니다."));
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -9,7 +9,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.HandlerMapping;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Map;
 
@@ -34,10 +36,17 @@ public class MediaController {
     }
 
     private SessionView require(String auth) { return sessionService.me(auth); }
+    private boolean canManageMedia(SessionView session) {
+        if (session == null) return false;
+        String role = session.user().role();
+        return "admin".equals(role) || "instructor".equals(role);
+    }
 
     @PostMapping("/upload-video")
     public ResponseEntity<ApiResponse<Map<String, Object>>> upload(@RequestHeader(value = "Authorization", required = false) String auth, @RequestParam("lecture_id") String lectureId, @RequestParam(value = "video_file", required = false) org.springframework.web.multipart.MultipartFile file) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!canManageMedia(session)) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "영상 업로드는 강사와 운영자만 사용할 수 있습니다."));
         if (lectureId == null || lectureId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
         String fileName = file != null ? file.getOriginalFilename() : "uploaded.mp4";
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.mediaUpload(lectureId.trim(), fileName), "강의 영상이 업로드되었습니다."));
@@ -45,7 +54,9 @@ public class MediaController {
 
     @PostMapping("/extract-audio")
     public ResponseEntity<ApiResponse<Map<String, Object>>> extract(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!canManageMedia(session)) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "오디오 추출은 강사와 운영자만 사용할 수 있습니다."));
         String lectureId = String.valueOf(body.getOrDefault("lecture_id", "")).trim();
         if (lectureId.isEmpty()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.createExtraction(lectureId), "오디오 추출 job이 생성되었습니다."));
@@ -120,9 +131,21 @@ public class MediaController {
         return ResponseEntity.ok(ApiResponse.success(Map.of("status", "ok", "service", "spring-media-processor")));
     }
 
-    @GetMapping("/assets/{assetKey}")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> assets(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String assetKey) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+    @GetMapping("/assets/**")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> assets(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestHeader(value = "X-Processor-Token", required = false) String processorToken,
+            HttpServletRequest request
+    ) {
+        String path = String.valueOf(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE));
+        String prefix = "/api/v1/media/assets/";
+        String assetKey = path.startsWith(prefix) ? path.substring(prefix.length()) : "";
+        if (assetKey.isBlank()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("ASSET_NOT_FOUND", "미디어 파일을 찾을 수 없습니다."));
+        }
+        if (processorToken == null || !processorToken.equals(callbackToken)) {
+            if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
         Map<String, Object> asset = featureStore.mediaAsset(assetKey);
         if (asset == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("ASSET_NOT_FOUND", "미디어 파일을 찾을 수 없습니다."));
         return ResponseEntity.ok(ApiResponse.success(asset));

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/LearningStoreAdminService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/LearningStoreAdminService.java
@@ -1,0 +1,23 @@
+package com.myway.backendspring.domain;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+public class LearningStoreAdminService {
+    private final AtomicInteger reloadCount = new AtomicInteger();
+    private volatile Instant lastReloadedAt;
+
+    public Map<String, Object> reload() {
+        int count = reloadCount.incrementAndGet();
+        lastReloadedAt = Instant.now();
+        return Map.of(
+                "reloaded", true,
+                "reload_count", count,
+                "last_reloaded_at", lastReloadedAt.toString()
+        );
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 @Service
 public class FeatureStoreService {
     private static final String AI_SETTINGS_SCOPE = "ai_settings";
-    private static final String AI_SETTINGS_ID = "global";
     private static final String TRANSCRIPT_SCOPE = "media_transcript";
     private static final String EXTRACTION_SCOPE = "media_extraction";
     private static final String PIPELINE_SCOPE = "media_pipeline";
@@ -39,9 +38,9 @@ public class FeatureStoreService {
     }
 
     private void ensureDefaults() {
-        Map<String, Object> settings = store.getKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID);
+        Map<String, Object> settings = store.getKv(AI_SETTINGS_SCOPE, "global");
         if (settings == null) {
-            store.upsertKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID, new HashMap<>(Map.of(
+            store.upsertKv(AI_SETTINGS_SCOPE, "global", new HashMap<>(Map.of(
                     "daily_limit", 100,
                     "provider", "demo",
                     "model", "demo-v1"
@@ -63,38 +62,55 @@ public class FeatureStoreService {
             changed = true;
         }
         if (changed) {
-            store.upsertKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID, settings);
+            store.upsertKv(AI_SETTINGS_SCOPE, "global", settings);
         }
     }
 
-    public Map<String, Object> aiInsights() {
-        return Map.of("total_requests", 0, "success_rate", 1.0, "last_updated", Instant.now().toString());
+    public Map<String, Object> aiInsights(String userId) {
+        Map<String, Object> settings = aiSettings(userId);
+        return Map.of(
+                "user_id", userId,
+                "total_requests", 0,
+                "success_rate", 1.0,
+                "provider", settings.getOrDefault("provider", "demo"),
+                "model", settings.getOrDefault("model", "demo-v1"),
+                "last_updated", Instant.now().toString()
+        );
     }
 
-    public Map<String, Object> aiLogs() {
-        return Map.of("items", List.of(), "count", 0);
+    public Map<String, Object> aiLogs(String userId) {
+        return Map.of("user_id", userId, "items", List.of(), "count", 0);
     }
 
-    public Map<String, Object> aiRecommendations() {
-        return Map.of("items", List.of(), "count", 0);
+    public Map<String, Object> aiRecommendations(String userId) {
+        return Map.of("user_id", userId, "items", List.of(), "count", 0);
     }
 
-    public Map<String, Object> aiSettings() {
-        Map<String, Object> settings = store.getKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID);
-        return settings != null ? settings : Map.of();
+    public Map<String, Object> aiSettings(String userId) {
+        Map<String, Object> global = store.getKv(AI_SETTINGS_SCOPE, "global");
+        Map<String, Object> settings = store.getKv(AI_SETTINGS_SCOPE, userId);
+        if (settings == null) {
+            return global != null ? global : Map.of();
+        }
+        Map<String, Object> merged = new HashMap<>();
+        if (global != null) {
+            merged.putAll(global);
+        }
+        merged.putAll(settings);
+        return merged;
     }
 
-    public Map<String, Object> updateAiSettings(Map<String, Object> patch) {
-        Map<String, Object> settings = new HashMap<>(aiSettings());
+    public Map<String, Object> updateAiSettings(String userId, Map<String, Object> patch) {
+        Map<String, Object> settings = new HashMap<>(aiSettings(userId));
         if (patch != null) {
             settings.putAll(patch);
         }
-        store.upsertKv(AI_SETTINGS_SCOPE, AI_SETTINGS_ID, settings);
+        store.upsertKv(AI_SETTINGS_SCOPE, userId, settings);
         return settings;
     }
 
-    public Map<String, Object> aiProviders() {
-        return Map.of("providers", List.of("demo", "ollama", "gemini"), "current", aiSettings().getOrDefault("provider", "demo"));
+    public Map<String, Object> aiProviders(String userId) {
+        return Map.of("providers", List.of("demo", "ollama", "gemini"), "current", aiSettings(userId).getOrDefault("provider", "demo"));
     }
 
     public Map<String, Object> mediaUpload(String lectureId, String fileName) {
@@ -253,11 +269,12 @@ public class FeatureStoreService {
         video.put("user_id", userId);
         video.put("title", payload.getOrDefault("title", "untitled"));
         video.put("description", payload.getOrDefault("description", ""));
-        video.put("video_url", "https://example.com/shortform/" + id + ".mp4");
-        video.put("export_status", "COMPLETED");
+        video.put("video_url", null);
+        video.put("export_status", "PROCESSING");
         video.put("retry_count", 0);
         video.put("last_event_version", 0L);
-        video.put("export_result_url", video.get("video_url"));
+        video.put("export_result_url", null);
+        video.put("export_job_id", "job_" + id);
         video.put("error_message", null);
         video.put("updated_at", Instant.now().toString());
 

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AdminEndpointMigrationIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AdminEndpointMigrationIntegrationTest.java
@@ -28,6 +28,19 @@ class AdminEndpointMigrationIntegrationTest {
     @Test
     void mediaEndpoints_shouldSupportLegacyAdminFlow() throws Exception {
         String auth = "Bearer " + loginAndGetToken("usr_ins_001");
+        String studentAuth = "Bearer " + loginAndGetToken("usr_std_001");
+
+        mockMvc.perform(post("/api/v1/media/upload-video")
+                        .header("Authorization", studentAuth)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .param("lecture_id", "lec_java_01"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", studentAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isForbidden());
 
         String transcribe = mockMvc.perform(post("/api/v1/media/transcribe")
                         .header("Authorization", auth)
@@ -72,6 +85,22 @@ class AdminEndpointMigrationIntegrationTest {
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         assertThat(objectMapper.readTree(callback).path("data").path("extraction").path("status").asText()).isEqualTo("COMPLETED");
+
+        String upload = mockMvc.perform(post("/api/v1/media/upload-video")
+                        .header("Authorization", auth)
+                        .param("lecture_id", "lec_java_01"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        String assetKey = objectMapper.readTree(upload).path("data").path("asset_key").asText();
+
+        mockMvc.perform(get("/api/v1/media/assets/{assetKey}", assetKey))
+                .andExpect(status().isUnauthorized());
+
+        String asset = mockMvc.perform(get("/api/v1/media/assets/{assetKey}", assetKey)
+                        .header("X-Processor-Token", "dev-media-callback-token"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(asset).path("data").path("asset_key").asText()).isEqualTo(assetKey);
     }
 
     @Test
@@ -104,8 +133,10 @@ class AdminEndpointMigrationIntegrationTest {
                         .content("{\"extraction_id\":\"" + extractionId + "\",\"title\":\"admin-flow\"}"))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
-        String videoId = objectMapper.readTree(compose).path("data").path("id").asText();
+        JsonNode composed = objectMapper.readTree(compose).path("data");
+        String videoId = composed.path("id").asText();
         assertThat(videoId).isNotBlank();
+        assertThat(composed.path("export_status").asText()).isEqualTo("PROCESSING");
 
         String videos = mockMvc.perform(get("/api/v1/shortform/videos/my")
                         .header("Authorization", auth))
@@ -144,6 +175,37 @@ class AdminEndpointMigrationIntegrationTest {
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         assertThat(objectMapper.readTree(response).path("data").path("reloaded").asBoolean()).isTrue();
+        assertThat(objectMapper.readTree(response).path("data").path("reload_count").asInt()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void aiSettings_shouldRemainUserScoped() throws Exception {
+        String adminAuth = "Bearer " + loginAndGetToken("usr_admin_001");
+        String studentAuth = "Bearer " + loginAndGetToken("usr_std_001");
+
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", adminAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"model\":\"admin-model\",\"provider\":\"gemini\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", studentAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"model\":\"student-model\",\"provider\":\"demo\"}"))
+                .andExpect(status().isOk());
+
+        String adminSettings = mockMvc.perform(get("/api/v1/ai/settings")
+                        .header("Authorization", adminAuth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        String studentSettings = mockMvc.perform(get("/api/v1/ai/settings")
+                        .header("Authorization", studentAuth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        assertThat(objectMapper.readTree(adminSettings).path("data").path("model").asText()).isEqualTo("admin-model");
+        assertThat(objectMapper.readTree(studentSettings).path("data").path("model").asText()).isEqualTo("student-model");
     }
 
     private String loginAndGetToken(String userId) throws Exception {


### PR DESCRIPTION
﻿# 변경 요약
관리자 오케스트레이션 후속으로 남아 있던 운영 리스크(P0) 동작을 Spring API에 맞춰 보강했습니다.

## 배경
기존 관리자 이관(#200) 이후에도 일부 엔드포인트는 권한/상태전이/운영 동작이 legacy와 달라 운영상 오해 또는 보안 리스크가 남아 있었습니다.

## 변경 내용
- media 권한 보강
  - `POST /api/v1/media/upload-video`, `POST /api/v1/media/extract-audio`를 `admin|instructor` 권한으로 제한
- media assets 동작 보강
  - `GET /api/v1/media/assets/**`로 slash 포함 assetKey 지원
  - `X-Processor-Token` 기반 프로세서 접근 우회 경로 추가
- shortform 상태 전이 보강
  - `POST /api/v1/shortform/compose` 응답을 `PROCESSING` 시작 상태로 조정
- dev reload 실동작 보강
  - `LearningStoreAdminService` 추가, reload 호출 시 `reload_count`, `last_reloaded_at` 반환
  - `myway.app.env` 기본 fallback을 `production`으로 조정
- AI 설정 user-scope 보강
  - `/api/v1/ai/settings|providers|insights|logs|recommendations`를 사용자 단위 스코프로 동작하도록 조정
- 통합 테스트 보강
  - 관리자 흐름 테스트에 권한/asset 접근/compose 상태/dev reload/user-scope 검증 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- media assets 경로 처리(`assets/**`)와 processor token 우회 분기
- AI 설정 user-scope 변경이 기존 응답 envelope를 깨지 않는지
- admin 통합 테스트가 운영 핵심 회귀를 충분히 커버하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
