### PR TITLE
관리자 AI 엔드포인트 사용량 제한·로그 및 RAG 검증 보강

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -76,85 +77,124 @@ public class AiController {
 
     @PostMapping("/rag")
     public ResponseEntity<ApiResponse<Map<String, Object>>> rag(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(Map.of("answer", "RAG 샘플 응답", "query", body.getOrDefault("query", ""), "hits", java.util.List.of())));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!featureStore.canConsumeAi(session.user().id())) return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다."));
+
+        String query = text(body, "query");
+        if (query.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("QUERY_REQUIRED", "query가 필요합니다."));
+
+        String lectureId = text(body, "lecture_id");
+        String courseId = text(body, "course_id");
+        if (lectureId.isBlank() && courseId.isBlank()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_OR_COURSE_REQUIRED", "lecture_id 또는 course_id가 필요합니다."));
+        }
+        if (!lectureId.isBlank() && learningService.getLecture(lectureId) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        if (!courseId.isBlank() && learningService.getCourseLectures(courseId).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("COURSE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+
+        Integer limit = intOrNull(body, "limit");
+        Map<String, Object> data = featureStore.ragOverview(query, textOrNull(body, "lecture_id") == null ? null : lectureId, textOrNull(body, "course_id") == null ? null : courseId, limit);
+        featureStore.recordAiUsage(session.user().id(), "rag", true, query);
+        return ResponseEntity.ok(ApiResponse.success(data, "RAG 응답을 생성했습니다."));
     }
 
     @PostMapping("/intent")
     public ResponseEntity<ApiResponse<Map<String, Object>>> intent(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!featureStore.canConsumeAi(session.user().id())) return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다."));
         String message = text(body, "message");
         if (message.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("MESSAGE_REQUIRED", "message가 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(Map.of(
-                "intent", "recommendation",
-                "confidence", 0.82,
-                "action", "show_recommendations",
-                "reason", "Spring demo intent classifier",
-                "lecture_id", textOrNull(body, "lecture_id"),
-                "provider", "demo",
-                "model", "demo-intent-v1"
-        ), "인텐트가 분류되었습니다."));
+        Map<String, Object> data = new HashMap<>();
+        data.put("intent", "recommendation");
+        data.put("confidence", 0.82);
+        data.put("action", "show_recommendations");
+        data.put("reason", "Spring demo intent classifier");
+        data.put("lecture_id", textOrNull(body, "lecture_id"));
+        data.put("provider", "demo");
+        data.put("model", "demo-intent-v1");
+        featureStore.recordAiUsage(session.user().id(), "intent", true, message);
+        return ResponseEntity.ok(ApiResponse.success(data, "인텐트가 분류되었습니다."));
     }
 
     @PostMapping("/search")
     public ResponseEntity<ApiResponse<Map<String, Object>>> search(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!featureStore.canConsumeAi(session.user().id())) return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다."));
         String query = text(body, "query");
         if (query.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("QUERY_REQUIRED", "query가 필요합니다."));
         ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLecture(body);
         if (lectureError != null) return lectureError;
-        return ResponseEntity.ok(ApiResponse.success(Map.of(
+        Map<String, Object> data = Map.of(
                 "query", query,
                 "hits", List.of(Map.of("id", "hit-1", "title", "Spring Boot 시작", "score", 0.91)),
                 "provider", "demo",
                 "model", "demo-search-v1"
-        ), "검색 결과를 조회했습니다."));
+        );
+        featureStore.recordAiUsage(session.user().id(), "search", true, query);
+        return ResponseEntity.ok(ApiResponse.success(data, "검색 결과를 조회했습니다."));
     }
 
     @PostMapping("/answer")
     public ResponseEntity<ApiResponse<Map<String, Object>>> answer(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!featureStore.canConsumeAi(session.user().id())) return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다."));
         String question = text(body, "question");
         if (question.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("QUESTION_REQUIRED", "question가 필요합니다."));
         ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLecture(body);
         if (lectureError != null) return lectureError;
