### PR TITLE
test: AI API 계약 테스트 확장 (#214)

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
@@ -104,13 +104,19 @@ class AiContractTest {
         mockMvc.perform(put("/api/v1/ai/settings")
                         .header("Authorization", authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"daily_limit\":0}"))
+                        .content("{\"daily_limit\":1}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/ai/intent")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"1차 호출\"}"))
                 .andExpect(status().isOk());
 
         assertFailureEnvelope(mockMvc.perform(post("/api/v1/ai/intent")
                         .header("Authorization", authHeader)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"쿼터 테스트\"}"))
+                        .content("{\"message\":\"2차 호출\"}"))
                         .andExpect(status().isTooManyRequests())
                         .andReturn(),
                 "DAILY_LIMIT_EXCEEDED");

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
@@ -29,6 +29,7 @@ class AiContractTest {
     @Test
     void aiEndpoints_shouldReturnSuccessEnvelope_whenAuthenticated() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+        setDailyLimit(authHeader, 999999);
 
         assertSuccessEnvelope(mockMvc.perform(get("/api/v1/ai/insights")
                         .header("Authorization", authHeader))
@@ -101,30 +102,31 @@ class AiContractTest {
     @Test
     void aiEndpoints_shouldReturnQuotaEnvelope_whenDailyLimitExceeded() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
-        mockMvc.perform(put("/api/v1/ai/settings")
-                        .header("Authorization", authHeader)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"daily_limit\":1}"))
-                .andExpect(status().isOk());
+        try {
+            setDailyLimit(authHeader, 1);
 
-        mockMvc.perform(post("/api/v1/ai/intent")
-                        .header("Authorization", authHeader)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"1차 호출\"}"))
-                .andExpect(status().isOk());
+            mockMvc.perform(post("/api/v1/ai/intent")
+                            .header("Authorization", authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"message\":\"1차 호출\"}"))
+                    .andExpect(status().isOk());
 
-        assertFailureEnvelope(mockMvc.perform(post("/api/v1/ai/intent")
-                        .header("Authorization", authHeader)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"2차 호출\"}"))
-                        .andExpect(status().isTooManyRequests())
-                        .andReturn(),
-                "DAILY_LIMIT_EXCEEDED");
+            assertFailureEnvelope(mockMvc.perform(post("/api/v1/ai/intent")
+                            .header("Authorization", authHeader)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"message\":\"2차 호출\"}"))
+                            .andExpect(status().isTooManyRequests())
+                            .andReturn(),
+                    "DAILY_LIMIT_EXCEEDED");
+        } finally {
+            setDailyLimit(authHeader, 999999);
+        }
     }
 
     @Test
     void aiEndpoints_shouldReturnNotFoundEnvelope_whenLectureOrCourseMissing() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+        setDailyLimit(authHeader, 999999);
 
         assertFailureEnvelope(mockMvc.perform(post("/api/v1/ai/summary")
                         .header("Authorization", authHeader)
@@ -152,6 +154,14 @@ class AiContractTest {
                 .getResponse()
                 .getContentAsString();
         return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+
+    private void setDailyLimit(String authHeader, int dailyLimit) throws Exception {
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"daily_limit\":" + dailyLimit + "}"))
+                .andExpect(status().isOk());
     }
 
     private void assertSuccessEnvelope(MvcResult result) throws Exception {

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
@@ -1,0 +1,166 @@
+package com.myway.backendspring.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AiContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void aiEndpoints_shouldReturnSuccessEnvelope_whenAuthenticated() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+
+        assertSuccessEnvelope(mockMvc.perform(get("/api/v1/ai/insights")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(get("/api/v1/ai/providers")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/ai/intent")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"다음 강의 추천해줘\",\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/ai/search")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"Spring\",\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/ai/answer")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"question\":\"REST API가 뭐야?\",\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/ai/summary")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"style\":\"brief\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/ai/quiz")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"요약해줘\",\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+    }
+
+    @Test
+    void aiEndpoints_shouldReturnUnauthenticatedEnvelope_whenUnauthorized() throws Exception {
+        assertFailureEnvelope(mockMvc.perform(get("/api/v1/ai/insights"))
+                        .andExpect(status().isUnauthorized())
+                        .andReturn(),
+                "UNAUTHENTICATED");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/ai/intent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"테스트\"}"))
+                        .andExpect(status().isUnauthorized())
+                        .andReturn(),
+                "UNAUTHENTICATED");
+    }
+
+    @Test
+    void aiEndpoints_shouldReturnQuotaEnvelope_whenDailyLimitExceeded() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"daily_limit\":0}"))
+                .andExpect(status().isOk());
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/ai/intent")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"쿼터 테스트\"}"))
+                        .andExpect(status().isTooManyRequests())
+                        .andReturn(),
+                "DAILY_LIMIT_EXCEEDED");
+    }
+
+    @Test
+    void aiEndpoints_shouldReturnNotFoundEnvelope_whenLectureOrCourseMissing() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/ai/summary")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_not_found\"}"))
+                        .andExpect(status().isNotFound())
+                        .andReturn(),
+                "LECTURE_NOT_FOUND");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"테스트\",\"course_id\":\"crs_not_found\"}"))
+                        .andExpect(status().isNotFound())
+                        .andReturn(),
+                "COURSE_NOT_FOUND");
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+
+    private void assertSuccessEnvelope(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isTrue();
+        assertThat(root.get("data")).isNotNull();
+        assertThat(root.path("error").isNull()).isTrue();
+        assertThat(root.has("message")).isTrue();
+    }
+
+    private void assertFailureEnvelope(MvcResult result, String expectedCode) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isFalse();
+        assertThat(root.path("data").isNull()).isTrue();
+        assertThat(root.path("error").path("code").asText()).isEqualTo(expectedCode);
+        assertThat(root.path("message").asText()).isNotBlank();
+    }
+}


### PR DESCRIPTION
﻿# 변경 요약
`/api/v1/ai/*` 전용 contract 테스트를 추가해 성공/실패 envelope와 인증·quota·not found 규약을 고정했습니다.

## 배경
- 기존 contract 테스트는 media/shortform 중심이라 AI 라우트 회귀를 포괄적으로 막기 어려웠습니다.
- 이슈 #214의 목표대로 AI API 계약 안정성을 우선 강화해야 했습니다.

## 변경 내용
- `backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java` 추가
  - 인증 성공 시 주요 AI 라우트 envelope 검증
    - `/ai/insights`, `/ai/providers`, `/ai/intent`, `/ai/search`, `/ai/answer`, `/ai/summary`, `/ai/quiz`, `/ai/rag`
  - 미인증 시 `401 + UNAUTHENTICATED` 검증
  - quota 초과 시 `429 + DAILY_LIMIT_EXCEEDED` 검증
  - 없는 강의/코스 요청 시 `404 + LECTURE_NOT_FOUND/COURSE_NOT_FOUND` 검증

## 연결 이슈
- Closes #214
- Fixes #214

## 검증
- [ ] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 시 확인 포인트
- AI 라우트별 envelope 규약이 기존 컨트랙트와 충돌하지 않는지
- quota/not found/unauthenticated 실패 코드가 API 정책과 일치하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다
