### PR TITLE
Spring 운영 문서 보강: Persistence 구조 및 Callback 충돌 대응

### DIFF
--- a/backend-spring/README.md
+++ b/backend-spring/README.md
@@ -22,6 +22,28 @@
 - concurrency: 동일 브랜치에서 새 실행 시작 시 이전 실행 자동 취소(`cancel-in-progress: true`)
 - timeout: job 기준 15분(`timeout-minutes: 15`)
 
+## Persistence Architecture
+- Store: H2 file DB (`jdbc:h2:file:./data/myway-feature-store`)
+- Adapter: `FeatureJdbcStore`
+- Scope-based 저장 구조:
+  - KV: `scope + item_id` 기반 단건 상태 저장
+  - Event: `scope + owner_id + event_id` 기반 이력 저장
+- 주요 스코프:
+  - AI: `ai_settings`, `ai_usage_daily`, `ai_log`
+  - Media: `media_transcript`, `media_extraction`, `media_pipeline`, `media_note`, `media_asset`
+  - Shortform: `shortform_extraction`, `shortform_video`, `shortform_save`, `shortform_share`, `shortform_like`
+  - Custom: `custom_course`
+
+## Shortform Retry / Callback Policy
+- 재시도 상한: `myway.shortform.retry.max-attempts` (기본값 3, 최소 1)
+- 재시도 흐름:
+  1. 실패 상태에서 `/api/v1/shortform/retry` 호출 시 `retry_count` 증가
+  2. 상한 미만이면 `PROCESSING`으로 재진입
+  3. 상한 도달 시 `FAILED_PERMANENT`로 고정
+- Callback 멱등/순서 보장:
+  - `event_version`이 현재 `last_event_version`보다 작거나 같으면 무시
+  - 최신 버전 이벤트만 상태를 갱신
+
 ## Implemented Endpoints
 - GET `/`
 - GET `/api/v1/health`

--- a/docs/dev-logs/2026-05-03-spring-ai-persistence-rag-guard.md
+++ b/docs/dev-logs/2026-05-03-spring-ai-persistence-rag-guard.md
@@ -1,0 +1,11 @@
+# 2026-05-03 Spring AI 사용량 제한/로그 및 RAG 검증 보강
+
+## 요약
+- `/api/v1/ai/*` 주요 엔드포인트에 일일 사용량 제한(429) 가드 추가
+- AI 요청 성공 시 사용량(`ai_usage_daily`) 및 로그(`ai_log`) 적재
+- `/api/v1/ai/rag`에 `query`, `lecture_id|course_id`, 존재 검증 계약 보강
+- 통합 테스트(`AdminEndpointMigrationIntegrationTest`, `LegacyEndpointMigrationIntegrationTest`) 보강
+
+## 검증
+- `./mvnw.cmd -Dtest=AdminEndpointMigrationIntegrationTest test` 통과
+- `./mvnw.cmd test` 전체 통과

--- a/docs/troubleshooting-shortform-callback-version.md
+++ b/docs/troubleshooting-shortform-callback-version.md
@@ -1,0 +1,25 @@
+# Shortform Callback / Version 충돌 트러블슈팅
+
+## 증상
+- export callback이 왔는데 상태가 갱신되지 않음
+- `FAILED` 이후 다시 `PROCESSING`으로 보냈는데 이전 callback이 상태를 덮어씀
+- 동일 callback 재전송 시 상태가 흔들림
+
+## 원인
+- callback `event_version`이 이미 처리된 `last_event_version` 이하
+- 구버전 callback 재전송 또는 지연 도착
+
+## 확인 방법
+1. 대상 shortform 레코드의 `last_event_version` 확인
+2. callback payload의 `event_version`과 비교
+3. `event_version <= last_event_version`이면 서버가 무시하는 것이 정상
+
+## 대응 방법
+1. callback 발행자에서 `event_version`을 단조 증가로 관리
+2. 재시도 시에도 동일 버전을 재사용하지 말고 새 버전으로 발행
+3. 실패 상태에서 재시도 API(`/api/v1/shortform/retry`)로 `PROCESSING` 재진입 후 callback 발행
+
+## 운영 체크리스트
+- [ ] callback producer가 shortform 단위로 증가 버전을 보장하는가
+- [ ] callback 재전송 로직이 과거 버전을 재사용하지 않는가
+- [ ] `retry_count`가 상한(`myway.shortform.retry.max-attempts`)을 초과하지 않는가


### PR DESCRIPTION
﻿# 변경 요약
Spring 백엔드 운영 문서에 persistence 구조와 shortform callback/version 충돌 대응 가이드를 추가했습니다.

## 배경
관리자 오케스트레이션 후속으로, 운영 중 자주 발생하는 callback 버전 충돌과 재시도 정책을 문서로 명확히 남길 필요가 있었습니다.

## 변경 내용
- `backend-spring/README.md`
  - persistence architecture 섹션 추가
  - shortform retry/callback policy 섹션 추가
- `docs/troubleshooting-shortform-callback-version.md`
  - callback `event_version` 충돌 증상/원인/확인/대응 절차 추가
- `docs/dev-logs/2026-05-03-spring-ai-persistence-rag-guard.md`
  - AI usage/rag guard 작업 로그 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- README 정책 문구가 실제 구현(`retry_count`, `last_event_version`)과 일치하는지
- troubleshooting 절차가 운영자가 바로 실행 가능한지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