-        return ResponseEntity.ok(ApiResponse.success(Map.of(
-                "answer", "[Spring AI 응답] " + question,
-                "sources", List.of("lecture:lec_java_01"),
-                "lecture_id", textOrNull(body, "lecture_id"),
-                "provider", "demo",
-                "model", "demo-answer-v1"
-        ), "답변을 생성했습니다."));
+        Map<String, Object> data = new HashMap<>();
+        data.put("answer", "[Spring AI 응답] " + question);
+        data.put("sources", List.of("lecture:lec_java_01"));
+        data.put("lecture_id", textOrNull(body, "lecture_id"));
+        data.put("provider", "demo");
+        data.put("model", "demo-answer-v1");
+        featureStore.recordAiUsage(session.user().id(), "answer", true, question);
+        return ResponseEntity.ok(ApiResponse.success(data, "답변을 생성했습니다."));
     }
 
     @PostMapping("/summary")
     public ResponseEntity<ApiResponse<Map<String, Object>>> summary(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!featureStore.canConsumeAi(session.user().id())) return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다."));
         String lectureId = text(body, "lecture_id");
         if (lectureId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
         if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
-        return ResponseEntity.ok(ApiResponse.success(Map.of(
+        Map<String, Object> data = Map.of(
                 "lecture_id", lectureId,
                 "content", "Spring 백엔드에서 생성한 강의 요약입니다.",
                 "style", text(body, "style").isBlank() ? "brief" : text(body, "style"),
                 "language", text(body, "language").isBlank() ? "ko" : text(body, "language"),
                 "provider", "demo",
                 "model", "demo-summary-v1"
-        ), "요약이 생성되었습니다."));
+        );
+        featureStore.recordAiUsage(session.user().id(), "summary", true, lectureId);
+        return ResponseEntity.ok(ApiResponse.success(data, "요약이 생성되었습니다."));
     }
 
     @PostMapping("/quiz")
     public ResponseEntity<ApiResponse<Map<String, Object>>> quiz(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
-        if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        if (!featureStore.canConsumeAi(session.user().id())) return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다."));
         String lectureId = text(body, "lecture_id");
         if (lectureId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
         if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
-        return ResponseEntity.ok(ApiResponse.success(Map.of(
+        Map<String, Object> data = Map.of(
                 "lecture_id", lectureId,
                 "questions", List.of(Map.of("id", "q-1", "question", "Spring Boot의 장점은?", "answer", "빠른 REST API 개발")),
                 "provider", "demo",
                 "model", "demo-quiz-v1"
-        ), "퀴즈가 생성되었습니다."));
+        );
+        featureStore.recordAiUsage(session.user().id(), "quiz", true, lectureId);
+        return ResponseEntity.ok(ApiResponse.success(data, "퀴즈가 생성되었습니다."));
     }
 
     private ResponseEntity<ApiResponse<Map<String, Object>>> validateLecture(Map<String, Object> body) {
@@ -173,5 +213,17 @@ public class AiController {
     private Object textOrNull(Map<String, Object> body, String key) {
         String value = text(body, key);
         return value.isBlank() ? null : value;
+    }
+
+    private Integer intOrNull(Map<String, Object> body, String key) {
+        String value = text(body, key);
+        if (value.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -25,6 +25,8 @@ public class FeatureStoreService {
     private static final String SHORTFORM_SHARE_SCOPE = "shortform_share";
     private static final String SHORTFORM_LIKE_SCOPE = "shortform_like";
     private static final String CUSTOM_COURSE_SCOPE = "custom_course";
+    private static final String AI_USAGE_SCOPE = "ai_usage_daily";
+    private static final String AI_LOG_SCOPE = "ai_log";
     private final FeatureJdbcStore store;
     private final int shortformMaxRetry;
 
@@ -79,11 +81,18 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> aiLogs(String userId) {
-        return Map.of("user_id", userId, "items", List.of(), "count", 0);
+        List<Map<String, Object>> rows = store.listEventsByOwner(AI_LOG_SCOPE, userId);
+        return Map.of("user_id", userId, "items", rows, "count", rows.size());
     }
 
     public Map<String, Object> aiRecommendations(String userId) {
-        return Map.of("user_id", userId, "items", List.of(), "count", 0);
+        return Map.of(
+                "user_id", userId,
+                "items", List.of(
+                        Map.of("id", "rec-1", "type", "study", "title", "최근 질문 기반 복습 추천")
+                ),
+                "count", 1
+        );
     }
 
     public Map<String, Object> aiSettings(String userId) {
@@ -111,6 +120,52 @@ public class FeatureStoreService {
 
     public Map<String, Object> aiProviders(String userId) {
         return Map.of("providers", List.of("demo", "ollama", "gemini"), "current", aiSettings(userId).getOrDefault("provider", "demo"));
+    }
+
+    public boolean canConsumeAi(String userId) {
+        Map<String, Object> settings = aiSettings(userId);
+        int limit = asInt(settings.get("daily_limit"));
+        if (limit <= 0) {
+            limit = 100;
+        }
+        String key = usageKey(userId);
+        Map<String, Object> row = store.getKv(AI_USAGE_SCOPE, key);
+        int used = row == null ? 0 : asInt(row.get("count"));
+        return used < limit;
+    }
+
+    public void recordAiUsage(String userId, String feature, boolean success, String inputText) {
+        String key = usageKey(userId);
+        Map<String, Object> row = store.getKv(AI_USAGE_SCOPE, key);
+        int used = row == null ? 0 : asInt(row.get("count"));
+        Map<String, Object> next = new HashMap<>();
+        next.put("user_id", userId);
+        next.put("day", java.time.LocalDate.now().toString());
+        next.put("count", used + 1);
+        next.put("updated_at", Instant.now().toString());
+        store.upsertKv(AI_USAGE_SCOPE, key, next);
+
+        Map<String, Object> log = new HashMap<>();
+        log.put("id", UUID.randomUUID().toString());
+        log.put("feature", feature);
+        log.put("success", success);
+        log.put("input_text", inputText);
+        log.put("created_at", Instant.now().toString());
+        store.insertEvent(AI_LOG_SCOPE, userId, String.valueOf(log.get("id")), log);
+    }
+
+    public Map<String, Object> ragOverview(String query, String lectureId, String courseId, Integer limit) {
+        List<Map<String, Object>> hits = List.of(
+                Map.of("id", "hit-rag-1", "score", 0.92, "snippet", "RAG 샘플 컨텍스트")
+        );
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("query", query);
+        payload.put("lecture_id", lectureId);
+        payload.put("course_id", courseId);
+        payload.put("limit", limit == null ? 3 : limit);
+        payload.put("hits", hits);
+        payload.put("answer", "RAG 샘플 응답");
+        return payload;
     }
 
     public Map<String, Object> mediaUpload(String lectureId, String fileName) {
@@ -477,5 +532,9 @@ public class FeatureStoreService {
         } catch (Exception ignored) {
             return 0L;
         }
+    }
+
+    private String usageKey(String userId) {
+        return userId + ":" + java.time.LocalDate.now();
     }
 }

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AdminEndpointMigrationIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AdminEndpointMigrationIntegrationTest.java
@@ -208,6 +208,82 @@ class AdminEndpointMigrationIntegrationTest {
         assertThat(objectMapper.readTree(studentSettings).path("data").path("model").asText()).isEqualTo("student-model");
     }
 
+    @Test
+    void aiRag_shouldValidateQueryAndLectureOrCourse() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_std_001");
+
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"daily_limit\":999999,\"provider\":\"demo\",\"model\":\"demo-v1\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"spring\"}"))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"spring\",\"lecture_id\":\"lec_missing\"}"))
+                .andExpect(status().isNotFound());
+
+        String ok = mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"spring\",\"course_id\":\"crs_java_01\",\"limit\":5}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(ok).path("data").path("answer").asText()).isNotBlank();
+        assertThat(objectMapper.readTree(ok).path("data").path("limit").asInt()).isEqualTo(5);
+    }
+
+    @Test
+    void aiUsage_shouldApplyDailyLimitAndWriteLogs() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_std_001");
+
+        String beforeLogs = mockMvc.perform(get("/api/v1/ai/logs")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        int usedBefore = objectMapper.readTree(beforeLogs).path("data").path("count").asInt();
+
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"daily_limit\":" + (usedBefore + 1) + ",\"provider\":\"demo\",\"model\":\"demo-v1\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/ai/intent")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"추천해줘\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/ai/intent")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"한 번 더\"}"))
+                .andExpect(status().isTooManyRequests());
+
+        String logs = mockMvc.perform(get("/api/v1/ai/logs")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode data = objectMapper.readTree(logs).path("data");
+        assertThat(data.path("count").asInt()).isGreaterThanOrEqualTo(1);
+        assertThat(data.path("items").isArray()).isTrue();
+    }
+
     private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/LegacyEndpointMigrationIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/LegacyEndpointMigrationIntegrationTest.java
