### PR TITLE
test: restart-like persistence reload 통합 테스트 추가

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/integration/PersistenceReloadIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/PersistenceReloadIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.myway.backendspring.integration;
+
+import com.myway.backendspring.feature.FeatureStoreService;
+import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PersistenceReloadIntegrationTest {
+
+    @Autowired
+    private FeatureJdbcStore store;
+
+    @Test
+    void restartLikeServiceRecreation_shouldReloadPersistedAiAndMediaState() {
+        FeatureStoreService beforeRestart = new FeatureStoreService(store, 3);
+        String userId = "it-user-" + UUID.randomUUID();
+        String lectureId = "it-lecture-" + UUID.randomUUID();
+
+        beforeRestart.updateAiSettings(userId, Map.of(
+                "daily_limit", 42,
+                "provider", "gemini",
+                "model", "gemini-2.5-flash"
+        ));
+        Map<String, Object> extraction = beforeRestart.createExtraction(lectureId);
+        assertThat(extraction.get("id")).isNotNull();
+
+        FeatureStoreService afterRestart = new FeatureStoreService(store, 3);
+
+        Map<String, Object> aiSettings = afterRestart.aiSettings(userId);
+        assertThat(aiSettings.get("daily_limit")).isEqualTo(42);
+        assertThat(aiSettings.get("provider")).isEqualTo("gemini");
+        assertThat(aiSettings.get("model")).isEqualTo("gemini-2.5-flash");
+
+        Map<String, Object> pipeline = afterRestart.pipeline(lectureId);
+        assertThat(pipeline.get("status")).isEqualTo("READY");
+
+        Map<String, Object> transcript = afterRestart.transcript(lectureId);
+        assertThat(transcript).isNotNull();
+        assertThat(transcript.get("lecture_id")).isEqualTo(lectureId);
+
+        List<Map<String, Object>> extractions = afterRestart.extractions(lectureId);
+        assertThat(extractions).isNotEmpty();
+        assertThat(extractions)
+                .anySatisfy(row -> assertThat(row.get("id")).isEqualTo(extraction.get("id")));
+    }
+}


### PR DESCRIPTION
﻿# 변경 요약
Spring persistence 재시작 유사 시나리오에서 AI 설정/미디어 파이프라인 상태가 다시 로드되는지 검증하는 통합 테스트를 추가했습니다.

## 배경
- phase3 T011 항목(재시작 후 persisted state reload 검증)이 아직 테스트로 명시되지 않았습니다.
- 현재는 파일 기반 저장소를 사용하므로, 서비스 재생성(재기동 유사) 후 데이터 재조회가 되는지 자동 검증이 필요합니다.

## 변경 내용
- `backend-spring/src/test/java/com/myway/backendspring/integration/PersistenceReloadIntegrationTest.java` 추가
  - `FeatureStoreService` 인스턴스 A에서 AI 설정 업데이트 + extraction 생성
  - `FeatureStoreService` 인스턴스 B(재시작 유사)에서 아래 항목 재조회 검증
    - 사용자 AI 설정(`daily_limit/provider/model`)
    - lecture pipeline 상태(`READY`)
    - transcript 존재 및 lecture_id 일치
    - extraction 이벤트 재조회 가능 여부

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [ ] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 시 확인 포인트
- 테스트가 실제 "서비스 재생성 후 persisted state 재로딩"을 충분히 대변하는지
- phase3 T011 independent test 의도를 충족하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
