### PR TITLE
feat: media callback event version guard 추가

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -35,6 +35,13 @@ public class MediaController {
         this.callbackToken = callbackToken;
     }
 
+    public record ExtractionCallbackRequest(
+            String extraction_id,
+            String status,
+            String error_message,
+            Long event_version
+    ) {}
+
     private SessionView require(String auth) { return sessionService.me(auth); }
     private boolean canManageMedia(SessionView session) {
         if (session == null) return false;
@@ -154,7 +161,7 @@ public class MediaController {
     @PostMapping("/extract-audio/callback")
     public ResponseEntity<ApiResponse<Map<String, Object>>> callback(
             @RequestHeader(value = "X-Callback-Token", required = false) String token,
-            @RequestBody Map<String, Object> body
+            @RequestBody ExtractionCallbackRequest body
     ) {
         if (token == null || token.isBlank() || !token.equals(callbackToken)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "유효한 callback token이 필요합니다."));
@@ -162,15 +169,22 @@ public class MediaController {
         if (body == null) {
             return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID", "callback payload가 올바르지 않습니다."));
         }
-        String extractionId = String.valueOf(body.getOrDefault("extraction_id", "")).trim();
+        String extractionId = body.extraction_id() == null ? "" : body.extraction_id().trim();
         if (extractionId.isEmpty()) {
             return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID", "callback payload가 올바르지 않습니다."));
         }
-        String status = String.valueOf(body.getOrDefault("status", "COMPLETED"));
-        String errorMessage = body.get("error_message") == null ? null : String.valueOf(body.get("error_message"));
-        Map<String, Object> result = featureStore.completeExtractionCallback(extractionId, status, errorMessage);
+        long eventVersion = body.event_version() != null ? body.event_version() : 1L;
+        String status = body.status() == null ? "COMPLETED" : body.status();
+        String errorMessage = body.error_message();
+        Map<String, Object> result = featureStore.completeExtractionCallback(extractionId, status, errorMessage, eventVersion);
         if (result == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
+        }
+        if (Boolean.TRUE.equals(result.get("callback_ignored"))) {
+            return ResponseEntity.ok(ApiResponse.success(
+                    Map.of("extraction", result, "pipeline", featureStore.pipeline(String.valueOf(result.getOrDefault("lecture_id", "")))),
+                    "오래된 callback 이벤트를 무시했습니다."
+            ));
         }
         return ResponseEntity.ok(ApiResponse.success(Map.of("extraction", result, "pipeline", featureStore.pipeline(String.valueOf(result.getOrDefault("lecture_id", "")))), "오디오 추출 callback이 반영되었습니다."));
     }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -185,6 +185,7 @@ public class FeatureStoreService {
         item.put("created_at", Instant.now().toString());
 
         store.insertEvent(EXTRACTION_SCOPE, lectureId, id, item);
+        store.upsertKv(EXTRACTION_SCOPE, id, item);
 
         Map<String, Object> transcript = Map.of(
                 "lecture_id", lectureId,
@@ -227,11 +228,16 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> completeExtractionCallback(String extractionId, String status, String errorMessage, long eventVersion) {
-        Map<String, Object> extraction = null;
-        for (Map<String, Object> row : store.listEventsByScope(EXTRACTION_SCOPE)) {
-            if (extractionId.equals(String.valueOf(row.getOrDefault("id", "")))) {
-                extraction = new HashMap<>(row);
-                break;
+        Map<String, Object> extraction = store.getKv(EXTRACTION_SCOPE, extractionId);
+        if (extraction != null) {
+            extraction = new HashMap<>(extraction);
+        }
+        if (extraction == null) {
+            for (Map<String, Object> row : store.listEventsByScope(EXTRACTION_SCOPE)) {
+                if (extractionId.equals(String.valueOf(row.getOrDefault("id", "")))) {
+                    extraction = new HashMap<>(row);
+                    break;
+                }
             }
         }
         if (extraction == null) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -181,6 +181,7 @@ public class FeatureStoreService {
         item.put("id", id);
         item.put("lecture_id", lectureId);
         item.put("status", "COMPLETED");
+        item.put("last_event_version", 0L);
         item.put("created_at", Instant.now().toString());
 
         store.insertEvent(EXTRACTION_SCOPE, lectureId, id, item);
@@ -225,7 +226,7 @@ public class FeatureStoreService {
         return store.listEventsByOwner(EXTRACTION_SCOPE, lectureId);
     }
 
-    public Map<String, Object> completeExtractionCallback(String extractionId, String status, String errorMessage) {
+    public Map<String, Object> completeExtractionCallback(String extractionId, String status, String errorMessage, long eventVersion) {
         Map<String, Object> extraction = null;
         for (Map<String, Object> row : store.listEventsByScope(EXTRACTION_SCOPE)) {
             if (extractionId.equals(String.valueOf(row.getOrDefault("id", "")))) {
@@ -237,6 +238,13 @@ public class FeatureStoreService {
             return null;
         }
 
+        long currentVersion = asLong(extraction.get("last_event_version"));
+        if (eventVersion <= currentVersion) {
+            extraction.put("callback_ignored", true);
+            return extraction;
+        }
+
+        extraction.put("last_event_version", eventVersion);
         extraction.put("status", status == null || status.isBlank() ? "COMPLETED" : status.toUpperCase());
         extraction.put("error_message", errorMessage);
         extraction.put("updated_at", Instant.now().toString());

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/MediaCallbackVersionIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/MediaCallbackVersionIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.myway.backendspring.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MediaCallbackVersionIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void extractAudioCallback_shouldIgnoreStaleEvents() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        String extractionResponse = mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String extractionId = objectMapper.readTree(extractionResponse).path("data").path("id").asText();
+        assertThat(extractionId).isNotBlank();
+
+        String failedCallback = mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("X-Callback-Token", "dev-media-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"FAILED\",\"error_message\":\"boom\",\"event_version\":2}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode failedRoot = objectMapper.readTree(failedCallback);
+        assertThat(failedRoot.path("data").path("extraction").path("status").asText()).isEqualTo("FAILED");
+        assertThat(failedRoot.path("data").path("extraction").path("last_event_version").asLong()).isEqualTo(2L);
+
+        String staleCallback = mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("X-Callback-Token", "dev-media-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\",\"event_version\":1}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode staleRoot = objectMapper.readTree(staleCallback);
+        assertThat(staleRoot.path("data").path("extraction").path("callback_ignored").asBoolean()).isTrue();
+        assertThat(staleRoot.path("data").path("extraction").path("status").asText()).isEqualTo("FAILED");
+        assertThat(staleRoot.path("data").path("extraction").path("last_event_version").asLong()).isEqualTo(2L);
+
+        String successCallback = mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("X-Callback-Token", "dev-media-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\",\"event_version\":3}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode successRoot = objectMapper.readTree(successCallback);
+        assertThat(successRoot.path("data").path("extraction").path("status").asText()).isEqualTo("COMPLETED");
+        assertThat(successRoot.path("data").path("extraction").path("last_event_version").asLong()).isEqualTo(3L);
+
+        mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\",\"event_version\":4}"))
+                .andExpect(status().isForbidden());
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+}

--- a/docs/dev-logs/2026-05-05-media-callback-version-guard.md
+++ b/docs/dev-logs/2026-05-05-media-callback-version-guard.md
@@ -1,0 +1,11 @@
+# 2026-05-05 media callback event version guard 추가
+
+## 요약
+- `/api/v1/media/extract-audio/callback`에 `event_version` 기반 stale-event guard를 추가
+- 오래된 callback(`event_version <= last_event_version`)은 상태 갱신 없이 무시
+- shortform callback과 동일한 idempotency 패턴으로 media callback 정책 정합성 확보
+- 통합 테스트 `MediaCallbackVersionIntegrationTest` 추가 (FAILED→stale 무시→COMPLETED 전이 검증)
+
+## 검증
+- 로컬 Maven 테스트는 환경 제약으로 미실행
+  - `JAVA_HOME` 설정 후 `mvnw` 실행 시 wrapper 다운로드 네트워크 실패

--- a/docs/dev-logs/README.md
+++ b/docs/dev-logs/README.md
@@ -16,6 +16,7 @@
 - 로그는 `왜 바꿨는지`, `무엇을 바꿨는지`, `어떻게 검증했는지`만 짧게 적는다.
 
 ## 최신 로그
+- `2026-05-05-media-callback-version-guard.md`
 - `2026-05-05-dev-sync-lms-frontend-stability.md`
 - `2026-04-12-course-management-workspace-and-stepflow.md`
 - `2026-04-12-course-workspace-hub-and-auto-media.md`


### PR DESCRIPTION
﻿# 변경 요약
media extract callback에 event_version 기반 idempotency/stale-event guard를 추가해 중복/역순 콜백으로 인한 상태 오염을 방지했습니다.

## 배경
- shortform export callback에는 event_version 보호가 있었지만, media extract callback에는 동일 보호가 없어 오래된 콜백이 최신 상태를 덮어쓸 수 있었습니다.
- Spring phase3 T008(콜백 낙관적 버전/idempotency 가드) 항목을 media 경로까지 일관되게 확장할 필요가 있었습니다.

## 변경 내용
- `backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java`
  - `/api/v1/media/extract-audio/callback` 요청 본문을 record(`ExtractionCallbackRequest`)로 명시
  - `event_version` 파라미터 처리(기본값 1)
  - stale 이벤트 무시 시 `callback_ignored` 응답 및 안내 메시지 반환
- `backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java`
  - extraction 생성 시 `last_event_version` 초기값(0) 저장
  - `completeExtractionCallback` 시그니처 확장(`eventVersion` 추가)
  - `eventVersion <= last_event_version`이면 상태 갱신 없이 무시
- `backend-spring/src/test/java/com/myway/backendspring/integration/MediaCallbackVersionIntegrationTest.java`
  - FAILED(v2) 적용 → stale COMPLETED(v1) 무시 → COMPLETED(v3) 반영 시나리오 통합 테스트 추가
  - callback token 누락 시 403 유지 검증

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [ ] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 시 확인 포인트
- extraction callback의 stale event 무시 조건(`eventVersion <= last_event_version`)이 의도대로 동작하는지
- 기존 콜백 성공/실패 경로의 응답 호환성이 유지되는지
- media extraction 상태 저장 경로에서 version 필드가 누락되지 않는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