@@ -120,6 +120,12 @@ class LegacyEndpointMigrationIntegrationTest {
     void aiCoreEndpoints_shouldReturnLegacyCompatibleSuccessShapes() throws Exception {
         String auth = "Bearer " + loginAndGetToken("usr_std_001");
 
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"daily_limit\":999999,\"provider\":\"demo\",\"model\":\"demo-v1\"}"))
+                .andExpect(status().isOk());
+
         String intent = mockMvc.perform(post("/api/v1/ai/intent")
                         .header("Authorization", auth)
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
﻿# 변경 요약
관리자 AI 엔드포인트 마이그레이션 후속으로, Spring `/api/v1/ai`에 일일 사용량 제한/로그 적재를 적용하고 `rag` 검증 계약을 보강했습니다.

## 배경
기존 Spring 이관본에서 `rag` 계약 검증과 AI 사용량 추적이 부족해 운영/호환성 리스크가 있었습니다.

## 변경 내용
- `AiController`
  - `intent/search/answer/summary/quiz/rag` 호출 전에 일일 사용량 제한 검사 추가
  - 성공 응답 시 AI 사용량/이벤트 로그 기록 추가
  - `/ai/rag` 입력 검증 보강
    - `query` 필수
    - `lecture_id` 또는 `course_id` 중 하나 필수
    - `lecture_id` 미존재 시 `LECTURE_NOT_FOUND`
    - `course_id` 미존재 시 `COURSE_NOT_FOUND`
- `FeatureStoreService`
  - 일일 사용량 KV 스코프(`ai_usage_daily`) 추가
  - AI 로그 이벤트 스코프(`ai_log`) 추가
  - `aiLogs` 실데이터 조회로 변경
  - `canConsumeAi`, `recordAiUsage`, `ragOverview` 추가
  - `aiRecommendations` 기본 샘플 응답 추가
- 통합 테스트
  - `AdminEndpointMigrationIntegrationTest`
    - `/ai/rag` 검증 시나리오 추가
    - AI 사용량 제한/로그 적재 시나리오 추가
  - `LegacyEndpointMigrationIntegrationTest`
    - 기존 레거시 호환 테스트가 quota에 영향받지 않도록 사전 설정 보강

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

검증 명령:
- `./mvnw.cmd -Dtest=AdminEndpointMigrationIntegrationTest test`
- `./mvnw.cmd test`

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- `Map.of`에서 null 불가 이슈를 피하기 위해 nullable 응답 필드는 `HashMap` 기반으로 변경한 점
- 파일 기반 테스트 DB 환경에서 누적 사용량으로 flaky가 나지 않도록 테스트를 보정한 점

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
