### PR TITLE
Media 엔드포인트 계약 회귀 테스트 추가

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -1,0 +1,88 @@
+package com.myway.backendspring.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MediaContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void mediaEndpoints_shouldReturnSuccessEnvelope_whenAuthenticated() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        assertSuccessEnvelope(mockMvc.perform(get("/api/v1/media/providers")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/media/transcribe")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"language\":\"ko\"}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+    }
+
+    @Test
+    void mediaEndpoints_shouldReturnFailureEnvelope_whenUnauthorizedOrForbidden() throws Exception {
+        assertFailureEnvelope(mockMvc.perform(get("/api/v1/media/providers"))
+                        .andExpect(status().isUnauthorized())
+                        .andReturn(),
+                "UNAUTHENTICATED");
+
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"abc\",\"status\":\"COMPLETED\"}"))
+                .andExpect(status().isForbidden())
+                .andReturn(),
+                "FORBIDDEN");
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+
+    private void assertSuccessEnvelope(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isTrue();
+        assertThat(root.get("data")).isNotNull();
+        assertThat(root.path("error").isNull()).isTrue();
+        assertThat(root.has("message")).isTrue();
+    }
+
+    private void assertFailureEnvelope(MvcResult result, String expectedCode) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isFalse();
+        assertThat(root.path("data").isNull()).isTrue();
+        assertThat(root.path("error").path("code").asText()).isEqualTo(expectedCode);
+        assertThat(root.path("message").asText()).isNotBlank();
+    }
+}


### PR DESCRIPTION
﻿# 변경 요약
`/api/v1/media/*` 엔드포인트의 응답 envelope 및 인증/콜백 실패 계약을 고정하는 contract 테스트를 추가했습니다.

## 배경
Spring 이관 이후 media API의 동작 회귀를 빠르게 감지하려면, envelope 형식과 대표 에러코드에 대한 자동 검증이 필요했습니다.

## 변경 내용
- `backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java` 추가
  - 인증 성공 시 success envelope 검증
    - `GET /api/v1/media/providers`
    - `POST /api/v1/media/transcribe`
  - 실패 시 failure envelope + 코드 검증
    - 비인증 접근: `UNAUTHENTICATED`
    - callback 토큰 누락/불일치: `FORBIDDEN`

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

검증 명령:
- `./mvnw.cmd -Dtest=MediaContractTest test`
- `./mvnw.cmd test`

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- media 실패 응답의 코드/메시지 계약이 테스트 단언과 일치하는지
- callback 토큰 보호 동작이 회귀 없이 유지되는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
