### PR TITLE
Auth 회귀 테스트 확장: POST 엔드포인트 401/UNAUTHENTICATED 보강

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AuthSemanticsIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AuthSemanticsIntegrationTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -38,6 +40,30 @@ class AuthSemanticsIntegrationTest {
                 .andReturn());
 
         assertUnauthenticated(mockMvc.perform(get("/api/v1/custom-courses/my"))
+                .andExpect(status().isUnauthorized())
+                .andReturn());
+
+        assertUnauthenticated(mockMvc.perform(post("/api/v1/ai/intent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"추천\"}"))
+                .andExpect(status().isUnauthorized())
+                .andReturn());
+
+        assertUnauthenticated(mockMvc.perform(post("/api/v1/media/transcribe")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isUnauthorized())
+                .andReturn());
+
+        assertUnauthenticated(mockMvc.perform(post("/api/v1/shortform/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"course_id\":\"crs_java_01\"}"))
+                .andExpect(status().isUnauthorized())
+                .andReturn());
+
+        assertUnauthenticated(mockMvc.perform(post("/api/v1/custom-courses/compose")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"course_id\":\"crs_java_01\"}"))
                 .andExpect(status().isUnauthorized())
                 .andReturn());
     }


### PR DESCRIPTION
# 변경 요약
인증 누락 시 401/UNAUTHENTICATED 계약 회귀 테스트를 GET 대표 엔드포인트에서 POST 엔드포인트까지 확장했습니다.

## 배경
기존 테스트는 대표 GET 위주라 일부 쓰기 API의 인증 회귀를 놓칠 수 있어, 핵심 POST 경로까지 계약을 고정할 필요가 있었습니다.

## 변경 내용
- AuthSemanticsIntegrationTest 확장
  - 기존: ai/media/shortform/custom-courses GET 4종
  - 추가: ai/media/shortform/custom-courses POST 4종
    - /api/v1/ai/intent
    - /api/v1/media/transcribe
    - /api/v1/shortform/generate
    - /api/v1/custom-courses/compose

## 검증
- ./mvnw.cmd -Dtest=AuthSemanticsIntegrationTest test
- ./mvnw.cmd test
모두 통과
