### PR TITLE
프론트 UI 2차 개선: 헤더·사이드바·공개 홈 시각 정리

### DIFF
--- a/frontend/src/features/lms/components/AppHeader.tsx
+++ b/frontend/src/features/lms/components/AppHeader.tsx
@@ -7,8 +7,8 @@ type AppHeaderProps = {
 
 export function AppHeader({ title, theme, onToggleTheme, onOpenMobile }: AppHeaderProps) {
   return (
-    <header className="glass sticky top-0 z-10 border-b border-[var(--app-border)]">
-      <div className="mx-auto flex h-14 max-w-[1400px] items-center justify-between px-4 sm:px-6 lg:px-8">
+    <header className="glass sticky top-0 z-10 border-b border-[var(--app-border)]/80">
+      <div className="mx-auto flex h-16 max-w-[1480px] items-center justify-between px-4 sm:px-6 lg:px-10">
         <div className="flex items-center gap-3">
           <button
             type="button"
@@ -17,15 +17,20 @@ export function AppHeader({ title, theme, onToggleTheme, onOpenMobile }: AppHead
           >
             <i className="ri-menu-line text-lg" />
           </button>
-          <div>
-            <h1 className="text-[15px] font-bold tracking-tight text-[var(--app-text)]">{title}</h1>
+          <div className="min-w-0">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--app-text-muted)]">Workspace</p>
+            <h1 className="truncate text-[15px] font-bold tracking-tight text-[var(--app-text)]">{title}</h1>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2.5">
+          <span className="hidden items-center gap-1.5 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1 text-[10px] font-semibold text-emerald-500 sm:inline-flex">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            LIVE
+          </span>
           <button
             type="button"
             title="알림"
-            className="relative flex h-9 w-9 items-center justify-center rounded-xl text-[var(--app-text-muted)] transition-all hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95"
+            className="relative flex h-9 w-9 items-center justify-center rounded-xl border border-transparent text-[var(--app-text-muted)] transition-all hover:border-[var(--app-border)] hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95"
           >
             <i className="ri-notification-3-line text-[16px]" />
             <span className="absolute right-[5px] top-[5px] h-[7px] w-[7px] rounded-full border border-white bg-red-500" />
@@ -34,7 +39,7 @@ export function AppHeader({ title, theme, onToggleTheme, onOpenMobile }: AppHead
             type="button"
             onClick={onToggleTheme}
             title={theme === 'light' ? '다크 모드 전환' : '라이트 모드 전환'}
-            className="flex h-9 w-9 items-center justify-center rounded-xl text-[var(--app-text-muted)] transition-all hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95"
+            className="flex h-9 w-9 items-center justify-center rounded-xl border border-transparent text-[var(--app-text-muted)] transition-all hover:border-[var(--app-border)] hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95"
           >
             <i className={theme === 'light' ? 'ri-moon-line text-[16px]' : 'ri-sun-line text-[16px]'} />
           </button>

--- a/frontend/src/features/lms/components/AppSidebar.tsx
+++ b/frontend/src/features/lms/components/AppSidebar.tsx
@@ -55,7 +55,7 @@ export function AppSidebar({
     <aside
       className={`fixed inset-y-0 z-30 flex flex-col border-[var(--app-border)] bg-[var(--app-surface)] shadow-[var(--app-shadow-lg)] ${dockClass} ${sidebarWidthClass}`}
     >
-      <div className="flex h-16 items-center justify-between gap-2 border-b border-[var(--app-border)] px-4">
+      <div className="flex h-16 items-center justify-between gap-2 border-b border-[var(--app-border)]/80 px-4">
         <button
           type="button"
           onClick={() => {
@@ -92,7 +92,7 @@ export function AppSidebar({
         {groups.map((group) => (
           <div key={group.label} className="mb-5">
             {!collapsed ? (
-              <div className="mb-2 px-3 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--app-text-muted)]">
+              <div className="mb-2 px-3 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--app-text-muted)]/90">
                 {group.label}
               </div>
             ) : null}
@@ -122,7 +122,7 @@ export function AppSidebar({
         ))}
       </nav>
 
-      <div className="border-t border-[var(--app-border)] px-3 py-3">
+      <div className="border-t border-[var(--app-border)]/80 px-3 py-3">
         <div className={`flex items-center gap-2.5 rounded-xl px-3 py-2.5 ${collapsed ? 'justify-center' : ''}`}>
           <div className={`flex h-9 w-9 items-center justify-center rounded-xl text-[13px] font-bold text-white shadow-sm ${avatarTone}`}>
             {session.user.name[0]}

--- a/frontend/src/features/lms/pages/PublicHomePage.tsx
+++ b/frontend/src/features/lms/pages/PublicHomePage.tsx
@@ -79,7 +79,7 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
   const visualCourses = courseCards.slice(0, 3);
 
   return (
-    <div className="min-h-screen bg-[#f8f9fb]">
+    <div className="min-h-screen bg-[var(--app-bg)]">
       <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/90 backdrop-blur">
         <div className="mx-auto flex h-16 max-w-[1320px] items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
           <div className="flex items-center gap-3">
@@ -142,9 +142,9 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
         </div>
       </header>
 
-      <main className="mx-auto max-w-[1320px] space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+      <main className="mx-auto max-w-[1400px] space-y-6 px-4 py-6 sm:px-6 lg:px-10">
         <section className="grid gap-5 xl:grid-cols-[1.15fr_0.85fr]">
-          <div className="relative overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-7 py-8 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8 lg:py-9">
+          <div className="relative overflow-hidden rounded-3xl bg-[linear-gradient(135deg,#0f172a_0%,#0f4c81_52%,#1f2937_100%)] px-7 py-8 text-white shadow-[0_24px_48px_rgba(15,23,42,0.18)] lg:px-8 lg:py-9">
             <div className="pointer-events-none absolute -right-8 top-10 h-64 w-64 rounded-full bg-white/10 blur-3xl" />
             <div className="pointer-events-none absolute -bottom-20 left-1/3 h-56 w-56 rounded-full bg-cyan-300/10 blur-3xl" />
 
@@ -152,8 +152,8 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
               <span className="inline-flex rounded-full bg-white/14 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
                 강의 탐색 허브
               </span>
-              <h1 className="mt-5 text-[2.1rem] font-extrabold tracking-[-0.05em] text-white lg:text-[3.2rem]">
-                찾기 쉽고,
+              <h1 className="mt-5 text-[2rem] font-extrabold tracking-[-0.04em] text-white lg:text-[2.7rem]">
+                찾기 쉽고
                 <br />
                 보기 쉬운 학습 화면
               </h1>
@@ -196,7 +196,7 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
           </div>
 
           <div className="grid gap-4">
-            <div className="rounded-[28px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+            <div className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Search</div>
@@ -244,7 +244,7 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
                 visualCourses.map((course) => (
                   <article
                     key={course.id}
-                    className="overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-sm transition hover:-translate-y-0.5"
+                    className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-0.5"
                   >
                     <div className="relative h-32 bg-[linear-gradient(135deg,#4338ca,#1d4ed8)]">
                       <div className="absolute inset-0 opacity-20">


### PR DESCRIPTION
﻿# 변경 요약
LMS 메인 네비게이션과 공개 홈 화면의 시각 구성을 정리해 화면 밀도, 가독성, 상태 인지를 개선했습니다.

## 배경
기능은 동작하지만 헤더/사이드바/퍼블릭 홈의 톤과 정보 계층이 혼재되어 있어 첫 인지와 탐색 효율이 떨어지는 문제가 있었습니다.

## 변경 내용
- `AppHeader`
  - 상단 높이/폭 정렬 재조정
  - 페이지 타이틀 상단에 `Workspace` 라벨 추가
  - 상태 배지(`LIVE`) 및 아이콘 버튼 보더 인터랙션 보강
- `AppSidebar`
  - 경계선 대비/그룹 라벨 톤 미세 조정
  - 정보 계층(섹션 라벨 → 메뉴 아이템 → 사용자 영역) 가독성 보강
- `PublicHomePage`
  - 컨테이너 폭/여백 조정(`max-w` 확장)
  - 히어로 그라디언트 톤 정리(보라 편중 완화)
  - 카드/패널 반경·그림자 통일감 개선

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

검증 명령:
- `npm run build` (frontend)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- 라이트/다크 테마에서 헤더/사이드바 대비가 과하지 않은지
- 공개 홈 히어로/카드 톤이 기존 브랜드 인식과 충돌 없는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
