### PR TITLE
Shortform/CustomCourses 계약 회귀 테스트 추가

### DIFF
--- a/backend-spring/README.md
+++ b/backend-spring/README.md
@@ -22,6 +22,28 @@
 - concurrency: 동일 브랜치에서 새 실행 시작 시 이전 실행 자동 취소(`cancel-in-progress: true`)
 - timeout: job 기준 15분(`timeout-minutes: 15`)
 
+## Persistence Architecture
+- Store: H2 file DB (`jdbc:h2:file:./data/myway-feature-store`)
+- Adapter: `FeatureJdbcStore`
+- Scope-based 저장 구조:
+  - KV: `scope + item_id` 기반 단건 상태 저장
+  - Event: `scope + owner_id + event_id` 기반 이력 저장
+- 주요 스코프:
+  - AI: `ai_settings`, `ai_usage_daily`, `ai_log`
+  - Media: `media_transcript`, `media_extraction`, `media_pipeline`, `media_note`, `media_asset`
+  - Shortform: `shortform_extraction`, `shortform_video`, `shortform_save`, `shortform_share`, `shortform_like`
+  - Custom: `custom_course`
+
+## Shortform Retry / Callback Policy
+- 재시도 상한: `myway.shortform.retry.max-attempts` (기본값 3, 최소 1)
+- 재시도 흐름:
+  1. 실패 상태에서 `/api/v1/shortform/retry` 호출 시 `retry_count` 증가
+  2. 상한 미만이면 `PROCESSING`으로 재진입
+  3. 상한 도달 시 `FAILED_PERMANENT`로 고정
+- Callback 멱등/순서 보장:
+  - `event_version`이 현재 `last_event_version`보다 작거나 같으면 무시
+  - 최신 버전 이벤트만 상태를 갱신
+
 ## Implemented Endpoints
 - GET `/`
 - GET `/api/v1/health`

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/ShortformCustomCoursesContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/ShortformCustomCoursesContractTest.java
@@ -1,0 +1,86 @@
+package com.myway.backendspring.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ShortformCustomCoursesContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shortformAndCustomCourseEndpoints_shouldReturnSuccessEnvelope_whenAuthenticated() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/shortform/generate")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"course_id\":\"crs_java_01\",\"mode\":\"cross\"}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/custom-courses/compose")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"course_id\":\"crs_java_01\",\"title\":\"내 코스\"}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+    }
+
+    @Test
+    void shortformAndCustomCourseEndpoints_shouldReturnUnauthenticatedEnvelope_whenUnauthorized() throws Exception {
+        assertFailureEnvelope(mockMvc.perform(get("/api/v1/shortform/library"))
+                        .andExpect(status().isUnauthorized())
+                        .andReturn(),
+                "UNAUTHENTICATED");
+
+        assertFailureEnvelope(mockMvc.perform(get("/api/v1/custom-courses/my"))
+                        .andExpect(status().isUnauthorized())
+                        .andReturn(),
+                "UNAUTHENTICATED");
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+
+    private void assertSuccessEnvelope(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isTrue();
+        assertThat(root.get("data")).isNotNull();
+        assertThat(root.path("error").isNull()).isTrue();
+        assertThat(root.has("message")).isTrue();
+    }
+
+    private void assertFailureEnvelope(MvcResult result, String expectedCode) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isFalse();
+        assertThat(root.path("data").isNull()).isTrue();
+        assertThat(root.path("error").path("code").asText()).isEqualTo(expectedCode);
+        assertThat(root.path("message").asText()).isNotBlank();
+    }
+}

--- a/docs/dev-logs/2026-05-03-spring-ai-persistence-rag-guard.md
+++ b/docs/dev-logs/2026-05-03-spring-ai-persistence-rag-guard.md
@@ -1,0 +1,11 @@
+# 2026-05-03 Spring AI 사용량 제한/로그 및 RAG 검증 보강
+
+## 요약
+- `/api/v1/ai/*` 주요 엔드포인트에 일일 사용량 제한(429) 가드 추가
+- AI 요청 성공 시 사용량(`ai_usage_daily`) 및 로그(`ai_log`) 적재
+- `/api/v1/ai/rag`에 `query`, `lecture_id|course_id`, 존재 검증 계약 보강
+- 통합 테스트(`AdminEndpointMigrationIntegrationTest`, `LegacyEndpointMigrationIntegrationTest`) 보강
+
+## 검증
+- `./mvnw.cmd -Dtest=AdminEndpointMigrationIntegrationTest test` 통과
+- `./mvnw.cmd test` 전체 통과

--- a/docs/troubleshooting-shortform-callback-version.md
+++ b/docs/troubleshooting-shortform-callback-version.md
@@ -1,0 +1,25 @@
+# Shortform Callback / Version 충돌 트러블슈팅
+
+## 증상
+- export callback이 왔는데 상태가 갱신되지 않음
+- `FAILED` 이후 다시 `PROCESSING`으로 보냈는데 이전 callback이 상태를 덮어씀
+- 동일 callback 재전송 시 상태가 흔들림
+
+## 원인
+- callback `event_version`이 이미 처리된 `last_event_version` 이하
+- 구버전 callback 재전송 또는 지연 도착
+
+## 확인 방법
+1. 대상 shortform 레코드의 `last_event_version` 확인
+2. callback payload의 `event_version`과 비교
+3. `event_version <= last_event_version`이면 서버가 무시하는 것이 정상
+
+## 대응 방법
+1. callback 발행자에서 `event_version`을 단조 증가로 관리
+2. 재시도 시에도 동일 버전을 재사용하지 말고 새 버전으로 발행
+3. 실패 상태에서 재시도 API(`/api/v1/shortform/retry`)로 `PROCESSING` 재진입 후 callback 발행
+
+## 운영 체크리스트
+- [ ] callback producer가 shortform 단위로 증가 버전을 보장하는가
+- [ ] callback 재전송 로직이 과거 버전을 재사용하지 않는가
+- [ ] `retry_count`가 상한(`myway.shortform.retry.max-attempts`)을 초과하지 않는가


### PR DESCRIPTION
﻿# 변경 요약
`/api/v1/shortform/*`, `/api/v1/custom-courses/*`의 응답 envelope 및 인증 실패 계약 회귀를 방어하는 contract 테스트를 추가했습니다.

## 배경
Spring 이관 이후 API 동작은 유지되고 있지만, shortform/custom-courses 영역의 envelope/auth 계약 회귀를 자동으로 감지할 테스트가 부족했습니다.

## 변경 내용
- `backend-spring/src/test/java/com/myway/backendspring/contract/ShortformCustomCoursesContractTest.java` 추가
  - 인증 성공 시 success envelope 검증
    - `POST /api/v1/shortform/generate`
    - `POST /api/v1/custom-courses/compose`
  - 인증 실패 시 failure envelope + `UNAUTHENTICATED` 코드 검증
    - `GET /api/v1/shortform/library`
    - `GET /api/v1/custom-courses/my`

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

검증 명령:
- `./mvnw.cmd -Dtest=ShortformCustomCoursesContractTest test`
- `./mvnw.cmd test`

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- 기존 envelope 형식(`success/data/error/message`)과 신규 테스트의 단언이 일치하는지
- unauthorized 응답의 에러코드(`UNAUTHENTICATED`) 계약이 일관적인지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
