### PR TITLE
프론트 UI 3차 개선: 홈 히어로·로그인 진입 UX 정리

### DIFF
--- a/frontend/src/features/lms/components/LoginScreen.tsx
+++ b/frontend/src/features/lms/components/LoginScreen.tsx
@@ -29,14 +29,14 @@ const iconClass: Record<'student' | 'instructor' | 'admin', string> = {
 
 export function LoginScreen({ demoUsers, busy, onLogin, onBackToHome }: LoginScreenProps) {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#f8f9fb]">
-      <div className="pointer-events-none absolute -right-28 -top-36 h-[38rem] w-[38rem] rounded-full bg-[radial-gradient(circle,rgba(79,70,229,0.06)_0%,transparent_68%)]" />
-      <div className="pointer-events-none absolute -bottom-36 -left-24 h-[34rem] w-[34rem] rounded-full bg-[radial-gradient(circle,rgba(124,58,237,0.05)_0%,transparent_68%)]" />
+    <div className="relative min-h-screen overflow-hidden bg-[var(--app-bg)]">
+      <div className="pointer-events-none absolute -right-28 -top-36 h-[38rem] w-[38rem] rounded-full bg-[radial-gradient(circle,rgba(20,184,166,0.07)_0%,transparent_68%)]" />
+      <div className="pointer-events-none absolute -bottom-36 -left-24 h-[34rem] w-[34rem] rounded-full bg-[radial-gradient(circle,rgba(59,130,246,0.06)_0%,transparent_68%)]" />
 
       <header className="relative z-10 border-b border-slate-200 bg-white/90 backdrop-blur">
         <div className="mx-auto flex h-16 max-w-[1320px] items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
           <button type="button" onClick={onBackToHome} className="text-[15px] font-extrabold tracking-[-0.03em] text-slate-900">
-            로그인
+            내맘대로클래스
           </button>
           <div className="flex items-center gap-2">
             <button
@@ -44,14 +44,7 @@ export function LoginScreen({ demoUsers, busy, onLogin, onBackToHome }: LoginScr
               onClick={onBackToHome}
               className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
             >
-              로그인
-            </button>
-            <button
-              type="button"
-              onClick={onBackToHome}
-              className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
-            >
-              회원가입
+              홈으로
             </button>
           </div>
         </div>
@@ -66,7 +59,7 @@ export function LoginScreen({ demoUsers, busy, onLogin, onBackToHome }: LoginScr
             <p className="mt-1.5 text-[15px] text-slate-500">AI 기반 맞춤형 학습 플랫폼</p>
           </div>
 
-          <div className="rounded-[22px] border border-slate-200 bg-white px-8 py-8 shadow-[0_20px_48px_rgba(15,23,42,0.08)]">
+          <div className="rounded-3xl border border-slate-200 bg-white px-8 py-8 shadow-[0_16px_36px_rgba(15,23,42,0.10)]">
             <h2 className="text-[1.1rem] font-bold tracking-[-0.02em] text-slate-900">로그인</h2>
             <p className="mt-1 text-[13px] leading-6 text-slate-500">이메일과 비밀번호로 로그인하세요.</p>
 

--- a/frontend/src/features/lms/pages/HomePage.tsx
+++ b/frontend/src/features/lms/pages/HomePage.tsx
@@ -43,14 +43,14 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-8 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8 lg:py-10">
+      <section className="overflow-hidden rounded-[30px] bg-[linear-gradient(135deg,#0b1220_0%,#1d4ed8_52%,#1f2937_100%)] px-6 py-8 text-white shadow-[0_22px_48px_rgba(15,23,42,0.18)] lg:px-8 lg:py-10">
         <div className="pointer-events-none absolute right-0 top-0 h-full w-1/2 bg-[radial-gradient(circle_at_70%_30%,rgba(168,85,247,0.30),transparent_55%)]" />
         <div className="relative z-10 max-w-2xl">
           <span className="inline-flex rounded-full bg-white/10 px-4 py-2 text-[12px] font-semibold text-white/90 backdrop-blur">
             AI 기반 학습 플랫폼 · {session.user.name}
           </span>
-          <h2 className="mt-6 text-[2.45rem] font-extrabold tracking-[-0.06em] leading-[1.05] text-white lg:text-[4rem]">
-            찾기 쉽고,
+          <h2 className="mt-6 text-[2.25rem] font-extrabold tracking-[-0.04em] leading-[1.05] text-white lg:text-[3.4rem]">
+            찾기 쉽고
             <br />
             보기 쉬운 학습 화면
           </h2>
@@ -67,13 +67,13 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
             >
               강의 탐색하기
             </button>
-            <button
-              type="button"
-              onClick={() => onNavigate('dashboard')}
-              className="rounded-full border border-white/25 bg-white/10 px-5 py-3 text-[13px] font-semibold text-white backdrop-blur transition hover:bg-white/15"
-            >
-              로그인 후 계속
-            </button>
+              <button
+                type="button"
+                onClick={() => onNavigate('dashboard')}
+                className="rounded-full border border-white/25 bg-white/10 px-5 py-3 text-[13px] font-semibold text-white backdrop-blur transition hover:bg-white/15"
+              >
+                대시보드 보기
+              </button>
           </div>
 
           <div className="mt-8 flex flex-wrap gap-2">


### PR DESCRIPTION
﻿# 변경 요약
홈 화면 히어로와 로그인 진입 화면의 시각/카피를 정리해 첫 진입 UX를 더 명확하고 안정적으로 개선했습니다.

## 배경
이전 단계에서 내비게이션/공개 홈 톤을 정리했지만, 로그인 진입과 홈 히어로 CTA의 문맥이 일부 혼재되어 사용자의 다음 행동 선택이 직관적이지 않았습니다.

## 변경 내용
- `HomePage`
  - 히어로 배경 톤을 운영형 대시보드 분위기에 맞게 정리
  - 헤드라인 타이포/크기 조정
  - 보조 CTA 문구를 `로그인 후 계속`에서 `대시보드 보기`로 명확화
- `LoginScreen`
  - 화면 배경 라디얼 톤을 기존 보라 편중에서 청록/블루 기반으로 완화
  - 상단 좌측 라벨을 `내맘대로클래스`로 변경
  - 상단 액션을 단일 `홈으로`로 단순화
  - 로그인 카드 라운드/그림자 조정으로 시각 밀도 개선

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

검증 명령:
- `npm run build` (frontend)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- 홈 히어로 CTA 문구가 역할별 유입 플로우와 충돌 없는지
- 로그인 상단 액션 단순화가 전환 흐름에 미치는 영향

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
