### PR TITLE
feat: LMS 전반 레퍼런스 스타일 UI 개편

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="https://img.shields.io/badge/TypeScript-5.8-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black" alt="React 19" />
   <img src="https://img.shields.io/badge/Vite-6-646CFF?logo=vite&logoColor=white" alt="Vite" />
-  <img src="https://img.shields.io/badge/Cloudflare_Workers-ready-F38020?logo=cloudflare&logoColor=white" alt="Cloudflare Workers" />
+  <img src="https://img.shields.io/badge/Spring_Boot-3.4-6DB33F?logo=springboot&logoColor=white" alt="Spring Boot" />
 </p>
 
 [English README](./README.en.md)
@@ -87,9 +87,9 @@
 | 구분 | 기술 |
 |------|------|
 | Frontend | React 19, TypeScript, Vite, Tailwind CSS |
-| Backend | Hono, TypeScript, Cloudflare Workers 계열 도구 |
+| Backend | Spring Boot (Java 21), Maven |
 | Shared | `packages/shared` 기반 공용 타입, 데이터, AI/LMS 로직 |
-| Build | npm workspaces, esbuild, wrangler, TypeScript |
+| Build | npm workspaces, Vite, Maven, TypeScript |
 | Media | `ffmpeg-static` 기반 미디어 처리 |
 
 ## 프로젝트 구조
@@ -144,24 +144,23 @@ npm run dev:backend
 ### 검증 및 빌드
 
 ```bash
-npm run verify
 npm run build
+npm run test:backend
 ```
 
-- `npm run verify`는 의존성 확인, 미디어 프로세서 타입 체크, 백엔드 빌드, 프론트엔드 타입 체크를 묶어서 검사합니다.
-- `npm run build`는 프론트엔드와 백엔드 빌드를 수행합니다.
+- `npm run build`는 프론트엔드 빌드 + Spring 백엔드 패키징을 수행합니다.
+- `npm run test:backend`는 Spring 백엔드 테스트를 실행합니다.
 
 ## 스크립트
 
 | 명령어 | 설명 |
 |------|------|
-| `npm run dev` | 전체 로컬 개발 실행 |
+| `npm run dev` | 프론트엔드 개발 서버 실행 |
 | `npm run dev:frontend` | 프론트엔드만 실행 |
-| `npm run dev:backend` | 백엔드만 실행 |
-| `npm run dev:media-processor` | 미디어 프로세서 번들 실행 |
+| `npm run dev:backend` | Spring 백엔드 실행 |
+| `npm run dev:backend:legacy` | 레거시(TypeScript) 백엔드 실행 |
 | `npm run build` | 프론트엔드 + 백엔드 빌드 |
-| `npm run verify` | 의존성, 타입, 빌드 검증 |
-| `npm run check:media-processor` | 미디어 프로세서 타입 체크 |
+| `npm run test:backend` | Spring 백엔드 테스트 |
 
 ## CI 운영
 

--- a/frontend/src/features/lms/components/AIChatComposer.tsx
+++ b/frontend/src/features/lms/components/AIChatComposer.tsx
@@ -1,4 +1,4 @@
-﻿type AIChatComposerProps = {
+type AIChatComposerProps = {
   value: string;
   onChange: (value: string) => void;
   onSubmit: () => void;
@@ -9,8 +9,8 @@
 
 export function AIChatComposer({ value, onChange, onSubmit, quickPrompts, onQuickPrompt, disabled = false }: AIChatComposerProps) {
   return (
-    <div className="border-t border-slate-200 px-5 py-4">
-      <div className="mb-3 flex items-center justify-between gap-3 text-[11px] text-slate-400">
+    <div className="border-t border-[#d8e8f6] bg-[linear-gradient(180deg,#ffffff_0%,#f7fbff_100%)] px-5 py-4">
+      <div className="mb-3 flex items-center justify-between gap-3 text-[11px] text-[#68829f]">
         <span>Enter로 전송, Shift+Enter로 줄바꿈</span>
         <span>질문은 짧게 적어도 됩니다.</span>
       </div>
@@ -20,7 +20,7 @@ export function AIChatComposer({ value, onChange, onSubmit, quickPrompts, onQuic
             key={prompt}
             type="button"
             onClick={() => onQuickPrompt(prompt)}
-            className="flex-shrink-0 rounded-full bg-slate-100 px-3 py-1.5 text-[12px] text-slate-600 hover:bg-slate-200"
+            className="flex-shrink-0 rounded-full border border-[#c9deef] bg-white px-3 py-1.5 text-[12px] text-[#355777] transition hover:border-[#9ad8f8] hover:text-[#00619b]"
           >
             {prompt}
           </button>
@@ -39,13 +39,13 @@ export function AIChatComposer({ value, onChange, onSubmit, quickPrompts, onQuic
           disabled={disabled}
           rows={2}
           placeholder="핵심 개념, 시험 대비, 이전 강의와 연결 같은 질문을 입력하세요..."
-          className="min-h-[56px] flex-1 resize-none rounded-[22px] border border-slate-200 bg-white px-4 py-3 text-[13px] leading-6 text-slate-700 outline-none transition focus:border-cyan-300 disabled:bg-slate-50"
+          className="min-h-[56px] flex-1 resize-none rounded-[22px] border border-[#cce0f2] bg-white px-4 py-3 text-[13px] leading-6 text-[#19344f] outline-none transition placeholder:text-[#7e94ad] focus:border-[#38c8f3] disabled:bg-slate-50"
         />
         <button
           type="button"
           onClick={onSubmit}
           disabled={disabled}
-          className="flex h-[56px] w-[56px] items-center justify-center rounded-[22px] bg-cyan-600 text-white transition hover:bg-cyan-500 disabled:opacity-50"
+          className="flex h-[56px] w-[56px] items-center justify-center rounded-[22px] bg-[linear-gradient(135deg,#00b8e6_0%,#0077b6_100%)] text-white shadow-[0_10px_24px_rgba(0,119,182,0.35)] transition hover:brightness-105 disabled:opacity-50"
         >
           <i className="ri-send-plane-fill" />
         </button>
@@ -53,4 +53,3 @@ export function AIChatComposer({ value, onChange, onSubmit, quickPrompts, onQuic
     </div>
   );
 }
-

--- a/frontend/src/features/lms/components/AIChatSidebar.tsx
+++ b/frontend/src/features/lms/components/AIChatSidebar.tsx
@@ -1,4 +1,4 @@
-﻿import type { AIInsights, LectureDetail } from '@myway/shared';
+import type { AIInsights, LectureDetail } from '@myway/shared';
 import type { AIRagResult } from '@myway/shared';
 
 type AIChatSidebarProps = {
@@ -25,7 +25,7 @@ export function AIChatSidebar({
 }: AIChatSidebarProps) {
   return (
     <aside className={`${openOnMobile ? 'block' : 'hidden'} lg:block`}>
-      <div className="rounded-[30px] border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm lg:sticky lg:top-6 lg:max-h-[calc(100vh-8rem)] lg:overflow-y-auto">
+      <div className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)] lg:sticky lg:top-6 lg:max-h-[calc(100vh-8rem)] lg:overflow-y-auto">
         <div className="flex items-center justify-between gap-3">
           <div>
             <h3 className="text-[15px] font-bold text-[var(--app-text)]">추천 질문</h3>
@@ -38,20 +38,20 @@ export function AIChatSidebar({
 
         <div className="mt-4 flex flex-wrap gap-2">
           {['핵심 개념 요약', '시험 대비 문제', '이전 강의와 연결', '숏폼으로 복습'].map((chip) => (
-            <span key={chip} className="rounded-full border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-3 py-1.5 text-[12px] text-[var(--app-text-secondary)]">
+            <span key={chip} className="rounded-full border border-[#cce0f2] bg-[#f4faff] px-3 py-1.5 text-[12px] text-[#355777]">
               {sanitizeDisplayText(chip)}
             </span>
           ))}
         </div>
 
         {insights ? (
-          <div className="mt-6 rounded-[24px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
+          <div className="mt-6 rounded-[24px] border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
             <div className="text-[12px] font-semibold text-[var(--app-text-muted)]">최근 AI 사용량</div>
             <div className="mt-2 text-[28px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{insights.summary.total_requests}</div>
           </div>
         ) : null}
 
-        <div className="mt-6 rounded-[24px] border border-[var(--app-border)] bg-white px-4 py-4">
+        <div className="mt-6 rounded-[24px] border border-[#dce9f7] bg-white px-4 py-4">
           <div className="flex items-center justify-between gap-3">
             <div>
               <div className="text-[12px] font-semibold text-[var(--app-text-muted)]">RAG 파이프라인</div>
@@ -60,7 +60,7 @@ export function AIChatSidebar({
               </div>
             </div>
             {ragOverview ? (
-              <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-[11px] font-semibold text-cyan-600">
+              <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-[11px] font-semibold text-cyan-700">
                 {sanitizeDisplayText(ragOverview.provider.search_provider)}
               </span>
             ) : null}
@@ -77,9 +77,9 @@ export function AIChatSidebar({
               <p className="mt-4 text-[12px] leading-5 text-[var(--app-text-secondary)]">{sanitizeDisplayText(ragOverview.answer.answer)}</p>
               <div className="mt-4 space-y-2">
                 {ragOverview.chunks.slice(0, 2).map((chunk) => (
-                  <div key={chunk.id} className="rounded-2xl border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-3 py-3">
+                  <div key={chunk.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-3 py-3">
                     <div className="flex items-center justify-between gap-2">
-                      <div className="text-[11px] font-semibold text-cyan-600">{sanitizeDisplayText(chunk.title)}</div>
+                      <div className="text-[11px] font-semibold text-cyan-700">{sanitizeDisplayText(chunk.title)}</div>
                       <div className="text-[11px] text-[var(--app-text-muted)]">{Math.round(chunk.similarity * 100)}%</div>
                     </div>
                     <p className="mt-1 text-[12px] leading-5 text-[var(--app-text-secondary)]">{sanitizeDisplayText(chunk.excerpt)}</p>
@@ -90,7 +90,7 @@ export function AIChatSidebar({
                 {ragOverview.entities.slice(0, 4).map((entity) => (
                   <span
                     key={`${entity.kind}-${entity.value}`}
-                    className="rounded-full border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] text-[var(--app-text-secondary)]"
+                    className="rounded-full border border-[#cce0f2] bg-[#f4faff] px-2.5 py-1 text-[11px] text-[#355777]"
                   >
                     {sanitizeDisplayText(entity.label)}: {sanitizeDisplayText(entity.value)}
                   </span>
@@ -107,4 +107,3 @@ export function AIChatSidebar({
     </aside>
   );
 }
-

--- a/frontend/src/features/lms/components/AIChatThread.tsx
+++ b/frontend/src/features/lms/components/AIChatThread.tsx
@@ -1,4 +1,4 @@
-﻿import type { AIReference, AIIntentResult } from '@myway/shared';
+import type { AIReference, AIIntentResult } from '@myway/shared';
 
 type ChatRole = 'assistant' | 'user';
 
@@ -31,22 +31,30 @@ export function AIChatThread({ messages, loading }: AIChatThreadProps) {
           <div key={message.id} className={`flex gap-3 ${isUser ? 'flex-row-reverse' : ''}`}>
             <div
               className={`mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full ${
-                isUser ? 'bg-cyan-600 text-white' : 'bg-[var(--app-surface-soft)] text-[var(--app-text-secondary)]'
+                isUser
+                  ? 'bg-[linear-gradient(135deg,#01bee8_0%,#0079b8_100%)] text-white'
+                  : 'bg-[linear-gradient(135deg,#f1f8ff_0%,#e9f4ff_100%)] text-[#1c3f60]'
               }`}
             >
               <i className={isUser ? 'ri-user-3-line' : 'ri-robot-2-line'} />
             </div>
-            <div className={`max-w-[85%] rounded-[22px] px-4 py-3 text-[13px] leading-6 ${isUser ? 'bg-cyan-600 text-white' : 'bg-[var(--app-surface-soft)] text-[var(--app-text-secondary)]'}`}>
+            <div
+              className={`max-w-[85%] rounded-[22px] px-4 py-3 text-[13px] leading-6 ${
+                isUser
+                  ? 'bg-[linear-gradient(135deg,#01bee8_0%,#0079b8_100%)] text-white'
+                  : 'border border-[#d7e6f5] bg-[linear-gradient(135deg,#ffffff_0%,#f3f9ff_100%)] text-[#1c3f60]'
+              }`}
+            >
               <p>{sanitizeDisplayText(message.content)}</p>
               {message.references?.length ? (
                 <div className="mt-3 space-y-2">
                   {message.references.slice(0, 3).map((reference) => (
-                    <div key={reference.id} className="rounded-xl bg-white/70 px-3 py-2 text-[11px] text-[var(--app-text-secondary)]">
+                    <div key={reference.id} className="rounded-xl border border-[#c9e0f2] bg-white/90 px-3 py-2 text-[11px] text-[#31516f]">
                       <div className="flex items-center justify-between gap-2">
-                        <span className="font-semibold text-cyan-600">{sanitizeDisplayText(reference.title)}</span>
-                        <span className="text-[var(--app-text-muted)]">{Math.round(reference.similarity * 100)}%</span>
+                        <span className="font-semibold text-[#0079b8]">{sanitizeDisplayText(reference.title)}</span>
+                        <span className="text-[#6988a7]">{Math.round(reference.similarity * 100)}%</span>
                       </div>
-                      <p className="mt-1 text-[var(--app-text-secondary)]">{sanitizeDisplayText(reference.excerpt)}</p>
+                      <p className="mt-1 text-[#3a5d7d]">{sanitizeDisplayText(reference.excerpt)}</p>
                     </div>
                   ))}
                 </div>
@@ -54,7 +62,10 @@ export function AIChatThread({ messages, loading }: AIChatThreadProps) {
               {message.suggestions?.length ? (
                 <div className="mt-3 flex flex-wrap gap-2">
                   {message.suggestions.slice(0, 4).map((suggestion) => (
-                    <span key={suggestion} className="rounded-full bg-white/70 px-2.5 py-1 text-[11px] text-[var(--app-text-secondary)]">
+                    <span
+                      key={suggestion}
+                      className="rounded-full border border-[#cae0f2] bg-white/90 px-2.5 py-1 text-[11px] text-[#31516f]"
+                    >
                       {sanitizeDisplayText(suggestion)}
                     </span>
                   ))}
@@ -67,10 +78,10 @@ export function AIChatThread({ messages, loading }: AIChatThreadProps) {
 
       {loading ? (
         <div className="flex gap-3">
-          <div className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-[var(--app-surface-soft)] text-[var(--app-text-muted)]">
+          <div className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-[#e6f4ff] text-[#5a7a99]">
             <i className="ri-robot-2-line" />
           </div>
-          <div className="max-w-[85%] rounded-[22px] bg-[var(--app-surface-soft)] px-4 py-4 text-[13px] text-[var(--app-text-muted)]">
+          <div className="max-w-[85%] rounded-[22px] border border-[#d7e6f5] bg-[linear-gradient(135deg,#ffffff_0%,#f3f9ff_100%)] px-4 py-4 text-[13px] text-[#5a7a99]">
             답변을 준비하고 있습니다...
           </div>
         </div>
@@ -78,4 +89,3 @@ export function AIChatThread({ messages, loading }: AIChatThreadProps) {
     </div>
   );
 }
-

--- a/frontend/src/features/lms/components/AdminFilterBar.tsx
+++ b/frontend/src/features/lms/components/AdminFilterBar.tsx
@@ -35,14 +35,14 @@ export function AdminFilterBar({
   chips,
 }: AdminFilterBarProps) {
   return (
-    <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+    <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <h2 className="text-[15px] font-bold text-slate-900">{title}</h2>
           <p className="mt-1 text-[12px] leading-6 text-slate-500">{subtitle}</p>
         </div>
 
-        <label className="flex min-w-[240px] items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-[12px] text-slate-500">
+        <label className="flex min-w-[240px] items-center gap-2 rounded-2xl border border-[#cce0f2] bg-[#f4faff] px-4 py-3 text-[12px] text-slate-500">
           <i className="ri-search-line text-slate-400" />
           <input
             className="w-full bg-transparent text-[13px] text-slate-900 outline-none placeholder:text-slate-400"
@@ -61,7 +61,7 @@ export function AdminFilterBar({
               type="button"
               onClick={chip.onSelect}
               className={`rounded-full px-3 py-1.5 text-[11px] font-semibold transition ${
-                chip.active ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                chip.active ? 'bg-cyan-600 text-white' : 'bg-[#f4faff] text-[#3e5d7b] hover:bg-cyan-50'
               }`}
             >
               {chip.label}
@@ -72,7 +72,7 @@ export function AdminFilterBar({
         <label className="flex items-center gap-2 text-[12px] font-medium text-slate-500">
           {sortLabel}
           <select
-            className="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-[12px] text-slate-900 outline-none"
+            className="rounded-2xl border border-[#cce0f2] bg-white px-3 py-2 text-[12px] text-slate-900 outline-none"
             value={sortValue}
             onChange={(event) => onSortChange(event.target.value)}
           >

--- a/frontend/src/features/lms/components/AdminStatsDistributionPanel.tsx
+++ b/frontend/src/features/lms/components/AdminStatsDistributionPanel.tsx
@@ -11,11 +11,11 @@ export function AdminStatsDistributionPanel({ aiLogs }: AdminStatsDistributionPa
 
   return (
     <section className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-      <article className="rounded-3xl border border-cyan-100 bg-white px-5 py-5 shadow-sm">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <h2 className="text-[15px] font-bold text-slate-900">Provider 분포</h2>
         <div className="mt-4 space-y-3">
           {providerStats.map((stat) => (
-            <div key={stat.key} className="rounded-2xl border border-cyan-100 bg-cyan-50/50 px-4 py-3">
+            <div key={stat.key} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-3">
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-[13px] font-semibold text-slate-900">{stat.label}</div>
@@ -33,11 +33,11 @@ export function AdminStatsDistributionPanel({ aiLogs }: AdminStatsDistributionPa
         </div>
       </article>
 
-      <article className="rounded-3xl border border-cyan-100 bg-white px-5 py-5 shadow-sm">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <h2 className="text-[15px] font-bold text-slate-900">Model 분포</h2>
         <div className="mt-4 space-y-3">
           {modelStats.map((stat) => (
-            <div key={stat.key} className="rounded-2xl border border-cyan-100 bg-cyan-50/50 px-4 py-3">
+            <div key={stat.key} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-3">
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-[13px] font-semibold text-slate-900">{stat.label}</div>

--- a/frontend/src/features/lms/components/AdminStatsLogPanel.tsx
+++ b/frontend/src/features/lms/components/AdminStatsLogPanel.tsx
@@ -11,12 +11,12 @@ export function AdminStatsLogPanel({ aiLogs }: AdminStatsLogPanelProps) {
 
   return (
     <section className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-      <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <h2 className="text-[15px] font-bold text-slate-900">인텐트 로그</h2>
         <div className="mt-4 space-y-3">
           {intentLogs.length > 0 ? (
             intentLogs.map((log) => (
-              <div key={log.id} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <div key={log.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-3">
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <div className="text-[13px] font-semibold text-slate-900">{log.detected_intent}</div>
@@ -37,12 +37,12 @@ export function AdminStatsLogPanel({ aiLogs }: AdminStatsLogPanelProps) {
         </div>
       </article>
 
-      <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <h2 className="text-[15px] font-bold text-slate-900">질문/답변 로그</h2>
         <div className="mt-4 space-y-3">
           {questionLogs.length > 0 ? (
             questionLogs.map((log) => (
-              <div key={log.id} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <div key={log.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-3">
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <div className="text-[13px] font-semibold text-slate-900">{log.question}</div>

--- a/frontend/src/features/lms/components/AdminStatsOperationalPanel.tsx
+++ b/frontend/src/features/lms/components/AdminStatsOperationalPanel.tsx
@@ -15,7 +15,7 @@ export function AdminStatsOperationalPanel({ courses, users, insights, aiLogs }:
 
   return (
     <section className="grid grid-cols-1 gap-4 xl:grid-cols-[1.2fr_0.8fr]">
-      <article className="rounded-3xl border border-cyan-100 bg-white px-5 py-5 shadow-sm">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <h2 className="text-[15px] font-bold text-slate-900">운영 현황</h2>
         <p className="mt-3 text-[13px] leading-7 text-slate-500">
           전체 {users.length}명 사용자 중 수강생, 교강사, 운영자가 함께 사용 중이며, 현재 등록된 강의는 {courses.length}개입니다.
@@ -24,19 +24,19 @@ export function AdminStatsOperationalPanel({ courses, users, insights, aiLogs }:
 
         {aiSummary ? (
           <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
-            <div className="rounded-2xl border border-cyan-100 bg-cyan-50/60 px-4 py-4">
+            <div className="rounded-2xl bg-[#f4faff] px-4 py-4">
               <div className="text-[12px] text-slate-500">성공률</div>
               <div className="mt-1 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">{aiSummary.success_rate}%</div>
             </div>
-            <div className="rounded-2xl border border-cyan-100 bg-cyan-50/60 px-4 py-4">
+            <div className="rounded-2xl bg-[#f4faff] px-4 py-4">
               <div className="text-[12px] text-slate-500">평균 지연시간</div>
               <div className="mt-1 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">{aiSummary.avg_latency_ms}ms</div>
             </div>
-            <div className="rounded-2xl border border-cyan-100 bg-cyan-50/60 px-4 py-4">
+            <div className="rounded-2xl bg-[#f4faff] px-4 py-4">
               <div className="text-[12px] text-slate-500">입력 토큰</div>
               <div className="mt-1 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">{formatTokenCount(aiSummary.total_input_tokens)}</div>
             </div>
-            <div className="rounded-2xl border border-cyan-100 bg-cyan-50/60 px-4 py-4">
+            <div className="rounded-2xl bg-[#f4faff] px-4 py-4">
               <div className="text-[12px] text-slate-500">대표 provider</div>
               <div className="mt-1 text-[18px] font-bold tracking-[-0.03em] text-slate-900">{aiSummary.top_provider}</div>
               <div className="mt-1 text-[11px] text-slate-500">대표 model: {aiSummary.top_model}</div>
@@ -45,12 +45,12 @@ export function AdminStatsOperationalPanel({ courses, users, insights, aiLogs }:
         ) : null}
       </article>
 
-      <article className="rounded-3xl border border-cyan-100 bg-white px-5 py-5 shadow-sm">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <h2 className="text-[15px] font-bold text-slate-900">최근 AI 호출</h2>
         <div className="mt-4 space-y-3">
           {usageLogs.length > 0 ? (
             usageLogs.map((log) => (
-              <div key={log.id} className="rounded-2xl border border-cyan-100 bg-cyan-50/50 px-4 py-3">
+              <div key={log.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-3">
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <div className="text-[13px] font-semibold text-slate-900">{log.feature}</div>

--- a/frontend/src/features/lms/components/AdminStatsOverviewCards.tsx
+++ b/frontend/src/features/lms/components/AdminStatsOverviewCards.tsx
@@ -15,19 +15,19 @@ export function AdminStatsOverviewCards({ dashboard, courses, users, insights, a
 
   return (
     <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-      <article className="rounded-3xl border border-cyan-100 bg-white px-5 py-5 shadow-sm">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-5 py-5 shadow-[0_10px_24px_rgba(6,31,57,0.08)]">
         <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{users.length}</div>
         <div className="mt-1 text-[12px] text-slate-500">전체 사용자</div>
       </article>
-      <article className="rounded-3xl border border-cyan-100 bg-white px-5 py-5 shadow-sm">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-5 py-5 shadow-[0_10px_24px_rgba(6,31,57,0.08)]">
         <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{courses.length}</div>
         <div className="mt-1 text-[12px] text-slate-500">전체 강의</div>
       </article>
-      <article className="rounded-3xl border border-cyan-100 bg-white px-5 py-5 shadow-sm">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-5 py-5 shadow-[0_10px_24px_rgba(6,31,57,0.08)]">
         <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{averageProgress}%</div>
         <div className="mt-1 text-[12px] text-slate-500">평균 진도</div>
       </article>
-      <article className="rounded-3xl border border-cyan-100 bg-white px-5 py-5 shadow-sm">
+      <article className="rounded-3xl border border-[#d6e6f5] bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-5 py-5 shadow-[0_10px_24px_rgba(6,31,57,0.08)]">
         <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{aiSummary?.total_requests ?? insights?.summary.total_requests ?? 0}</div>
         <div className="mt-1 text-[12px] text-slate-500">AI 요청 수</div>
       </article>

--- a/frontend/src/features/lms/components/AiNoticeBanner.tsx
+++ b/frontend/src/features/lms/components/AiNoticeBanner.tsx
@@ -6,27 +6,22 @@ type AiNoticeBannerProps = {
 };
 
 const TONE_CLASS: Record<NonNullable<AiNoticeBannerProps['tone']>, string> = {
-  slate: 'border-slate-200 bg-slate-50 text-slate-800',
-  indigo: 'border-cyan-100 bg-cyan-50 text-cyan-950',
-  amber: 'border-amber-100 bg-amber-50 text-amber-900',
-  rose: 'border-rose-100 bg-rose-50 text-rose-900',
-  emerald: 'border-emerald-100 bg-emerald-50 text-emerald-900',
+  slate: 'border-[#c9d8ea] bg-[linear-gradient(135deg,#f4f8fd_0%,#edf4fb_100%)] text-[#12324f]',
+  indigo: 'border-[#a8dcff] bg-[linear-gradient(135deg,#e8f8ff_0%,#d9f1ff_100%)] text-[#0d3554]',
+  amber: 'border-[#f2d6a0] bg-[linear-gradient(135deg,#fff8e8_0%,#ffefd1_100%)] text-[#6c4a13]',
+  rose: 'border-[#f7c2d8] bg-[linear-gradient(135deg,#fff1f7_0%,#ffe4f0_100%)] text-[#6d2247]',
+  emerald: 'border-[#aee9de] bg-[linear-gradient(135deg,#ebfffb_0%,#d6f8f1_100%)] text-[#0e4e43]',
 };
 
 export function AiNoticeBanner({ title, description, tone = 'indigo', meta }: AiNoticeBannerProps) {
   return (
-    <section className={`rounded-3xl border px-5 py-5 shadow-[0_4px_18px_rgba(15,23,42,0.05)] ${TONE_CLASS[tone]}`}>
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="max-w-3xl">
-          <div className="text-[11px] font-bold uppercase tracking-[0.12em] opacity-80">Learning Guidance</div>
-          <h3 className="mt-1 text-[15px] font-extrabold tracking-[-0.02em]">{title}</h3>
+    <section className={`rounded-[28px] border px-5 py-4 shadow-[0_14px_32px_rgba(6,24,44,0.08)] ${TONE_CLASS[tone]}`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[12px] font-semibold uppercase tracking-[0.08em] opacity-80">{title}</div>
           <p className="mt-2 text-[13px] leading-6 opacity-90">{description}</p>
         </div>
-        {meta ? (
-          <div className="rounded-xl border border-white/70 bg-white/75 px-3 py-2 text-[11px] font-semibold">
-            {meta}
-          </div>
-        ) : null}
+        {meta ? <div className="rounded-full bg-white/70 px-3 py-1 text-[11px] font-semibold">{meta}</div> : null}
       </div>
     </section>
   );

--- a/frontend/src/features/lms/components/AppHeader.tsx
+++ b/frontend/src/features/lms/components/AppHeader.tsx
@@ -7,25 +7,25 @@ type AppHeaderProps = {
 
 export function AppHeader({ title, theme, onToggleTheme, onOpenMobile }: AppHeaderProps) {
   return (
-    <header className="glass sticky top-0 z-10 border-b border-[var(--app-border)]">
+    <header className="sticky top-0 z-20 border-b border-cyan-100/25 bg-[linear-gradient(90deg,#113454,#174667_55%,#1b4f71)] text-cyan-50">
       <div className="mx-auto flex h-14 max-w-[1400px] items-center justify-between px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-3">
           <button
             type="button"
             onClick={onOpenMobile}
-            className="flex h-9 w-9 items-center justify-center rounded-xl text-[var(--app-text-muted)] transition-all hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95 lg:hidden"
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-cyan-100 transition-all hover:bg-white/10 hover:text-white active:scale-95 lg:hidden"
           >
             <i className="ri-menu-line text-lg" />
           </button>
           <div>
-            <h1 className="text-[15px] font-bold tracking-tight text-[var(--app-text)]">{title}</h1>
+            <h1 className="text-[15px] font-bold tracking-tight text-white">{title}</h1>
           </div>
         </div>
         <div className="flex items-center gap-2">
           <button
             type="button"
             title="알림"
-            className="relative flex h-9 w-9 items-center justify-center rounded-xl text-[var(--app-text-muted)] transition-all hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95"
+            className="relative flex h-9 w-9 items-center justify-center rounded-xl text-cyan-100 transition-all hover:bg-white/10 hover:text-white active:scale-95"
           >
             <i className="ri-notification-3-line text-[16px]" />
             <span className="absolute right-[5px] top-[5px] h-[7px] w-[7px] rounded-full border border-white bg-red-500" />
@@ -34,7 +34,7 @@ export function AppHeader({ title, theme, onToggleTheme, onOpenMobile }: AppHead
             type="button"
             onClick={onToggleTheme}
             title={theme === 'light' ? '다크 모드 전환' : '라이트 모드 전환'}
-            className="flex h-9 w-9 items-center justify-center rounded-xl text-[var(--app-text-muted)] transition-all hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95"
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-cyan-100 transition-all hover:bg-white/10 hover:text-white active:scale-95"
           >
             <i className={theme === 'light' ? 'ri-moon-line text-[16px]' : 'ri-sun-line text-[16px]'} />
           </button>

--- a/frontend/src/features/lms/components/AppHeader.tsx
+++ b/frontend/src/features/lms/components/AppHeader.tsx
@@ -7,25 +7,25 @@ type AppHeaderProps = {
 
 export function AppHeader({ title, theme, onToggleTheme, onOpenMobile }: AppHeaderProps) {
   return (
-    <header className="sticky top-0 z-10 border-b border-[var(--app-border)] bg-[var(--app-surface)]/95 backdrop-blur">
-      <div className="mx-auto flex h-16 max-w-[1400px] items-center justify-between px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center gap-2.5">
+    <header className="glass sticky top-0 z-10 border-b border-[var(--app-border)]">
+      <div className="mx-auto flex h-14 max-w-[1400px] items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-3">
           <button
             type="button"
             onClick={onOpenMobile}
-            className="flex h-10 w-10 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition-colors hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] lg:hidden"
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-[var(--app-text-muted)] transition-all hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95 lg:hidden"
           >
             <i className="ri-menu-line text-lg" />
           </button>
           <div>
-            <h1 className="text-[16px] font-semibold tracking-tight text-[var(--app-text)]">{title}</h1>
+            <h1 className="text-[15px] font-bold tracking-tight text-[var(--app-text)]">{title}</h1>
           </div>
         </div>
-        <div className="flex items-center gap-2.5">
+        <div className="flex items-center gap-2">
           <button
             type="button"
             title="알림"
-            className="relative flex h-10 w-10 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition-colors hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]"
+            className="relative flex h-9 w-9 items-center justify-center rounded-xl text-[var(--app-text-muted)] transition-all hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95"
           >
             <i className="ri-notification-3-line text-[16px]" />
             <span className="absolute right-[5px] top-[5px] h-[7px] w-[7px] rounded-full border border-white bg-red-500" />
@@ -34,7 +34,7 @@ export function AppHeader({ title, theme, onToggleTheme, onOpenMobile }: AppHead
             type="button"
             onClick={onToggleTheme}
             title={theme === 'light' ? '다크 모드 전환' : '라이트 모드 전환'}
-            className="flex h-10 w-10 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition-colors hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]"
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-[var(--app-text-muted)] transition-all hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] active:scale-95"
           >
             <i className={theme === 'light' ? 'ri-moon-line text-[16px]' : 'ri-sun-line text-[16px]'} />
           </button>

--- a/frontend/src/features/lms/components/AppShell.tsx
+++ b/frontend/src/features/lms/components/AppShell.tsx
@@ -32,6 +32,7 @@ function readStorageValue<T extends string>(key: string, allowed: readonly T[], 
 export function AppShell({ session, activePage, activeNavKey, title, onNavigate, onHome, onLogout, children }: AppShellProps) {
   const [theme, setTheme] = useState<ThemeMode>(() => readStorageValue(themeStorageKey, ['light', 'dark'], 'light'));
   const [dock, setDock] = useState<SidebarDock>(() => readStorageValue(dockStorageKey, ['left', 'right'], 'left'));
+  const [mobileOpen, setMobileOpen] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') {
       return false;
@@ -58,7 +59,7 @@ export function AppShell({ session, activePage, activeNavKey, title, onNavigate,
   const shellOffsetClass = dock === 'right' ? (collapsed ? 'lg:mr-20' : 'lg:mr-72') : (collapsed ? 'lg:ml-20' : 'lg:ml-72');
 
   return (
-    <div className="hero-pattern min-h-screen bg-[var(--app-bg)] text-[var(--app-text)]">
+    <div className="min-h-screen bg-[var(--app-bg)] text-[var(--app-text)]">
       <AppSidebar
         session={session}
         activePage={activePage}
@@ -83,7 +84,7 @@ export function AppShell({ session, activePage, activeNavKey, title, onNavigate,
           onToggleTheme={() => setTheme((current) => (current === 'light' ? 'dark' : 'light'))}
           onOpenMobile={() => setMobileOpen(true)}
         />
-        <main className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6 lg:px-8">
+        <main className="mx-auto max-w-[1280px] px-4 py-5 sm:px-6 lg:px-8">
           <div className="animate-fade-in">{children}</div>
         </main>
       </div>

--- a/frontend/src/features/lms/components/AppShell.tsx
+++ b/frontend/src/features/lms/components/AppShell.tsx
@@ -32,7 +32,6 @@ function readStorageValue<T extends string>(key: string, allowed: readonly T[], 
 export function AppShell({ session, activePage, activeNavKey, title, onNavigate, onHome, onLogout, children }: AppShellProps) {
   const [theme, setTheme] = useState<ThemeMode>(() => readStorageValue(themeStorageKey, ['light', 'dark'], 'light'));
   const [dock, setDock] = useState<SidebarDock>(() => readStorageValue(dockStorageKey, ['left', 'right'], 'left'));
-  const [mobileOpen, setMobileOpen] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') {
       return false;
@@ -59,7 +58,7 @@ export function AppShell({ session, activePage, activeNavKey, title, onNavigate,
   const shellOffsetClass = dock === 'right' ? (collapsed ? 'lg:mr-20' : 'lg:mr-72') : (collapsed ? 'lg:ml-20' : 'lg:ml-72');
 
   return (
-    <div className="min-h-screen bg-[var(--app-bg)] text-[var(--app-text)]">
+    <div className="hero-pattern min-h-screen bg-[var(--app-bg)] text-[var(--app-text)]">
       <AppSidebar
         session={session}
         activePage={activePage}
@@ -84,7 +83,7 @@ export function AppShell({ session, activePage, activeNavKey, title, onNavigate,
           onToggleTheme={() => setTheme((current) => (current === 'light' ? 'dark' : 'light'))}
           onOpenMobile={() => setMobileOpen(true)}
         />
-        <main className="mx-auto max-w-[1280px] px-4 py-6 sm:px-6 lg:px-8">
+        <main className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6 lg:px-8">
           <div className="animate-fade-in">{children}</div>
         </main>
       </div>

--- a/frontend/src/features/lms/components/AppShell.tsx
+++ b/frontend/src/features/lms/components/AppShell.tsx
@@ -57,6 +57,13 @@ export function AppShell({ session, activePage, activeNavKey, title, onNavigate,
 
   const sidebarWidthClass = collapsed ? 'lg:w-20' : 'lg:w-72';
   const shellOffsetClass = dock === 'right' ? (collapsed ? 'lg:mr-20' : 'lg:mr-72') : (collapsed ? 'lg:ml-20' : 'lg:ml-72');
+  const mobileTabs: Array<{ key: string; label: string; icon: string; page: LmsPageId }> = [
+    { key: 'home', label: '홈', icon: 'ri-home-5-line', page: 'home' },
+    { key: 'my-courses', label: '강의 탐색', icon: 'ri-book-open-line', page: 'my-courses' },
+    { key: 'ai-chat', label: 'AI 도구', icon: 'ri-robot-line', page: 'ai-chat' },
+    { key: 'dashboard', label: '내 학습', icon: 'ri-pie-chart-2-line', page: 'dashboard' },
+    { key: 'menu', label: '마이페이지', icon: 'ri-user-3-line', page: activePage },
+  ];
 
   return (
     <div className="min-h-screen bg-[var(--app-bg)] text-[var(--app-text)]">
@@ -84,9 +91,35 @@ export function AppShell({ session, activePage, activeNavKey, title, onNavigate,
           onToggleTheme={() => setTheme((current) => (current === 'light' ? 'dark' : 'light'))}
           onOpenMobile={() => setMobileOpen(true)}
         />
-        <main className="mx-auto max-w-[1280px] px-4 py-5 sm:px-6 lg:px-8">
+        <main className="mx-auto max-w-[1280px] px-4 py-5 pb-24 sm:px-6 lg:px-8 lg:pb-5">
           <div className="animate-fade-in">{children}</div>
         </main>
+        <nav className="fixed inset-x-0 bottom-0 z-20 border-t border-slate-200 bg-white/95 px-2 py-2 backdrop-blur lg:hidden">
+          <div className="mx-auto grid max-w-[560px] grid-cols-5 gap-1">
+            {mobileTabs.map((tab) => {
+              const active = tab.key === 'menu' ? mobileOpen : activePage === tab.page || activeNavKey === tab.key;
+              return (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => {
+                    if (tab.key === 'menu') {
+                      setMobileOpen(true);
+                      return;
+                    }
+                    onNavigate(tab.page);
+                  }}
+                  className={`flex flex-col items-center justify-center rounded-xl px-1 py-2 text-[10px] font-semibold transition ${
+                    active ? 'bg-cyan-50 text-cyan-700' : 'text-slate-500 hover:text-slate-700'
+                  }`}
+                >
+                  <i className={`${tab.icon} text-[18px]`} />
+                  <span className="mt-0.5">{tab.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </nav>
       </div>
     </div>
   );

--- a/frontend/src/features/lms/components/AppSidebar.tsx
+++ b/frontend/src/features/lms/components/AppSidebar.tsx
@@ -42,8 +42,8 @@ export function AppSidebar({
     session.user.role === 'ADMIN'
       ? 'bg-emerald-600'
       : session.user.role === 'INSTRUCTOR'
-        ? 'bg-teal-600'
-        : 'bg-cyan-600';
+        ? 'bg-violet-600'
+        : 'bg-indigo-600';
   const dockClass = dock === 'right' ? 'right-0 border-l border-r-0' : 'left-0 border-r border-l-0';
 
   const handleNavClick = (page: LmsPageId) => {
@@ -65,15 +65,15 @@ export function AppSidebar({
           className={`flex items-center gap-2.5 ${collapsed ? 'mx-auto' : ''}`}
           title="메인 화면으로 이동"
         >
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-cyan-500 to-teal-600 text-white shadow-md shadow-cyan-500/25">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 text-white shadow-md shadow-indigo-500/25">
             <i className="ri-play-circle-fill text-[18px]" />
           </div>
-          {!collapsed ? <span className="text-[15px] font-semibold tracking-tight text-[var(--app-text)]">내맘대로</span> : null}
+          {!collapsed ? <span className="text-[15px] font-extrabold tracking-tight text-[var(--app-text)]">내맘대로</span> : null}
         </button>
         <button
           type="button"
           onClick={onToggleCollapsed}
-          className="hidden h-10 w-10 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] lg:flex"
+          className="hidden h-8 w-8 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] lg:flex"
           title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
         >
           <i className={collapsed ? 'ri-arrow-right-s-line text-[17px]' : 'ri-arrow-left-s-line text-[17px]'} />
@@ -81,18 +81,18 @@ export function AppSidebar({
         <button
           type="button"
           onClick={onCloseMobile}
-          className="flex h-10 w-10 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] lg:hidden"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] lg:hidden"
           title="메뉴 닫기"
         >
           <i className="ri-close-line text-lg" />
         </button>
       </div>
 
-      <nav className={`flex-1 overflow-y-auto ${collapsed ? 'px-2.5' : 'px-3'} py-4`}>
+      <nav className={`flex-1 overflow-y-auto ${collapsed ? 'px-2' : 'px-3'} py-4`}>
         {groups.map((group) => (
           <div key={group.label} className="mb-5">
             {!collapsed ? (
-              <div className="mb-2 px-3 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--app-text-muted)]">
+              <div className="mb-2 px-3 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--app-text-muted)]">
                 {group.label}
               </div>
             ) : null}
@@ -105,7 +105,7 @@ export function AppSidebar({
                     type="button"
                     onClick={() => handleNavClick(item.page)}
                     title={collapsed ? item.label : undefined}
-                    className={`relative flex h-10 w-full items-center gap-2.5 rounded-lg px-3 text-left text-[13px] font-medium transition-all duration-150 ${
+                    className={`relative flex w-full items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-[13px] font-medium transition-all duration-150 ${
                       active
                         ? 'bg-[var(--app-accent-soft)] text-[var(--app-accent)] shadow-sm'
                         : 'text-[var(--app-text-secondary)] hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)]'
@@ -123,8 +123,8 @@ export function AppSidebar({
       </nav>
 
       <div className="border-t border-[var(--app-border)] px-3 py-3">
-        <div className={`flex items-center gap-2.5 rounded-lg px-3 py-2 ${collapsed ? 'justify-center' : ''}`}>
-          <div className={`flex h-10 w-10 items-center justify-center rounded-lg text-[13px] font-bold text-white shadow-sm ${avatarTone}`}>
+        <div className={`flex items-center gap-2.5 rounded-xl px-3 py-2.5 ${collapsed ? 'justify-center' : ''}`}>
+          <div className={`flex h-9 w-9 items-center justify-center rounded-xl text-[13px] font-bold text-white shadow-sm ${avatarTone}`}>
             {session.user.name[0]}
           </div>
           {!collapsed ? (
@@ -140,7 +140,7 @@ export function AppSidebar({
                 onLogout();
                 onCloseMobile();
               }}
-              className="flex h-10 w-10 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-red-500"
+              className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-red-500"
               title="로그아웃"
             >
               <i className="ri-logout-box-r-line text-[16px]" />
@@ -152,14 +152,14 @@ export function AppSidebar({
             <button
               type="button"
               onClick={onToggleDock}
-              className="h-10 flex-1 rounded-lg border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-3 text-[12px] font-medium text-[var(--app-text-secondary)] transition hover:bg-[var(--app-surface-hover)]"
+              className="flex-1 rounded-xl border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-3 py-2 text-[11px] font-semibold text-[var(--app-text-secondary)] transition hover:bg-[var(--app-surface-hover)]"
             >
               {dock === 'left' ? '오른쪽 고정' : '왼쪽 고정'}
             </button>
             <button
               type="button"
               onClick={onToggleTheme}
-              className="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--app-border)] bg-[var(--app-surface-soft)] text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-hover)] hover:text-[var(--app-text)]"
+              className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--app-border)] bg-[var(--app-surface-soft)] text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-hover)] hover:text-[var(--app-text)]"
               title={theme === 'light' ? '다크 모드' : '라이트 모드'}
             >
               <i className={theme === 'light' ? 'ri-moon-line text-[15px]' : 'ri-sun-line text-[15px]'} />
@@ -171,7 +171,7 @@ export function AppSidebar({
       <button
         type="button"
         onClick={onToggleCollapsed}
-        className="absolute right-3 top-[13px] hidden h-10 w-10 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] lg:flex"
+        className="absolute right-3 top-[15px] hidden h-8 w-8 items-center justify-center rounded-lg text-[var(--app-text-muted)] transition hover:bg-[var(--app-surface-soft)] hover:text-[var(--app-text)] lg:flex"
         title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
       >
         <i className={collapsed ? 'ri-arrow-right-s-line text-[17px]' : 'ri-arrow-left-s-line text-[17px]'} />

--- a/frontend/src/features/lms/components/ComparisonCardGrid.tsx
+++ b/frontend/src/features/lms/components/ComparisonCardGrid.tsx
@@ -18,16 +18,16 @@ type ComparisonCardGridProps = {
 };
 
 const toneClasses: Record<DashboardTone, { card: string; chip: string; accent: string }> = {
-  indigo: { card: 'bg-indigo-50 text-indigo-600', chip: 'bg-indigo-100 text-indigo-600', accent: 'text-indigo-700' },
+  indigo: { card: 'bg-cyan-50 text-cyan-700', chip: 'bg-cyan-100 text-cyan-700', accent: 'text-cyan-700' },
   emerald: { card: 'bg-emerald-50 text-emerald-600', chip: 'bg-emerald-100 text-emerald-600', accent: 'text-emerald-700' },
-  violet: { card: 'bg-violet-50 text-violet-600', chip: 'bg-violet-100 text-violet-600', accent: 'text-violet-700' },
+  violet: { card: 'bg-sky-50 text-sky-700', chip: 'bg-sky-100 text-sky-700', accent: 'text-sky-700' },
   amber: { card: 'bg-amber-50 text-amber-700', chip: 'bg-amber-100 text-amber-700', accent: 'text-amber-700' },
   slate: { card: 'bg-slate-50 text-slate-600', chip: 'bg-slate-100 text-slate-600', accent: 'text-slate-700' },
 };
 
 export function ComparisonCardGrid({ title, subtitle, metrics }: ComparisonCardGridProps) {
   return (
-    <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+    <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
       <div>
         <h2 className="text-[15px] font-bold text-slate-900">{title}</h2>
         <p className="mt-1 text-[12px] leading-6 text-slate-500">{subtitle}</p>
@@ -38,7 +38,7 @@ export function ComparisonCardGrid({ title, subtitle, metrics }: ComparisonCardG
           const tone = toneClasses[metric.tone];
 
           return (
-            <article key={metric.title} className="rounded-3xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+            <article key={metric.title} className="rounded-3xl border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <div className="text-[13px] font-semibold text-slate-900">{metric.title}</div>

--- a/frontend/src/features/lms/components/CourseExploreCard.tsx
+++ b/frontend/src/features/lms/components/CourseExploreCard.tsx
@@ -51,7 +51,13 @@ function formatDuration(minutes: number): string {
 }
 
 export function CourseExploreCard({ course, selected, onSelect, onOpen }: CourseExploreCardProps) {
-  const palette = paletteClasses[course.thumbnail_palette];
+  const palette = paletteClasses[course.thumbnail_palette] ?? paletteClasses.indigo;
+  const tags = Array.isArray(course.tags) ? course.tags : [];
+  const safeRating = Number.isFinite(course.rating) ? course.rating : 0;
+  const safeStudentCount = Number.isFinite(course.student_count) ? course.student_count : 0;
+  const safeDurationMinutes = Number.isFinite(course.total_duration_minutes) ? course.total_duration_minutes : 0;
+  const safeLectureCount = Number.isFinite(course.lecture_count) ? course.lecture_count : 0;
+  const safeProgressPercent = Number.isFinite(course.progress_percent) ? course.progress_percent : 0;
 
   return (
     <button
@@ -60,11 +66,11 @@ export function CourseExploreCard({ course, selected, onSelect, onOpen }: Course
         onSelect(course.id);
         onOpen?.(course.id);
       }}
-      className={`group overflow-hidden rounded-[28px] border bg-white text-left shadow-[0_1px_3px_rgba(15,23,42,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)] ${
+      className={`group overflow-hidden rounded-[24px] border bg-white text-left shadow-[0_1px_3px_rgba(15,23,42,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)] ${
         selected ? 'border-indigo-400 ring-2 ring-indigo-100' : 'border-[var(--app-border)]'
       }`}
     >
-      <div className={`relative flex h-36 flex-col justify-between px-5 py-4 text-white ${palette.panel}`}>
+      <div className={`relative flex h-32 flex-col justify-between px-5 py-4 text-white ${palette.panel}`}>
         <div className="absolute inset-0 opacity-15">
           <i className={`${palette.icon} absolute -right-4 -bottom-4 text-[104px]`} />
         </div>
@@ -75,7 +81,7 @@ export function CourseExploreCard({ course, selected, onSelect, onOpen }: Course
         <div className="relative z-10 flex items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="text-[13px] font-semibold opacity-90">{course.instructor_name}</div>
-            <div className="mt-1 line-clamp-2 text-[20px] font-extrabold tracking-[-0.03em]">{course.title}</div>
+            <div className="mt-1 line-clamp-2 text-[18px] font-extrabold">{course.title}</div>
           </div>
           <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-[24px]">
             <i className={palette.icon} />
@@ -85,30 +91,30 @@ export function CourseExploreCard({ course, selected, onSelect, onOpen }: Course
 
       <div className="px-5 py-4">
         <div className="mb-3 flex flex-wrap items-center gap-2">
-          <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${palette.chip}`}>{course.rating.toFixed(1)}점</span>
+          <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${palette.chip}`}>{safeRating.toFixed(1)}점</span>
           <span className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-semibold text-[var(--app-text-secondary)]">
-            수강생 {course.student_count}명
+            수강생 {safeStudentCount}명
           </span>
           <span className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-semibold text-[var(--app-text-secondary)]">
-            {formatDuration(course.total_duration_minutes)}
+            {formatDuration(safeDurationMinutes)}
           </span>
         </div>
 
         <div className="space-y-2">
           <div className="flex items-center justify-between text-[12px] text-[var(--app-text-secondary)]">
-            <span>{course.lecture_count}개 강의</span>
-            <span>{course.enrolled ? `${course.progress_percent}% 진행` : '수강 대기'}</span>
+            <span>{safeLectureCount}개 강의</span>
+            <span>{course.enrolled ? `${safeProgressPercent}% 진행` : '수강 대기'}</span>
           </div>
           <div className="h-2 overflow-hidden rounded-full bg-[var(--app-surface-soft)]">
-            <div className={`h-2 ${palette.line}`} style={{ width: `${Math.max(course.progress_percent, 12)}%` }} />
+            <div className={`h-2 ${palette.line}`} style={{ width: `${Math.max(safeProgressPercent, 12)}%` }} />
           </div>
         </div>
 
         <p className="mt-4 line-clamp-2 text-[13px] leading-6 text-[var(--app-text-secondary)]">{course.description}</p>
 
-        {course.tags.length > 0 ? (
+        {tags.length > 0 ? (
           <div className="mt-4 flex flex-wrap gap-2">
-            {course.tags.slice(0, 3).map((tag) => (
+            {tags.slice(0, 3).map((tag) => (
               <span key={tag} className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-medium text-[var(--app-text-secondary)]">
                 #{tag}
               </span>

--- a/frontend/src/features/lms/components/CourseExploreCard.tsx
+++ b/frontend/src/features/lms/components/CourseExploreCard.tsx
@@ -13,53 +13,45 @@ const difficultyLabel: Record<CourseCard['difficulty'], string> = {
   advanced: '고급',
 };
 
-const paletteClasses: Record<CourseCard['thumbnail_palette'], { panel: string; chip: string; line: string; icon: string; soft: string }> = {
+const paletteClasses: Record<CourseCard['thumbnail_palette'], { panel: string; chip: string; line: string; icon: string }> = {
   indigo: {
-    panel: 'bg-[linear-gradient(135deg,#2c3fcf,#1d4ed8)]',
-    chip: 'bg-indigo-50 text-indigo-700',
+    panel: 'bg-[linear-gradient(135deg,#4338ca,#1d4ed8)]',
+    chip: 'bg-indigo-50 text-indigo-600',
     line: 'bg-indigo-500',
     icon: 'ri-brain-line',
-    soft: 'bg-indigo-50/80',
   },
   emerald: {
-    panel: 'bg-[linear-gradient(135deg,#0f766e,#10b981)]',
-    chip: 'bg-emerald-50 text-emerald-700',
+    panel: 'bg-[linear-gradient(135deg,#047857,#10b981)]',
+    chip: 'bg-emerald-50 text-emerald-600',
     line: 'bg-emerald-500',
     icon: 'ri-layout-grid-line',
-    soft: 'bg-emerald-50/80',
   },
   violet: {
-    panel: 'bg-[linear-gradient(135deg,#4338ca,#7c3aed)]',
-    chip: 'bg-violet-50 text-violet-700',
+    panel: 'bg-[linear-gradient(135deg,#6d28d9,#8b5cf6)]',
+    chip: 'bg-violet-50 text-violet-600',
     line: 'bg-violet-500',
     icon: 'ri-video-line',
-    soft: 'bg-violet-50/80',
   },
   amber: {
     panel: 'bg-[linear-gradient(135deg,#b45309,#f59e0b)]',
-    chip: 'bg-amber-50 text-amber-800',
+    chip: 'bg-amber-50 text-amber-700',
     line: 'bg-amber-500',
     icon: 'ri-lightbulb-flash-line',
-    soft: 'bg-amber-50/80',
   },
 };
 
 function formatDuration(minutes: number): string {
-  if (minutes < 60) return `${minutes}분`;
+  if (minutes < 60) {
+    return `${minutes}분`;
+  }
+
   const hours = Math.floor(minutes / 60);
   const remain = minutes % 60;
   return remain > 0 ? `${hours}시간 ${remain}분` : `${hours}시간`;
 }
 
 export function CourseExploreCard({ course, selected, onSelect, onOpen }: CourseExploreCardProps) {
-  const palette = paletteClasses[course.thumbnail_palette] ?? paletteClasses.indigo;
-  const tags = Array.isArray(course.tags) ? course.tags : [];
-  const safeRating = typeof course.rating === 'number' && Number.isFinite(course.rating) ? course.rating : 0;
-  const safeStudentCount = typeof course.student_count === 'number' && Number.isFinite(course.student_count) ? course.student_count : 0;
-  const safeDuration = typeof course.total_duration_minutes === 'number' && Number.isFinite(course.total_duration_minutes) ? course.total_duration_minutes : 0;
-  const safeLectureCount = typeof course.lecture_count === 'number' && Number.isFinite(course.lecture_count) ? course.lecture_count : 0;
-  const safeProgress = typeof course.progress_percent === 'number' && Number.isFinite(course.progress_percent) ? course.progress_percent : 0;
-  const progressLabel = course.enrolled ? `${safeProgress}% 진행 중` : '아직 시작 전';
+  const palette = paletteClasses[course.thumbnail_palette];
 
   return (
     <button
@@ -68,25 +60,24 @@ export function CourseExploreCard({ course, selected, onSelect, onOpen }: Course
         onSelect(course.id);
         onOpen?.(course.id);
       }}
-      className={`group overflow-hidden rounded-[26px] border bg-white text-left shadow-[0_2px_8px_rgba(15,23,42,0.05)] transition duration-200 hover:-translate-y-1 hover:shadow-[0_18px_36px_rgba(15,23,42,0.10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 ${
-        selected ? 'border-cyan-500 ring-2 ring-cyan-100' : 'border-[var(--app-border)]'
+      className={`group overflow-hidden rounded-[28px] border bg-white text-left shadow-[0_1px_3px_rgba(15,23,42,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)] ${
+        selected ? 'border-indigo-400 ring-2 ring-indigo-100' : 'border-[var(--app-border)]'
       }`}
-      aria-label={`${course.title} 강의 상세 열기`}
     >
       <div className={`relative flex h-36 flex-col justify-between px-5 py-4 text-white ${palette.panel}`}>
         <div className="absolute inset-0 opacity-15">
           <i className={`${palette.icon} absolute -right-4 -bottom-4 text-[104px]`} />
         </div>
-        <div className="relative z-10 flex items-center justify-between gap-3 text-[11px] font-semibold opacity-95">
-          <span className="rounded-full bg-white/15 px-2 py-1">{course.category}</span>
-          <span className="rounded-full bg-white/15 px-2 py-1">{difficultyLabel[course.difficulty]}</span>
+        <div className="relative z-10 flex items-center justify-between gap-3 text-[11px] font-semibold opacity-90">
+          <span>{course.category}</span>
+          <span>{difficultyLabel[course.difficulty]}</span>
         </div>
-        <div className="relative z-10 flex items-end justify-between gap-3">
+        <div className="relative z-10 flex items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="text-[13px] font-semibold opacity-90">{course.instructor_name}</div>
-            <div className="mt-1 line-clamp-2 text-[20px] font-extrabold tracking-[-0.03em] leading-[1.2] sm:text-[22px]">{course.title}</div>
+            <div className="mt-1 line-clamp-2 text-[20px] font-extrabold tracking-[-0.03em]">{course.title}</div>
           </div>
-          <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl bg-white/15 text-[24px]">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-[24px]">
             <i className={palette.icon} />
           </div>
         </div>
@@ -94,37 +85,37 @@ export function CourseExploreCard({ course, selected, onSelect, onOpen }: Course
 
       <div className="px-5 py-4">
         <div className="mb-3 flex flex-wrap items-center gap-2">
-          <span className={`rounded-full px-2.5 py-1 text-[11px] font-bold ${palette.chip}`}>{safeRating.toFixed(1)}점</span>
-          <span className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-semibold text-[var(--app-text-secondary)]">수강생 {safeStudentCount}명</span>
-          <span className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-semibold text-[var(--app-text-secondary)]">{formatDuration(safeDuration)}</span>
+          <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${palette.chip}`}>{course.rating.toFixed(1)}점</span>
+          <span className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-semibold text-[var(--app-text-secondary)]">
+            수강생 {course.student_count}명
+          </span>
+          <span className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-semibold text-[var(--app-text-secondary)]">
+            {formatDuration(course.total_duration_minutes)}
+          </span>
         </div>
 
-        <div className={`rounded-xl border border-slate-200 px-3 py-3 ${palette.soft}`}>
-          <div className="flex items-center justify-between text-[12px] font-semibold text-[var(--app-text-secondary)]">
-            <span>{safeLectureCount}개 강의</span>
-            <span>{progressLabel}</span>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-[12px] text-[var(--app-text-secondary)]">
+            <span>{course.lecture_count}개 강의</span>
+            <span>{course.enrolled ? `${course.progress_percent}% 진행` : '수강 대기'}</span>
           </div>
-          <div className="mt-2 h-2 overflow-hidden rounded-full bg-white/90">
-            <div className={`h-2 ${palette.line}`} style={{ width: `${course.enrolled ? Math.max(safeProgress, 8) : 12}%` }} />
+          <div className="h-2 overflow-hidden rounded-full bg-[var(--app-surface-soft)]">
+            <div className={`h-2 ${palette.line}`} style={{ width: `${Math.max(course.progress_percent, 12)}%` }} />
           </div>
         </div>
 
         <p className="mt-4 line-clamp-2 text-[13px] leading-6 text-[var(--app-text-secondary)]">{course.description}</p>
 
-        {tags.length > 0 ? (
+        {course.tags.length > 0 ? (
           <div className="mt-4 flex flex-wrap gap-2">
-            {tags.slice(0, 3).map((tag) => (
-              <span key={tag} className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-medium text-[var(--app-text-secondary)]">#{tag}</span>
+            {course.tags.slice(0, 3).map((tag) => (
+              <span key={tag} className="rounded-full bg-[var(--app-surface-soft)] px-2.5 py-1 text-[11px] font-medium text-[var(--app-text-secondary)]">
+                #{tag}
+              </span>
             ))}
           </div>
         ) : null}
-
-        <div className="mt-4 flex min-h-11 items-center justify-between rounded-xl border border-slate-200 bg-white px-3 text-[12px] font-semibold text-slate-700 transition group-hover:border-cyan-200 group-hover:text-slate-900">
-          <span>강의 상세 보기</span>
-          <i className="ri-arrow-right-line text-[16px]" />
-        </div>
       </div>
     </button>
   );
 }
-

--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -23,6 +23,11 @@ const courseTabs: { key: '강의' | '공지' | '자료'; label: string; icon: st
   { key: '자료', label: '자료', icon: 'ri-folder-line' },
 ];
 
+const primaryButtonClass =
+  'rounded-xl bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500';
+const secondaryButtonClass =
+  'rounded-xl border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600';
+
 function formatDisplayDate(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -47,7 +52,8 @@ function formatDuration(minutes: number): string {
 }
 
 function renderNoticeList(course: CourseDetail) {
-  if (course.notices.length === 0) {
+  const notices = Array.isArray(course.notices) ? course.notices : [];
+  if (notices.length === 0) {
     return (
       <StatePanel
         compact
@@ -61,7 +67,7 @@ function renderNoticeList(course: CourseDetail) {
 
   return (
     <div className="space-y-2">
-      {course.notices.map((notice) => (
+      {notices.map((notice) => (
         <article key={notice.id} className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
           <div className="flex items-start gap-3">
             <i className={`${notice.pinned ? 'ri-pushpin-fill text-indigo-500' : 'ri-megaphone-line text-slate-400'} mt-0.5 flex-shrink-0`} />
@@ -81,7 +87,8 @@ function renderNoticeList(course: CourseDetail) {
 }
 
 function renderMaterialList(course: CourseDetail) {
-  if (course.materials.length === 0) {
+  const materials = Array.isArray(course.materials) ? course.materials : [];
+  if (materials.length === 0) {
     return (
       <StatePanel
         compact
@@ -95,7 +102,7 @@ function renderMaterialList(course: CourseDetail) {
 
   return (
     <div className="space-y-2">
-      {course.materials.map((material) => (
+      {materials.map((material) => (
         <article key={material.id} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-white text-[18px] text-indigo-500 shadow-sm">
@@ -131,6 +138,7 @@ export function CourseExploreDetailPanel({
   const detailLecture = highlightedLecture;
   const isLocked = Boolean(course && !course.enrolled && !canManageCurrent);
   const protectedVideoUrl = buildProtectedVideoUrl(detailLecture?.video_url, sessionToken);
+  const safeRating = Number.isFinite(course?.rating) ? course.rating : 0;
 
   return (
     <section className="overflow-hidden rounded-[30px] border border-[var(--app-border)] bg-white shadow-sm">
@@ -201,7 +209,7 @@ export function CourseExploreDetailPanel({
           </div>
           <div className="rounded-2xl bg-white px-4 py-4">
             <div className="text-[12px] text-[var(--app-text-muted)]">평점</div>
-            <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{course.rating.toFixed(1)}</div>
+            <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{safeRating.toFixed(1)}</div>
           </div>
           <div className="rounded-2xl bg-white px-4 py-4">
             <div className="text-[12px] text-[var(--app-text-muted)]">수강생</div>
@@ -276,14 +284,14 @@ export function CourseExploreDetailPanel({
                               <button
                                 type="button"
                                 onClick={() => course && onEnroll(course.id)}
-                                className="rounded-full bg-amber-500 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-amber-400"
+                                className={primaryButtonClass}
                               >
                                 수강 신청하기
                               </button>
                               <button
                                 type="button"
                                 onClick={() => onNavigate('my-courses')}
-                                className="rounded-full border border-amber-200 bg-white px-4 py-2 text-[12px] font-semibold text-amber-700 transition hover:bg-amber-100"
+                                className={secondaryButtonClass}
                               >
                                 내 강의로 이동
                               </button>
@@ -307,7 +315,7 @@ export function CourseExploreDetailPanel({
                               <button
                                 type="button"
                                 onClick={() => course && onEnroll(course.id)}
-                                className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                                className={primaryButtonClass}
                               >
                                 수강 신청하기
                               </button>
@@ -316,14 +324,14 @@ export function CourseExploreDetailPanel({
                                 <button
                                   type="button"
                                   onClick={() => onNavigate('courses')}
-                                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
+                                  className={secondaryButtonClass}
                                 >
                                   강의 상세로 돌아가기
                                 </button>
                                 <button
                                   type="button"
                                   onClick={() => onNavigate('shortform')}
-                                  className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                                  className={primaryButtonClass}
                                 >
                                   숏폼 만들기
                                 </button>
@@ -331,7 +339,7 @@ export function CourseExploreDetailPanel({
                                   <button
                                     type="button"
                                     onClick={() => onNavigate('media-pipeline')}
-                                    className="rounded-full border border-indigo-200 bg-indigo-50 px-4 py-2 text-[12px] font-semibold text-indigo-700 transition hover:bg-indigo-100"
+                                    className={secondaryButtonClass}
                                   >
                                     업로드/전사 관리
                                   </button>
@@ -345,7 +353,7 @@ export function CourseExploreDetailPanel({
                               <button
                                 type="button"
                                 onClick={() => course && onEnroll(course.id)}
-                                className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                                className={primaryButtonClass}
                               >
                                 수강 신청하기
                               </button>
@@ -357,14 +365,14 @@ export function CourseExploreDetailPanel({
                                     onSelectLecture(detailLecture.id);
                                     onNavigate('lecture-watch');
                                   }}
-                                  className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                                  className={primaryButtonClass}
                                 >
                                   강의 시청으로 이동
                                 </button>
                                 <button
                                   type="button"
                                   onClick={() => onNavigate('ai-chat')}
-                                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
+                                  className={secondaryButtonClass}
                                 >
                                   챗봇으로 질문
                                 </button>
@@ -404,7 +412,7 @@ export function CourseExploreDetailPanel({
                       <button
                         type="button"
                         onClick={() => course && onEnroll(course.id)}
-                        className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                        className={primaryButtonClass}
                       >
                         수강 신청하기
                       </button>
@@ -413,14 +421,14 @@ export function CourseExploreDetailPanel({
                         <button
                           type="button"
                           onClick={() => onNavigate('ai-chat')}
-                          className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                          className={primaryButtonClass}
                         >
                           AI 챗봇으로 질문하기
                         </button>
                         <button
                           type="button"
                           onClick={() => onNavigate('lecture-watch')}
-                          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
+                          className={secondaryButtonClass}
                         >
                           강의 시청으로 이동
                         </button>

--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -23,11 +23,6 @@ const courseTabs: { key: '강의' | '공지' | '자료'; label: string; icon: st
   { key: '자료', label: '자료', icon: 'ri-folder-line' },
 ];
 
-const primaryButtonClass =
-  'inline-flex min-h-11 items-center rounded-xl bg-cyan-600 px-4 text-[12px] font-semibold text-white transition hover:bg-cyan-500';
-const secondaryButtonClass =
-  'inline-flex min-h-11 items-center rounded-xl border border-slate-200 bg-white px-4 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-700';
-
 function formatDisplayDate(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -52,8 +47,7 @@ function formatDuration(minutes: number): string {
 }
 
 function renderNoticeList(course: CourseDetail) {
-  const notices = Array.isArray(course.notices) ? course.notices : [];
-  if (notices.length === 0) {
+  if (course.notices.length === 0) {
     return (
       <StatePanel
         compact
@@ -67,14 +61,14 @@ function renderNoticeList(course: CourseDetail) {
 
   return (
     <div className="space-y-2">
-      {notices.map((notice) => (
+      {course.notices.map((notice) => (
         <article key={notice.id} className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
           <div className="flex items-start gap-3">
-            <i className={`${notice.pinned ? 'ri-pushpin-fill text-cyan-600' : 'ri-megaphone-line text-slate-400'} mt-0.5 flex-shrink-0`} />
+            <i className={`${notice.pinned ? 'ri-pushpin-fill text-indigo-500' : 'ri-megaphone-line text-slate-400'} mt-0.5 flex-shrink-0`} />
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
                 <p className="text-[13px] font-semibold text-slate-900">{notice.title}</p>
-                {notice.pinned ? <span className="rounded-full bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-700">고정</span> : null}
+                {notice.pinned ? <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-medium text-indigo-600">고정</span> : null}
               </div>
               <p className="mt-1 whitespace-pre-line text-[12px] leading-6 text-slate-500">{notice.content}</p>
               <p className="mt-2 text-[11px] text-slate-400">{formatDisplayDate(notice.created_at)}</p>
@@ -87,8 +81,7 @@ function renderNoticeList(course: CourseDetail) {
 }
 
 function renderMaterialList(course: CourseDetail) {
-  const materials = Array.isArray(course.materials) ? course.materials : [];
-  if (materials.length === 0) {
+  if (course.materials.length === 0) {
     return (
       <StatePanel
         compact
@@ -102,10 +95,10 @@ function renderMaterialList(course: CourseDetail) {
 
   return (
     <div className="space-y-2">
-      {materials.map((material) => (
+      {course.materials.map((material) => (
         <article key={material.id} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-white text-[18px] text-cyan-600 shadow-sm">
+            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-white text-[18px] text-indigo-500 shadow-sm">
               <i className="ri-file-pdf-2-line" />
             </div>
             <div className="min-w-0 flex-1">
@@ -138,12 +131,11 @@ export function CourseExploreDetailPanel({
   const detailLecture = highlightedLecture;
   const isLocked = Boolean(course && !course.enrolled && !canManageCurrent);
   const protectedVideoUrl = buildProtectedVideoUrl(detailLecture?.video_url, sessionToken);
-  const safeRating = Number.isFinite(course?.rating) ? course.rating : 0;
 
   return (
-    <section className="overflow-hidden rounded-[28px] border border-[var(--app-border)] bg-white shadow-sm">
+    <section className="overflow-hidden rounded-[30px] border border-[var(--app-border)] bg-white shadow-sm">
       {course ? (
-        <div className="bg-[linear-gradient(135deg,#082f49_0%,#0f766e_52%,#1f2937_100%)] px-5 py-5 text-white">
+        <div className="bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-5 py-5 text-white">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold opacity-90">
@@ -152,7 +144,7 @@ export function CourseExploreDetailPanel({
                   {course.difficulty === 'beginner' ? '입문' : course.difficulty === 'intermediate' ? '중급' : '고급'}
                 </span>
               </div>
-              <h1 className="mt-3 text-[24px] font-extrabold tracking-[-0.03em]">{course.title}</h1>
+              <h1 className="mt-3 text-[24px] font-extrabold tracking-[-0.04em]">{course.title}</h1>
               <p className="mt-2 text-[13px] leading-6 text-white/80">{course.description}</p>
               <div className="mt-4 flex flex-wrap items-center gap-3 text-[12px] text-white/80">
                 <span>{course.instructor_name}</span>
@@ -165,7 +157,7 @@ export function CourseExploreDetailPanel({
               </div>
             </div>
 
-            <div className="flex-shrink-0 rounded-3xl border border-white/20 bg-white/10 px-4 py-4 text-center backdrop-blur">
+            <div className="flex-shrink-0 rounded-3xl bg-white/10 px-4 py-4 text-center backdrop-blur">
               <div className="relative mx-auto flex h-16 w-16 items-center justify-center rounded-full border border-white/20 bg-white/5">
                 <svg className="h-16 w-16 -rotate-90" viewBox="0 0 36 36">
                   <circle cx="18" cy="18" r="16" fill="none" stroke="rgba(255,255,255,0.2)" strokeWidth="2.5" />
@@ -198,7 +190,7 @@ export function CourseExploreDetailPanel({
       )}
 
       {course ? (
-        <div className="grid grid-cols-2 gap-2.5 border-t border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-4 text-[var(--app-text)] md:grid-cols-4">
+        <div className="grid grid-cols-2 gap-3 border-t border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-5 text-[var(--app-text)] md:grid-cols-4">
           <div className="rounded-2xl bg-white px-4 py-4">
             <div className="text-[12px] text-[var(--app-text-muted)]">총 강의 수</div>
             <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{course.lecture_count}</div>
@@ -209,7 +201,7 @@ export function CourseExploreDetailPanel({
           </div>
           <div className="rounded-2xl bg-white px-4 py-4">
             <div className="text-[12px] text-[var(--app-text-muted)]">평점</div>
-            <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{safeRating.toFixed(1)}</div>
+            <div className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{course.rating.toFixed(1)}</div>
           </div>
           <div className="rounded-2xl bg-white px-4 py-4">
             <div className="text-[12px] text-[var(--app-text-muted)]">수강생</div>
@@ -221,7 +213,7 @@ export function CourseExploreDetailPanel({
       <div className="px-5 py-5">
         {course ? (
           <>
-            <div className="inline-flex rounded-xl border border-slate-200 bg-slate-50 p-1">
+            <div className="flex gap-1 overflow-x-auto border-b border-[var(--app-border)] pb-0.5">
               {courseTabs.map((tab) => {
                 const active = activeTab === tab.key;
                 return (
@@ -229,10 +221,9 @@ export function CourseExploreDetailPanel({
                     key={tab.key}
                     type="button"
                     onClick={() => onTabChange(tab.key)}
-                    className={`flex min-h-10 items-center gap-2 whitespace-nowrap rounded-lg px-3 text-[13px] font-semibold transition-colors ${
-                      active ? 'bg-white text-slate-900 shadow-sm' : 'text-[var(--app-text-muted)] hover:text-[var(--app-text-secondary)]'
+                    className={`flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 text-sm transition-colors ${
+                      active ? 'border-indigo-500 text-[var(--app-text)]' : 'border-transparent text-[var(--app-text-muted)] hover:border-slate-300 hover:text-[var(--app-text-secondary)]'
                     }`}
-                    aria-pressed={active}
                   >
                     <i className={`${tab.icon} text-[15px]`} />
                     {tab.label}
@@ -267,7 +258,7 @@ export function CourseExploreDetailPanel({
                             <span>{formatDuration(getLectureDisplayDurationMinutes(detailLecture))}</span>
                           </div>
                         </div>
-                        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-white text-[18px] text-cyan-600 shadow-sm">
+                        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-white text-[18px] text-indigo-500 shadow-sm">
                           <i className="ri-play-circle-line" />
                         </div>
                       </div>
@@ -285,14 +276,14 @@ export function CourseExploreDetailPanel({
                               <button
                                 type="button"
                                 onClick={() => course && onEnroll(course.id)}
-                                className={primaryButtonClass}
+                                className="rounded-full bg-amber-500 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-amber-400"
                               >
                                 수강 신청하기
                               </button>
                               <button
                                 type="button"
                                 onClick={() => onNavigate('my-courses')}
-                                className={secondaryButtonClass}
+                                className="rounded-full border border-amber-200 bg-white px-4 py-2 text-[12px] font-semibold text-amber-700 transition hover:bg-amber-100"
                               >
                                 내 강의로 이동
                               </button>
@@ -316,7 +307,7 @@ export function CourseExploreDetailPanel({
                               <button
                                 type="button"
                                 onClick={() => course && onEnroll(course.id)}
-                                className={primaryButtonClass}
+                                className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                               >
                                 수강 신청하기
                               </button>
@@ -324,23 +315,23 @@ export function CourseExploreDetailPanel({
                               <>
                                 <button
                                   type="button"
-                                  onClick={() => onNavigate('shortform')}
-                                  className={primaryButtonClass}
+                                  onClick={() => onNavigate('courses')}
+                                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
                                 >
-                                  숏폼 만들기
+                                  강의 상세로 돌아가기
                                 </button>
                                 <button
                                   type="button"
-                                  onClick={() => onNavigate('courses')}
-                                  className={secondaryButtonClass}
+                                  onClick={() => onNavigate('shortform')}
+                                  className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                                 >
-                                  강의 상세로 돌아가기
+                                  숏폼 만들기
                                 </button>
                                 {canManageCurrent ? (
                                   <button
                                     type="button"
                                     onClick={() => onNavigate('media-pipeline')}
-                                    className={secondaryButtonClass}
+                                    className="rounded-full border border-indigo-200 bg-indigo-50 px-4 py-2 text-[12px] font-semibold text-indigo-700 transition hover:bg-indigo-100"
                                   >
                                     업로드/전사 관리
                                   </button>
@@ -354,7 +345,7 @@ export function CourseExploreDetailPanel({
                               <button
                                 type="button"
                                 onClick={() => course && onEnroll(course.id)}
-                                className={primaryButtonClass}
+                                className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                               >
                                 수강 신청하기
                               </button>
@@ -366,11 +357,15 @@ export function CourseExploreDetailPanel({
                                     onSelectLecture(detailLecture.id);
                                     onNavigate('lecture-watch');
                                   }}
-                                  className={primaryButtonClass}
+                                  className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                                 >
                                   강의 시청으로 이동
                                 </button>
-                                <button type="button" onClick={() => onNavigate('ai-chat')} className={secondaryButtonClass}>
+                                <button
+                                  type="button"
+                                  onClick={() => onNavigate('ai-chat')}
+                                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:bg-slate-50"
+                                >
                                   챗봇으로 질문
                                 </button>
                               </>
@@ -409,7 +404,7 @@ export function CourseExploreDetailPanel({
                       <button
                         type="button"
                         onClick={() => course && onEnroll(course.id)}
-                        className={primaryButtonClass}
+                        className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                       >
                         수강 신청하기
                       </button>
@@ -418,14 +413,14 @@ export function CourseExploreDetailPanel({
                         <button
                           type="button"
                           onClick={() => onNavigate('ai-chat')}
-                          className={primaryButtonClass}
+                          className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                         >
                           AI 챗봇으로 질문하기
                         </button>
                         <button
                           type="button"
                           onClick={() => onNavigate('lecture-watch')}
-                          className={secondaryButtonClass}
+                          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
                         >
                           강의 시청으로 이동
                         </button>

--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -24,9 +24,9 @@ const courseTabs: { key: '강의' | '공지' | '자료'; label: string; icon: st
 ];
 
 const primaryButtonClass =
-  'rounded-xl bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500';
+  'rounded-xl bg-cyan-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-cyan-500';
 const secondaryButtonClass =
-  'rounded-xl border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600';
+  'rounded-xl border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-700';
 
 function formatDisplayDate(value: string): string {
   const date = new Date(value);
@@ -66,19 +66,27 @@ function renderNoticeList(course: CourseDetail) {
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
+      <div className="rounded-2xl border border-cyan-200/30 bg-cyan-50/70 px-4 py-3">
+        <div className="text-[12px] font-semibold text-cyan-800">공지 요약</div>
+        <div className="mt-1 text-[12px] text-cyan-700">총 {notices.length}건 · 중요 공지는 상단 고정되어 먼저 보입니다.</div>
+      </div>
       {notices.map((notice) => (
         <article key={notice.id} className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
-          <div className="flex items-start gap-3">
-            <i className={`${notice.pinned ? 'ri-pushpin-fill text-indigo-500' : 'ri-megaphone-line text-slate-400'} mt-0.5 flex-shrink-0`} />
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <p className="text-[13px] font-semibold text-slate-900">{notice.title}</p>
-                {notice.pinned ? <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-medium text-indigo-600">고정</span> : null}
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 flex-1 items-start gap-3">
+              <div className={`mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${notice.pinned ? 'bg-cyan-100 text-cyan-700' : 'bg-slate-100 text-slate-500'}`}>
+                <i className={notice.pinned ? 'ri-pushpin-fill' : 'ri-megaphone-line'} />
               </div>
-              <p className="mt-1 whitespace-pre-line text-[12px] leading-6 text-slate-500">{notice.content}</p>
-              <p className="mt-2 text-[11px] text-slate-400">{formatDisplayDate(notice.created_at)}</p>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-[14px] font-semibold text-slate-900">{notice.title}</p>
+                  {notice.pinned ? <span className="rounded-full bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-700">고정</span> : null}
+                </div>
+                <p className="mt-2 whitespace-pre-line text-[12px] leading-6 text-slate-500">{notice.content}</p>
+              </div>
             </div>
+            <div className="flex-shrink-0 text-[11px] text-slate-400">{formatDisplayDate(notice.created_at)}</div>
           </div>
         </article>
       ))}
@@ -101,19 +109,29 @@ function renderMaterialList(course: CourseDetail) {
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
+      <div className="rounded-2xl border border-cyan-200/30 bg-cyan-50/70 px-4 py-3">
+        <div className="text-[12px] font-semibold text-cyan-800">자료실</div>
+        <div className="mt-1 text-[12px] text-cyan-700">총 {materials.length}건 · 파일명과 업로드일을 기준으로 빠르게 찾을 수 있습니다.</div>
+      </div>
       {materials.map((material) => (
         <article key={material.id} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-white text-[18px] text-indigo-500 shadow-sm">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-white text-[18px] text-cyan-700 shadow-sm">
               <i className="ri-file-pdf-2-line" />
             </div>
             <div className="min-w-0 flex-1">
-              <p className="truncate text-[13px] font-semibold text-slate-900">{material.title}</p>
-              <p className="mt-1 text-[12px] leading-6 text-slate-500">{material.summary}</p>
-              <p className="mt-1 text-[11px] text-slate-400">
-                {material.file_name} · {formatDisplayDate(material.uploaded_at)}
-              </p>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="truncate text-[13px] font-semibold text-slate-900">{material.title}</p>
+                <span className="text-[11px] text-slate-400">{formatDisplayDate(material.uploaded_at)}</span>
+              </div>
+              <p className="mt-1 text-[11px] font-medium text-cyan-700">{material.file_name}</p>
+              <p className="mt-2 text-[12px] leading-6 text-slate-500">{material.summary}</p>
+              <div className="mt-3">
+                <button type="button" className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700">
+                  자료 보기
+                </button>
+              </div>
             </div>
           </div>
         </article>
@@ -143,7 +161,7 @@ export function CourseExploreDetailPanel({
   return (
     <section className="overflow-hidden rounded-[30px] border border-[var(--app-border)] bg-white shadow-sm">
       {course ? (
-        <div className="bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-5 py-5 text-white">
+        <div className="bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-5 py-5 text-white">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold opacity-90">
@@ -230,7 +248,7 @@ export function CourseExploreDetailPanel({
                     type="button"
                     onClick={() => onTabChange(tab.key)}
                     className={`flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 text-sm transition-colors ${
-                      active ? 'border-indigo-500 text-[var(--app-text)]' : 'border-transparent text-[var(--app-text-muted)] hover:border-slate-300 hover:text-[var(--app-text-secondary)]'
+                      active ? 'border-cyan-500 text-[var(--app-text)]' : 'border-transparent text-[var(--app-text-muted)] hover:border-slate-300 hover:text-[var(--app-text-secondary)]'
                     }`}
                   >
                     <i className={`${tab.icon} text-[15px]`} />

--- a/frontend/src/features/lms/components/CourseExploreFilters.tsx
+++ b/frontend/src/features/lms/components/CourseExploreFilters.tsx
@@ -27,18 +27,17 @@ export function CourseExploreFilters({
   onStatusChange,
   resultCount,
 }: CourseExploreFiltersProps) {
-  const uniqueCategories = [...new Set(categories.filter((category) => typeof category === 'string' && category.trim().length > 0))];
-  const selectedCount = (activeCategory ? 1 : 0) + (activeStatus === 'all' ? 0 : 1);
+  const uniqueCategories = [...new Set(categories.filter((category) => category.trim().length > 0))];
 
   return (
-    <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_6px_24px_rgba(15,23,42,0.05)]">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <section className="rounded-[26px] border border-slate-200 bg-white px-5 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.05)]">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <div className="text-[12px] font-semibold text-slate-900">카테고리와 상태로 빠르게 거르기</div>
-          <p className="mt-1 text-[12px] text-slate-500">검색 결과 {resultCount}개 · 적용된 필터 {selectedCount}개</p>
+          <p className="mt-1 text-[12px] text-slate-500">검색 결과 {resultCount}개 · 강의 탐색 기준을 레퍼런스처럼 위에 모았습니다.</p>
         </div>
 
-        <div className="inline-flex rounded-xl border border-slate-200 bg-slate-50 p-1">
+        <div className="flex flex-wrap gap-2">
           {statusTabs.map((tab) => {
             const active = activeStatus === tab.key;
             return (
@@ -46,10 +45,9 @@ export function CourseExploreFilters({
                 key={tab.key}
                 type="button"
                 onClick={() => onStatusChange(tab.key)}
-                className={`min-h-9 rounded-lg px-3.5 text-[11px] font-semibold transition ${
-                  active ? 'bg-slate-900 text-white shadow-sm' : 'text-slate-600 hover:bg-white'
+                className={`rounded-full px-3.5 py-1.5 text-[11px] font-semibold transition ${
+                  active ? 'bg-slate-900 text-white shadow-sm' : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
                 }`}
-                aria-pressed={active}
               >
                 {tab.label}
               </button>
@@ -62,14 +60,11 @@ export function CourseExploreFilters({
         <button
           type="button"
           onClick={() => onCategoryChange('')}
-          className={`flex min-h-11 items-center gap-2 whitespace-nowrap rounded-xl border px-4 py-2.5 text-[12px] font-semibold transition ${
-            !activeCategory
-              ? 'border-cyan-600 bg-cyan-600 text-white shadow-sm'
-              : 'border-slate-200 bg-white text-slate-700 hover:border-cyan-300 hover:bg-cyan-50'
+          className={`flex items-center gap-2 whitespace-nowrap rounded-2xl border px-4 py-2.5 text-[12px] font-semibold transition ${
+            !activeCategory ? 'border-indigo-600 bg-indigo-600 text-white shadow-sm' : 'border-slate-200 bg-white text-slate-600 hover:border-indigo-300 hover:bg-indigo-50'
           }`}
-          aria-pressed={!activeCategory}
         >
-          <i className="ri-apps-2-line text-[16px]" />
+          <i className="ri-apps-2-line text-base" />
           전체
         </button>
         {uniqueCategories.map((category) => {
@@ -79,16 +74,12 @@ export function CourseExploreFilters({
               key={category}
               type="button"
               onClick={() => onCategoryChange(category)}
-              className={`flex min-h-11 items-center gap-2 whitespace-nowrap rounded-xl border px-4 py-2.5 text-[12px] font-semibold transition ${
-                active
-                  ? 'border-cyan-600 bg-cyan-600 text-white shadow-sm'
-                  : 'border-slate-200 bg-white text-slate-700 hover:border-cyan-300 hover:bg-cyan-50'
+              className={`flex items-center gap-2 whitespace-nowrap rounded-2xl border px-4 py-2.5 text-[12px] font-semibold transition ${
+                active ? 'border-indigo-600 bg-indigo-600 text-white shadow-sm' : 'border-slate-200 bg-white text-slate-600 hover:border-indigo-300 hover:bg-indigo-50'
               }`}
-              aria-pressed={active}
             >
-              <i className={`${categoryIcons[category] ?? 'ri-book-2-line'} text-[16px]`} />
+              <i className={`${categoryIcons[category] ?? 'ri-book-2-line'} text-base`} />
               {category}
-              {active ? <i className="ri-check-line text-[15px]" /> : null}
             </button>
           );
         })}

--- a/frontend/src/features/lms/components/DashboardStatsGrid.tsx
+++ b/frontend/src/features/lms/components/DashboardStatsGrid.tsx
@@ -16,8 +16,8 @@ const toneClasses: Record<DashboardStat['tone'], { panel: string; icon: string; 
     value: 'text-slate-900',
   },
   violet: {
-    panel: 'bg-violet-50 text-violet-600',
-    icon: 'bg-violet-100 text-violet-600',
+    panel: 'bg-sky-50 text-sky-700',
+    icon: 'bg-sky-100 text-sky-700',
     value: 'text-slate-900',
   },
   amber: {
@@ -39,7 +39,10 @@ export function DashboardStatsGrid({ stats }: DashboardStatsGridProps) {
         const tone = toneClasses[stat.tone];
 
         return (
-          <article key={stat.id} className="rounded-[28px] border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm transition hover:-translate-y-0.5 hover:border-cyan-200 hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)]">
+          <article
+            key={stat.id}
+            className="rounded-[28px] border border-[#d6e6f5] bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)] transition hover:-translate-y-0.5 hover:shadow-[0_18px_34px_rgba(6,31,57,0.12)]"
+          >
             <div className={`mb-3 flex h-12 w-12 items-center justify-center rounded-2xl text-[20px] ${tone.icon}`}>
               <i className={stat.icon} />
             </div>

--- a/frontend/src/features/lms/components/DashboardTimeline.tsx
+++ b/frontend/src/features/lms/components/DashboardTimeline.tsx
@@ -19,9 +19,9 @@ const toneClasses: Record<DashboardActivity['tone'], { icon: string; line: strin
     badge: 'bg-emerald-50 text-emerald-600',
   },
   violet: {
-    icon: 'bg-violet-100 text-violet-600',
-    line: 'border-violet-200',
-    badge: 'bg-violet-50 text-violet-600',
+    icon: 'bg-sky-100 text-sky-700',
+    line: 'border-sky-200',
+    badge: 'bg-sky-50 text-sky-700',
   },
   amber: {
     icon: 'bg-amber-100 text-amber-700',
@@ -57,7 +57,7 @@ function formatRelativeTime(timestamp: string): string {
 
 export function DashboardTimeline({ title, subtitle, activities, emptyMessage }: DashboardTimelineProps) {
   return (
-    <section className="rounded-[30px] border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm">
+    <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h3 className="text-[15px] font-bold text-[var(--app-text)]">{title}</h3>

--- a/frontend/src/features/lms/components/LectureSideChatPanel.tsx
+++ b/frontend/src/features/lms/components/LectureSideChatPanel.tsx
@@ -109,7 +109,7 @@ export function LectureSideChatPanel({ highlightedLecture, sessionToken }: Lectu
 
   if (!highlightedLecture) {
     return (
-      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.05)]">
+      <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <StatePanel
           compact
           icon="ri-chat-3-line"
@@ -122,21 +122,21 @@ export function LectureSideChatPanel({ highlightedLecture, sessionToken }: Lectu
   }
 
   return (
-    <section className="rounded-3xl border border-slate-200 bg-white shadow-[0_1px_3px_rgba(15,23,42,0.05)]">
-      <div className="border-b border-slate-200 px-5 py-4">
+    <section className="rounded-3xl border border-[#d6e6f5] bg-white shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
+      <div className="border-b border-[#dce9f7] px-5 py-4">
         <div className="flex items-start justify-between gap-3">
           <div>
-            <div className="text-[12px] font-semibold text-indigo-600">강의 시청 챗봇</div>
+            <div className="text-[12px] font-semibold text-cyan-700">강의 시청 챗봇</div>
             <h3 className="mt-1 text-[15px] font-bold text-slate-900">우측 사이드 질문</h3>
             <p className="mt-1 text-[12px] leading-5 text-slate-500">{statusText}</p>
           </div>
-          <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">
+          <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
             {highlightedLecture.week_number ?? 1}주차 · {highlightedLecture.session_number ?? highlightedLecture.order_index + 1}차시
           </div>
         </div>
 
-        <div className="mt-3 grid gap-2 rounded-2xl border border-indigo-100 bg-indigo-50/70 px-4 py-3 text-[12px] text-slate-600">
-          <div className="flex items-center gap-2 font-semibold text-indigo-700">
+        <div className="mt-3 grid gap-2 rounded-2xl border border-cyan-100 bg-cyan-50/70 px-4 py-3 text-[12px] text-[#355777]">
+          <div className="flex items-center gap-2 font-semibold text-cyan-700">
             <i className="ri-lightbulb-flash-line" />
             지금 강의에 바로 물어보기
           </div>
@@ -145,7 +145,7 @@ export function LectureSideChatPanel({ highlightedLecture, sessionToken }: Lectu
       </div>
 
       <div className="px-5 py-5">
-        <div className="space-y-4 rounded-3xl border border-slate-200 bg-slate-50 px-4 py-4">
+        <div className="space-y-4 rounded-3xl border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
           <div>
             <div className="text-[12px] font-semibold text-slate-500">{highlightedLecture.course_title}</div>
             <div className="mt-1 text-[15px] font-bold tracking-[-0.03em] text-slate-900">{highlightedLecture.title}</div>

--- a/frontend/src/features/lms/components/MediaPipelineStatusBoard.tsx
+++ b/frontend/src/features/lms/components/MediaPipelineStatusBoard.tsx
@@ -51,7 +51,7 @@ export function MediaPipelineStatusBoard({
   return (
     <div className="space-y-4">
       <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">FFmpeg 실행 환경</div>
           <div className={`mt-3 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${statusTone(processorHealth?.ffmpeg.available ? 'available' : 'disabled')}`}>
             {statusLabel(processorHealth?.ffmpeg.available ? 'available' : 'disabled')}
@@ -60,7 +60,7 @@ export function MediaPipelineStatusBoard({
             {processorHealth?.ffmpeg.version ?? processorHealth?.ffmpeg.path ?? 'FFmpeg 버전 정보가 없습니다.'}
           </p>
         </div>
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">콜백 보안</div>
           <div className={`mt-3 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${statusTone(processorHealth?.callback_secret_configured ? 'available' : 'disabled')}`}>
             {statusLabel(processorHealth?.callback_secret_configured ? 'available' : 'disabled')}
@@ -69,7 +69,7 @@ export function MediaPipelineStatusBoard({
             {processorHealth?.callback_secret_configured ? 'callback secret이 설정되어 있습니다.' : 'callback secret이 비어 있습니다.'}
           </p>
         </div>
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">처리 job</div>
           <div className={`mt-3 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${statusTone((processorHealth?.jobs.processing ?? 0) > 0 ? 'PROCESSING' : 'COMPLETED')}`}>
             {(processorHealth?.jobs.processing ?? 0) > 0 ? statusLabel('PROCESSING') : statusLabel('COMPLETED')}
@@ -78,7 +78,7 @@ export function MediaPipelineStatusBoard({
             총 {processorHealth?.jobs.total ?? 0}건 · 처리 중 {processorHealth?.jobs.processing ?? 0}건 · 실패 {processorHealth?.jobs.failed ?? 0}건
           </p>
         </div>
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">작업 디렉터리</div>
           <div className="mt-3 break-all text-sm font-semibold text-slate-900">{processorHealth?.work_dir ?? '미확인'}</div>
           <p className="mt-4 text-sm text-slate-600">
@@ -88,7 +88,7 @@ export function MediaPipelineStatusBoard({
       </section>
 
       <section className="grid gap-3 md:grid-cols-3">
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">영상 업로드</div>
           <div className={`mt-3 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${statusTone(uploadResult ? 'COMPLETED' : 'PENDING')}`}>
             {statusLabel(uploadResult ? 'COMPLETED' : 'PENDING')}
@@ -97,7 +97,7 @@ export function MediaPipelineStatusBoard({
             {uploadResult ? uploadResult.file_name : 'R2 업로드 후 asset key가 생성됩니다.'}
           </p>
         </div>
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">오디오 추출</div>
           <div className={`mt-3 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${statusTone(extraction?.status ?? pipeline?.audio_status ?? 'PENDING')}`}>
             {statusLabel(extraction?.status ?? pipeline?.audio_status ?? 'PENDING')}
@@ -106,7 +106,7 @@ export function MediaPipelineStatusBoard({
             {extraction ? `오디오 포맷 ${extraction.audio_format} · ${Math.max(1, Math.round(extraction.audio_duration_ms / 1000))}초` : '오디오 추출 job이 아직 없습니다.'}
           </p>
         </div>
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">트랜스크립트</div>
           <div className={`mt-3 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${statusTone(pipeline?.transcript_status ?? 'PENDING')}`}>
             {statusLabel(pipeline?.transcript_status ?? 'PENDING')}
@@ -119,7 +119,7 @@ export function MediaPipelineStatusBoard({
 
       {compact ? null : (
         <section className="grid gap-3 xl:grid-cols-[1.2fr_0.8fr]">
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="flex items-center justify-between">
             <div>
               <div className="text-sm font-semibold text-slate-900">파이프라인 상태</div>
@@ -131,15 +131,15 @@ export function MediaPipelineStatusBoard({
                   type="button"
                   onClick={onRefresh}
                   disabled={isRefreshing}
-                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 transition hover:border-indigo-300 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="rounded-full border border-[#cce0f2] bg-white px-3 py-1 text-xs font-semibold text-[#3e5d7b] transition hover:border-cyan-300 hover:text-cyan-700 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {isRefreshing ? '갱신 중' : '상태 새로고침'}
                 </button>
               ) : null}
               {isRefreshing ? (
-                <div className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">상태 새로고침 중</div>
+                <div className="rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-700">상태 새로고침 중</div>
               ) : null}
-              <div className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+              <div className="rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-700">
                 {pipeline?.updated_at ? new Date(pipeline.updated_at).toLocaleString('ko-KR') : '업데이트 전'}
               </div>
             </div>
@@ -154,7 +154,7 @@ export function MediaPipelineStatusBoard({
               { label: '전사 ID', value: extraction?.transcript_id ?? pipeline?.transcript_id ?? '없음' },
               { label: '처리 완료 시각', value: extraction?.processed_at ? new Date(extraction.processed_at).toLocaleString('ko-KR') : '대기 중' },
             ].map((item) => (
-              <div key={item.label} className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+              <div key={item.label} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
                 <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">{item.label}</div>
                 <div className="mt-2 break-words text-sm font-semibold text-slate-900">{item.value}</div>
               </div>
@@ -166,7 +166,7 @@ export function MediaPipelineStatusBoard({
             {recentExtractions.length > 0 ? (
               <div className="space-y-3">
                 {recentExtractions.slice(0, 3).map((item) => (
-                  <div key={item.id} className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+                  <div key={item.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div>
                         <div className="text-sm font-semibold text-slate-900">{item.id}</div>
@@ -208,7 +208,7 @@ export function MediaPipelineStatusBoard({
             {processorHealth?.recent_jobs?.length ? (
               <div className="space-y-3">
                 {processorHealth.recent_jobs.slice(0, 3).map((job) => (
-                  <div key={job.id} className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+                  <div key={job.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div>
                         <div className="text-sm font-semibold text-slate-900">{job.lecture_id}</div>
@@ -272,7 +272,7 @@ export function MediaPipelineStatusBoard({
           <div className="mt-5 space-y-3">
             <div className="text-sm font-semibold text-slate-900">추출 진행 세부</div>
             {extraction ? (
-              <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-700">
+              <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4 text-sm text-slate-700">
                 <div className="grid gap-3 md:grid-cols-2">
                   <div>
                     <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">오디오 URL</div>
@@ -300,11 +300,11 @@ export function MediaPipelineStatusBoard({
           </div>
         </div>
 
-        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="text-sm font-semibold text-slate-900">STT provider 상태</div>
           <div className="mt-3 space-y-3">
             {providers?.providers?.map((provider) => (
-              <div key={provider.name} className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+              <div key={provider.name} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <div className="text-sm font-semibold text-slate-900">{provider.label}</div>

--- a/frontend/src/features/lms/components/MediaPipelineSummaryPanel.tsx
+++ b/frontend/src/features/lms/components/MediaPipelineSummaryPanel.tsx
@@ -34,7 +34,7 @@ export function MediaPipelineSummaryPanel({
   notice,
 }: MediaPipelineSummaryPanelProps) {
   return (
-    <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+    <section className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="text-sm font-semibold text-slate-900">요약 상태</div>
@@ -42,25 +42,25 @@ export function MediaPipelineSummaryPanel({
             {selectedLecture ? `${selectedLecture.title} · ${getLectureDisplayDurationMinutes(selectedLecture)}분` : '강의를 선택하면 요약 상태가 표시됩니다.'}
           </div>
         </div>
-        <div className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+        <div className="rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-700">
           {pipeline?.updated_at ? new Date(pipeline.updated_at).toLocaleString('ko-KR') : '업데이트 전'}
         </div>
       </div>
 
       <div className="mt-4 grid gap-3 sm:grid-cols-3">
-        <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+        <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">업로드</div>
           <div className={`mt-2 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${badgeTone(uploadResult ? 'COMPLETED' : 'PENDING')}`}>
             {badgeLabel(uploadResult ? 'COMPLETED' : 'PENDING')}
           </div>
         </div>
-        <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+        <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">전사</div>
           <div className={`mt-2 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${badgeTone(extraction?.stt_status ?? pipeline?.transcript_status ?? 'PENDING')}`}>
             {badgeLabel(extraction?.stt_status ?? pipeline?.transcript_status ?? 'PENDING')}
           </div>
         </div>
-        <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+        <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
           <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">요약</div>
           <div className={`mt-2 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${badgeTone(pipeline?.summary_status ?? 'PENDING')}`}>
             {badgeLabel(pipeline?.summary_status ?? 'PENDING')}
@@ -68,7 +68,7 @@ export function MediaPipelineSummaryPanel({
         </div>
       </div>
 
-      <div className="mt-4 rounded-2xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-700">
+      <div className="mt-4 rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4 text-sm text-[#355777]">
         {notice}
       </div>
     </section>

--- a/frontend/src/features/lms/components/ShortformCommunityCard.tsx
+++ b/frontend/src/features/lms/components/ShortformCommunityCard.tsx
@@ -1,4 +1,4 @@
-﻿import type { ShortformCommunityItem } from '@myway/shared';
+import type { ShortformCommunityItem } from '@myway/shared';
 
 type ShortformCommunityCardProps = {
   item: ShortformCommunityItem;
@@ -36,7 +36,7 @@ export function ShortformCommunityCard({ item, active, onOpen, onPreview }: Shor
         active ? 'border-cyan-400 ring-2 ring-cyan-100' : 'border-slate-200'
       }`}
     >
-      <div className="bg-[linear-gradient(135deg,#1e293b,#475569)] px-5 py-4 text-white">
+      <div className="bg-[linear-gradient(135deg,#0f3b5f,#0e7490,#06b6d4)] px-5 py-4 text-white">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <div className="text-[13px] font-semibold opacity-90">{item.shared_by_name}</div>
@@ -60,7 +60,7 @@ export function ShortformCommunityCard({ item, active, onOpen, onPreview }: Shor
         <div className="space-y-1.5">
           {item.clips.slice(0, 3).map((clip, index) => (
             <div key={`${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`} className="flex items-center gap-2 rounded-xl bg-slate-50 px-3 py-2 text-[12px]">
-              <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md bg-cyan-100 text-[10px] font-bold text-cyan-600">
+              <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md bg-cyan-100 text-[10px] font-bold text-cyan-700">
                 {index + 1}
               </span>
               <span className="min-w-0 flex-1 truncate text-slate-600">{clip.lecture_title}</span>
@@ -87,7 +87,7 @@ export function ShortformCommunityCard({ item, active, onOpen, onPreview }: Shor
                 event.stopPropagation();
                 onPreview(item);
               }}
-              className="rounded-full border border-slate-200 px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-600"
+              className="rounded-full border border-slate-200 px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700"
             >
               미리보기
             </button>
@@ -97,4 +97,3 @@ export function ShortformCommunityCard({ item, active, onOpen, onPreview }: Shor
     </article>
   );
 }
-

--- a/frontend/src/features/lms/components/ShortformPreviewModal.tsx
+++ b/frontend/src/features/lms/components/ShortformPreviewModal.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect } from 'react';
+import { useEffect } from 'react';
 import type { ShortformCommunityItem } from '@myway/shared';
 import { resolvePlayableVideoUrl } from '../../../lib/video-url';
 
@@ -58,7 +58,7 @@ export function ShortformPreviewModal({ item, onClose }: ShortformPreviewModalPr
       >
         <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
           <div>
-            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Shortform Preview</div>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-cyan-700">Shortform Preview</div>
             <h3 className="mt-1 text-[18px] font-extrabold tracking-[-0.03em] text-slate-900">{item.title}</h3>
           </div>
           <button
@@ -102,7 +102,7 @@ export function ShortformPreviewModal({ item, onClose }: ShortformPreviewModalPr
               item.clips.map((clip, index) => (
                 <article key={`${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`} className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
                   <div className="flex items-start gap-3">
-                    <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-[11px] font-bold text-cyan-600">
+                    <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-[11px] font-bold text-cyan-700">
                       {index + 1}
                     </div>
                     <div className="min-w-0 flex-1">
@@ -144,4 +144,3 @@ export function ShortformPreviewModal({ item, onClose }: ShortformPreviewModalPr
     </div>
   );
 }
-

--- a/frontend/src/features/lms/components/ShortformWizard.tsx
+++ b/frontend/src/features/lms/components/ShortformWizard.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { getLectureDisplayDurationMinutes, type CourseCard, type CourseDetail, type LectureDetail, type ShortformCommunityItem, type ShortformVideo } from '@myway/shared';
 import { loadCourseDetail, loadLectureTranscriptDetailed } from '../../../lib/api';
 import {
@@ -381,7 +381,7 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
 
   return (
     <div className="space-y-4">
-      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm">
+      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
@@ -433,7 +433,7 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
               강좌 선택 → 차시별 구간 선택 → 제목/미리보기/저장의 3단계로 정리했습니다.
             </p>
           </div>
-          <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-600">
+          <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
             {selectedClips.length}개 클립
           </span>
         </div>
@@ -457,7 +457,7 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
                   >
                     {completed ? <i className="ri-check-line" /> : index + 1}
                   </div>
-                  <span className={`hidden text-xs font-medium sm:inline ${active ? 'text-cyan-600' : 'text-slate-400'}`}>{label}</span>
+                  <span className={`hidden text-xs font-medium sm:inline ${active ? 'text-cyan-700' : 'text-slate-400'}`}>{label}</span>
                 </div>
               </div>
             );
@@ -531,4 +531,3 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
     </div>
   );
 }
-

--- a/frontend/src/features/lms/components/ShortformWizardSidebar.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardSidebar.tsx
@@ -1,4 +1,4 @@
-﻿import type { ShortformCommunityItem } from '@myway/shared';
+import type { ShortformCommunityItem } from '@myway/shared';
 
 type ShortformWizardSidebarProps = {
   courseTitle?: string | null;
@@ -17,7 +17,7 @@ export function ShortformWizardSidebar({
 }: ShortformWizardSidebarProps) {
   return (
     <aside className="space-y-4 lg:sticky lg:top-20">
-      <article className="rounded-2xl border border-slate-200 bg-white px-5 py-5">
+      <article className="rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_15%_10%,rgba(34,211,238,0.12),transparent_28%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-5 py-5">
         <h3 className="text-[15px] font-semibold text-slate-900">선택 요약</h3>
         <div className="mt-4 space-y-3">
           <div className="rounded-xl bg-slate-50 px-4 py-4">
@@ -62,7 +62,7 @@ export function ShortformWizardSidebar({
           {communityItems.length > 0 ? (
             communityItems.map((item) => (
               <article key={item.id} className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-4">
-                <div className="text-[12px] font-semibold text-cyan-600">{item.shared_by_name}</div>
+                <div className="text-[12px] font-semibold text-cyan-700">{item.shared_by_name}</div>
                 <div className="mt-1 text-[14px] font-bold text-slate-900">{item.title}</div>
                 <p className="mt-2 line-clamp-2 text-[12px] leading-6 text-slate-500">{item.description}</p>
                 <div className="mt-4 flex items-center justify-between text-[11px] text-slate-400">
@@ -88,4 +88,3 @@ export function ShortformWizardSidebar({
     </aside>
   );
 }
-

--- a/frontend/src/features/lms/components/ShortformWizardStep1.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep1.tsx
@@ -1,4 +1,4 @@
-﻿import type { CourseCard, LectureDetail } from '@myway/shared';
+import type { CourseCard, LectureDetail } from '@myway/shared';
 
 type ShortformWizardStep1Props = {
   courses: CourseCard[];
@@ -24,7 +24,7 @@ export function ShortformWizardStep1({
   return (
     <article className="rounded-2xl border border-slate-200 bg-white px-5 py-5">
       <div className="flex items-center gap-2">
-        <i className="ri-book-open-line text-[18px] text-cyan-500" />
+        <i className="ri-book-open-line text-[18px] text-cyan-600" />
         <h2 className="text-[16px] font-semibold text-slate-900">1단계 · 강좌 선택</h2>
       </div>
       <p className="mt-1 text-[12px] text-slate-500">
@@ -34,7 +34,7 @@ export function ShortformWizardStep1({
         <div className="mt-4 rounded-xl border border-cyan-100 bg-cyan-50 px-4 py-4">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <div className="text-[12px] font-semibold text-cyan-600">현재 차시</div>
+              <div className="text-[12px] font-semibold text-cyan-700">현재 차시</div>
               <div className="mt-1 text-[14px] font-bold text-slate-900">{highlightedLecture.title}</div>
               <div className="mt-1 text-[12px] leading-6 text-slate-500">
                 선택한 차시를 기준으로 바로 숏폼 구간을 좁혀볼 수 있습니다.
@@ -62,7 +62,7 @@ export function ShortformWizardStep1({
                 active ? 'border-cyan-400 ring-2 ring-cyan-100' : 'border-slate-200'
               }`}
             >
-              <div className="bg-[linear-gradient(135deg,#4338ca,#1d4ed8)] px-5 py-4 text-white">
+              <div className="bg-[linear-gradient(135deg,#0f3b5f,#0e7490,#06b6d4)] px-5 py-4 text-white">
                 <div className="flex items-center justify-between gap-3 text-[11px] font-semibold opacity-90">
                   <span>{course.category}</span>
                   <span>{course.enrolled ? '수강 중' : '전체'}</span>
@@ -74,7 +74,7 @@ export function ShortformWizardStep1({
               </div>
               <div className="px-5 py-4">
                 <div className="flex flex-wrap items-center gap-2 text-[11px]">
-                  <span className="rounded-full bg-cyan-50 px-2.5 py-1 font-semibold text-cyan-600">{course.lecture_count}강의</span>
+                  <span className="rounded-full bg-cyan-50 px-2.5 py-1 font-semibold text-cyan-700">{course.lecture_count}강의</span>
                   <span className="rounded-full bg-slate-100 px-2.5 py-1 font-semibold text-slate-500">{course.student_count}명</span>
                 </div>
                 <p className="mt-3 line-clamp-2 text-[13px] leading-6 text-slate-500">{course.description}</p>
@@ -98,4 +98,3 @@ export function ShortformWizardStep1({
     </article>
   );
 }
-

--- a/frontend/src/features/lms/components/ShortformWizardStep2.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep2.tsx
@@ -1,4 +1,4 @@
-﻿import { StatePanel } from './StatePanel';
+import { StatePanel } from './StatePanel';
 import type { ClipSuggestion } from './ShortformWizardTypes';
 
 type ShortformWizardStep2Props = {
@@ -34,13 +34,13 @@ export function ShortformWizardStep2({
       <div className="flex items-center justify-between gap-4">
         <div>
           <div className="flex items-center gap-2">
-            <i className="ri-scissors-cut-line text-[18px] text-cyan-500" />
+            <i className="ri-scissors-cut-line text-[18px] text-cyan-600" />
             <h2 className="text-[16px] font-semibold text-slate-900">2단계 · 구간 선택</h2>
           </div>
           <p className="mt-1 text-[12px] text-slate-500">레퍼런스처럼 차시 필터 탭으로 구간을 좁히고, 핵심 구간을 카드 단위로 선택합니다.</p>
         </div>
         <div className="flex items-center gap-2">
-          <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-600">
+          <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
             선택 {selectedClipKeys.length}개
           </span>
           <button type="button" onClick={onBack} className="inline-flex h-10 items-center rounded-lg border border-slate-200 px-4 text-[12px] font-semibold text-slate-600">
@@ -65,7 +65,7 @@ export function ShortformWizardStep2({
             type="button"
             onClick={() => onFilterChange(tab.id)}
             className={`rounded-lg px-3 py-1 text-[12px] font-semibold whitespace-nowrap ${
-              lectureFilter === tab.id ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
+              lectureFilter === tab.id ? 'bg-cyan-700 text-white' : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
             }`}
           >
             {tab.label}
@@ -129,4 +129,3 @@ export function ShortformWizardStep2({
     </article>
   );
 }
-

--- a/frontend/src/features/lms/components/ShortformWizardStep2.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep2.tsx
@@ -53,7 +53,7 @@ export function ShortformWizardStep2({
         <button
           type="button"
           onClick={() => onFilterChange('all')}
-          className={`inline-flex h-9 items-center rounded-lg px-3 text-[12px] font-semibold whitespace-nowrap ${
+          className={`rounded-lg px-3 py-1 text-[12px] font-semibold whitespace-nowrap ${
             lectureFilter === 'all' ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
           }`}
         >
@@ -64,7 +64,7 @@ export function ShortformWizardStep2({
             key={tab.id}
             type="button"
             onClick={() => onFilterChange(tab.id)}
-            className={`inline-flex h-9 items-center rounded-lg px-3 text-[12px] font-semibold whitespace-nowrap ${
+            className={`rounded-lg px-3 py-1 text-[12px] font-semibold whitespace-nowrap ${
               lectureFilter === tab.id ? 'bg-slate-800 text-white' : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
             }`}
           >
@@ -75,7 +75,7 @@ export function ShortformWizardStep2({
 
       <p className="mt-4 text-[12px] text-slate-500">AI가 추천한 핵심 구간입니다. 클릭하여 선택/해제하세요.</p>
 
-      <div className="mt-4 space-y-2.5">
+      <div className="mt-4 space-y-2">
         {filteredSuggestions.length > 0 ? (
           filteredSuggestions.map((clip, index) => {
             const key = `${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`;

--- a/frontend/src/features/lms/components/ShortformWizardStep3.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep3.tsx
@@ -1,4 +1,4 @@
-﻿import type { ClipSuggestion } from './ShortformWizardTypes';
+import type { ClipSuggestion } from './ShortformWizardTypes';
 
 type ShortformWizardStep3Props = {
   courseTitle?: string | null;
@@ -79,7 +79,7 @@ export function ShortformWizardStep3({
       <div className="flex items-center justify-between gap-4">
         <div>
           <div className="flex items-center gap-2">
-            <i className="ri-edit-line text-[18px] text-cyan-500" />
+            <i className="ri-edit-line text-[18px] text-cyan-600" />
             <h2 className="text-[16px] font-semibold text-slate-900">3단계 · 미리보기 / 저장</h2>
           </div>
           <p className="mt-1 text-[12px] text-slate-500">선택한 클립을 미리보고 제목과 설명을 입력한 뒤 저장합니다.</p>
@@ -123,7 +123,7 @@ export function ShortformWizardStep3({
             return (
               <div key={key} className="space-y-3 rounded-xl bg-white/5 px-3 py-3 text-xs">
                 <div className="flex items-center gap-2">
-                  <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-cyan-100 text-[10px] font-bold text-cyan-600">
+                  <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-cyan-100 text-[10px] font-bold text-cyan-700">
                     {index + 1}
                   </span>
                   <span className="min-w-0 flex-1 truncate">
@@ -215,4 +215,3 @@ export function ShortformWizardStep3({
     </article>
   );
 }
-

--- a/frontend/src/features/lms/components/ShortformWizardStep3.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep3.tsx
@@ -75,7 +75,7 @@ export function ShortformWizardStep3({
   const totalDurationMs = selectedClips.reduce((sum, clip) => sum + (clip.end_time_ms - clip.start_time_ms), 0);
 
   return (
-    <article className="space-y-4 rounded-2xl border border-slate-200 bg-white px-5 py-5">
+    <article className="space-y-5 rounded-2xl border border-slate-200 bg-white px-5 py-5">
       <div className="flex items-center justify-between gap-4">
         <div>
           <div className="flex items-center gap-2">
@@ -117,7 +117,7 @@ export function ShortformWizardStep3({
             </div>
           )}
         </div>
-        <div className="mt-4 space-y-2">
+        <div className="mt-4 space-y-1.5">
           {selectedClips.map((clip, index) => {
             const key = `${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`;
             return (

--- a/frontend/src/features/lms/components/TranscriptTimelineWorkspace.tsx
+++ b/frontend/src/features/lms/components/TranscriptTimelineWorkspace.tsx
@@ -46,7 +46,7 @@ export function TranscriptTimelineWorkspace({ selectedLecture, transcript }: Tra
   }
 
   return (
-    <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+    <section className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="text-sm font-semibold text-slate-900">타임라인 작업 공간</div>
@@ -56,7 +56,7 @@ export function TranscriptTimelineWorkspace({ selectedLecture, transcript }: Tra
               : '강의를 선택하면 전사 타임라인이 표시됩니다.'}
           </div>
         </div>
-        <div className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">
+        <div className="rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-700">
           {transcript ? `${segments.length}개 세그먼트` : '전사 대기'}
         </div>
       </div>
@@ -64,34 +64,34 @@ export function TranscriptTimelineWorkspace({ selectedLecture, transcript }: Tra
       {transcript ? (
         <div className="mt-4 space-y-4">
           <div className="grid gap-3 sm:grid-cols-3">
-            <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+            <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
               <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">전사 길이</div>
               <div className="mt-2 text-sm font-semibold text-slate-900">{totalDurationLabel}</div>
             </div>
-            <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+            <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
               <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">언어</div>
               <div className="mt-2 text-sm font-semibold text-slate-900">{transcript.language}</div>
             </div>
-            <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+            <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
               <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">단어 수</div>
               <div className="mt-2 text-sm font-semibold text-slate-900">{transcript.word_count.toLocaleString('ko-KR')}</div>
             </div>
           </div>
 
-          <div className="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4 text-sm text-slate-700">
+          <div className="rounded-2xl border border-cyan-100 bg-cyan-50/70 p-4 text-sm text-[#2f5473]">
             타임스탬프는 요약, 검색, 숏폼에서 같은 기준으로 사용합니다. 아래 구간을 복사해 바로 메모나 클립 선택에 쓸 수 있습니다.
           </div>
 
           <div className="max-h-[560px] space-y-3 overflow-auto pr-1">
             {segments.map((segment) => (
-              <article key={segment.index} className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
+              <article key={segment.index} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <button
                     type="button"
                     onClick={() => {
                       void copySegmentStart(segment.start_ms);
                     }}
-                    className="rounded-full bg-indigo-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-indigo-500"
+                    className="rounded-full bg-[linear-gradient(135deg,#00b8e6_0%,#0077b6_100%)] px-3 py-1 text-xs font-semibold text-white transition hover:brightness-105"
                   >
                     {formatTimecode(segment.start_ms)} - {formatTimecode(segment.end_ms)}
                   </button>

--- a/frontend/src/features/lms/pages/AIChatPage.tsx
+++ b/frontend/src/features/lms/pages/AIChatPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { AIRagResult, AIInsights, LectureDetail, SmartChatResult } from '@myway/shared';
 import { loadAIRAGOverview } from '../../../lib/ai-rag';
 import { sendSmartChatDetailed } from '../../../lib/api';
@@ -162,7 +162,7 @@ export function AIChatPage({ highlightedLecture, insights, selectedCourse, canMa
         />
       ) : null}
 
-      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8">
+      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#03162a_0%,#004e7d_42%,#00a7c8_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(5,44,74,0.25)] lg:px-8">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <span className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">AI 학습 챗</span>
@@ -198,7 +198,7 @@ export function AIChatPage({ highlightedLecture, insights, selectedCourse, canMa
                 질문, 요약, 퀴즈, 복습 순서로 이어가면 레퍼런스처럼 흐름이 안정적입니다.
               </p>
             </div>
-            <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-600">
+            <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
               {messages.length}개 메시지
             </span>
           </div>
@@ -213,7 +213,7 @@ export function AIChatPage({ highlightedLecture, insights, selectedCourse, canMa
                     <div className="text-[12px] font-semibold text-[var(--app-text-muted)]">RAG 파이프라인</div>
                     <div className="mt-1 text-[14px] font-bold text-[var(--app-text)]">{ragOverview.query}</div>
                   </div>
-                  <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-[11px] font-semibold text-cyan-600">
+                  <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-[11px] font-semibold text-cyan-700">
                     {ragOverview.provider.search_provider}
                   </span>
                 </div>
@@ -248,4 +248,3 @@ export function AIChatPage({ highlightedLecture, insights, selectedCourse, canMa
     </div>
   );
 }
-

--- a/frontend/src/features/lms/pages/AISummaryPage.tsx
+++ b/frontend/src/features/lms/pages/AISummaryPage.tsx
@@ -21,7 +21,7 @@ export function AISummaryPage({ highlightedLecture, insights }: AISummaryPagePro
         meta="로그인 + quota 적용"
       />
 
-      <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
+      <section className="overflow-hidden rounded-[32px] border border-cyan-100 bg-[linear-gradient(135deg,#03162a_0%,#005d93_48%,#0bc5ea_100%)] px-6 py-6 text-white shadow-[0_22px_50px_rgba(4,49,84,0.24)] lg:px-8 lg:py-8">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
@@ -60,7 +60,7 @@ export function AISummaryPage({ highlightedLecture, insights }: AISummaryPagePro
       </section>
 
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
-        <article className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+        <article className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h2 className="text-[15px] font-bold text-slate-900">강의 요약</h2>
@@ -68,7 +68,7 @@ export function AISummaryPage({ highlightedLecture, insights }: AISummaryPagePro
                 {lectureCourse} · {highlightedLecture ? highlightedLecture.course_instructor : '강의 선택 필요'}
               </p>
             </div>
-            <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">요약 우선</div>
+            <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">요약 우선</div>
           </div>
 
           <div className="mt-4 grid gap-3 sm:grid-cols-3">
@@ -77,15 +77,15 @@ export function AISummaryPage({ highlightedLecture, insights }: AISummaryPagePro
               { label: '복습 포인트', value: '자주 놓치는 개념 우선' },
               { label: '읽는 순서', value: '제목 → 요약 → 전사' },
             ].map((item) => (
-              <div key={item.label} className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
-                <div className="text-[11px] font-semibold text-slate-400">{item.label}</div>
+              <div key={item.label} className="rounded-[24px] border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
+                <div className="text-[11px] font-semibold text-[#6c86a0]">{item.label}</div>
                 <div className="mt-1 text-[14px] font-bold text-slate-900">{item.value}</div>
               </div>
             ))}
           </div>
 
-          <div className="mt-4 rounded-[26px] border border-slate-200 bg-slate-50 px-5 py-5">
-            <div className="text-[12px] font-semibold text-indigo-600">선택된 강의</div>
+          <div className="mt-4 rounded-[26px] border border-[#dce9f7] bg-[#f4faff] px-5 py-5">
+            <div className="text-[12px] font-semibold text-cyan-700">선택된 강의</div>
             <div className="mt-1 text-[20px] font-extrabold tracking-[-0.03em] text-slate-900">{lectureTitle}</div>
             <p className="mt-3 text-[13px] leading-7 text-slate-600">{lectureExcerpt}</p>
           </div>
@@ -104,32 +104,32 @@ export function AISummaryPage({ highlightedLecture, insights }: AISummaryPagePro
         </article>
 
         <aside className="space-y-5">
-          <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-robot-line text-indigo-600" />
+              <i className="ri-robot-line text-cyan-700" />
               AI 인사이트
             </h3>
             <div className="mt-4 grid grid-cols-2 gap-3">
-              <div className="rounded-2xl bg-slate-50 px-4 py-4">
+              <div className="rounded-2xl bg-[#f4faff] px-4 py-4">
                 <div className="text-[11px] text-slate-400">최근 AI 사용량</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">{insights?.summary.total_requests ?? 0}</div>
               </div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-4">
+              <div className="rounded-2xl bg-[#f4faff] px-4 py-4">
                 <div className="text-[11px] text-slate-400">성공률</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">{insights?.summary.success_rate ?? 0}%</div>
               </div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-4">
+              <div className="rounded-2xl bg-[#f4faff] px-4 py-4">
                 <div className="text-[11px] text-slate-400">추천 창</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">{insights?.summary.recent_window_days ?? 0}일</div>
               </div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-4">
+              <div className="rounded-2xl bg-[#f4faff] px-4 py-4">
                 <div className="text-[11px] text-slate-400">강의 인지</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">{highlightedLecture ? 'ON' : 'OFF'}</div>
               </div>
             </div>
           </section>
 
-          <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <h3 className="text-[15px] font-bold text-slate-900">사용 팁</h3>
             <div className="mt-3 space-y-2 text-[12px] leading-6 text-slate-500">
               <p>1. 강의 상세에서 차시를 먼저 선택한 뒤 요약을 보면 맥락이 더 잘 보입니다.</p>

--- a/frontend/src/features/lms/pages/AdminAssignPage.tsx
+++ b/frontend/src/features/lms/pages/AdminAssignPage.tsx
@@ -10,14 +10,23 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
   const instructors = users.filter((user) => user.role === 'INSTRUCTOR');
 
   return (
-    <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
+    <div className="space-y-5">
+      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-5 shadow-sm">
+        <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
+          <i className="ri-links-line" />
+          Assignment Detail
+        </div>
+        <h2 className="mt-3 text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">강사/수강생 배정 상세</h2>
+        <p className="mt-1 text-[13px] text-slate-600">강의별 담당 교강사와 수강생 그룹 분포를 한 번에 확인합니다.</p>
+      </section>
+      <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
       <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
         <h2 className="text-[15px] font-bold text-slate-900">강사 배정</h2>
         <p className="mt-1 text-[12px] text-slate-500">강의별 담당 교강사를 정리한 운영용 매핑 화면입니다.</p>
         <div className="mt-4 space-y-2">
           {courses.map((course) => (
             <div key={course.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3">
-              <div className="flex h-[34px] w-[34px] items-center justify-center rounded-xl bg-indigo-50 text-indigo-600">
+              <div className="flex h-[34px] w-[34px] items-center justify-center rounded-xl bg-cyan-50 text-cyan-700">
                 <i className="ri-book-open-line" />
               </div>
               <div className="min-w-0 flex-1">
@@ -56,6 +65,7 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
           ))}
         </div>
       </section>
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/AdminAutomationPage.tsx
+++ b/frontend/src/features/lms/pages/AdminAutomationPage.tsx
@@ -19,13 +19,13 @@ type AutomationRule = {
 const tools: AutomationTool[] = [
   {
     icon: 'ri-mail-send-line',
-    iconClass: 'bg-indigo-50 text-indigo-600',
+    iconClass: 'bg-cyan-50 text-cyan-700',
     title: '자동 알림 발송',
     description: '수강 독려, 과제 마감 알림 등을 자동으로 발송합니다.',
   },
   {
     icon: 'ri-calendar-schedule-line',
-    iconClass: 'bg-violet-50 text-violet-600',
+    iconClass: 'bg-sky-50 text-sky-700',
     title: '일정 자동 관리',
     description: '강의 일정, 시험 일정을 자동으로 등록하고 공유합니다.',
   },
@@ -82,11 +82,16 @@ export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProp
 
   return (
     <div className="space-y-5">
+      <section className="rounded-[30px] border border-cyan-100 bg-[linear-gradient(135deg,#03162a_0%,#005d93_48%,#0bc5ea_100%)] px-6 py-6 text-white shadow-[0_22px_50px_rgba(4,49,84,0.24)]">
+        <h1 className="text-[26px] font-extrabold tracking-[-0.04em]">운영 자동화와 AI 정책 관리</h1>
+        <p className="mt-2 text-[13px] leading-6 text-white/80">알림, 리포트, 권한 정책과 provider 우선순위를 한 화면에서 관리합니다.</p>
+      </section>
+
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         {tools.map((tool) => (
           <article
             key={tool.title}
-            className="rounded-3xl border border-slate-200 bg-white px-5 py-6 shadow-[0_1px_3px_rgba(15,23,42,0.06)] transition hover:-translate-y-0.5 hover:shadow-[0_12px_28px_rgba(15,23,42,0.08)]"
+            className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-6 shadow-[0_14px_30px_rgba(6,31,57,0.08)] transition hover:-translate-y-0.5 hover:shadow-[0_18px_34px_rgba(6,31,57,0.12)]"
           >
             <div className={`mb-4 flex h-12 w-12 items-center justify-center rounded-2xl text-[22px] ${tool.iconClass}`}>
               <i className={tool.icon} />
@@ -97,9 +102,9 @@ export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProp
         ))}
       </section>
 
-      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+      <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <h3 className="flex items-center gap-2 text-[15px] font-bold tracking-[-0.02em] text-slate-900">
-          <i className="ri-flashlight-line text-indigo-600" />
+          <i className="ri-flashlight-line text-cyan-700" />
           자동화 규칙
         </h3>
 
@@ -125,9 +130,9 @@ export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProp
         </div>
       </section>
 
-      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+      <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <h3 className="flex items-center gap-2 text-[15px] font-bold tracking-[-0.02em] text-slate-900">
-          <i className="ri-database-2-line text-indigo-600" />
+          <i className="ri-database-2-line text-cyan-700" />
           AI provider 계층
         </h3>
         <p className="mt-2 text-[12px] leading-6 text-slate-500">
@@ -163,7 +168,7 @@ export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProp
                   <div className="text-[13px] font-semibold text-slate-900">{plan.feature}</div>
                   <div className="mt-1 text-[12px] text-slate-500">{plan.current_provider}가 현재 runtime policy 기준의 우선 제공자예요.</div>
                 </div>
-                <span className="rounded-full bg-indigo-100 px-2.5 py-1 text-[11px] font-semibold text-indigo-600">
+                <span className="rounded-full bg-cyan-100 px-2.5 py-1 text-[11px] font-semibold text-cyan-700">
                   {plan.steps[0]?.status ?? 'planned'}
                 </span>
               </div>
@@ -174,7 +179,7 @@ export function AdminAutomationPage({ providerCatalog }: AdminAutomationPageProp
                     key={provider}
                     className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
                       index === 0
-                        ? 'bg-indigo-600 text-white'
+                        ? 'bg-cyan-600 text-white'
                         : provider === 'demo'
                           ? 'bg-slate-200 text-slate-600'
                           : 'bg-white text-slate-600 ring-1 ring-slate-200'

--- a/frontend/src/features/lms/pages/AdminDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/AdminDashboardPage.tsx
@@ -67,25 +67,21 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px] xl:items-end">
           <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
+            <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">
               <i className="ri-shield-star-line" />
               Admin Dashboard
             </div>
-            <h2 className="mt-4 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[32px]">
-              사용자, 강의, AI 요청을
-              <br />
-              운영 관점에서 한 번에 봅니다.
-            </h2>
-            <p className="mt-3 max-w-2xl text-[14px] leading-7 text-white/78">
+            <h2 className="mt-4 text-[24px] font-bold text-slate-900 lg:text-[28px]">운영 관리자 대시보드</h2>
+            <p className="mt-2 max-w-2xl text-[14px] leading-6 text-slate-500">
               {resolvedDashboard.next_action ?? '운영 통계와 AI 사용량을 확인하고 병목이 생긴 코스를 점검하세요.'}
             </p>
           </div>
 
-          <div className="rounded-[28px] border border-white/10 bg-white/10 px-5 py-5 backdrop-blur">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/60">역할 분포</div>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">역할 분포</div>
             <div className="mt-4 space-y-3">
               {[
                 { label: '운영자', count: roleCounts.ADMIN, color: 'bg-amber-400' },
@@ -93,15 +89,15 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
                 { label: '수강생', count: roleCounts.STUDENT, color: 'bg-indigo-400' },
               ].map((item) => (
                 <div key={item.label} className="flex items-center gap-3">
-                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-white/15">
+                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200">
                     <div
                       className={`h-full rounded-full ${item.color}`}
                       style={{ width: `${Math.max((item.count / Math.max(resolvedUsers.length, 1)) * 100, item.count > 0 ? 12 : 0)}%` }}
                     />
                   </div>
-                  <div className="w-12 text-right text-[12px] font-semibold text-white">
+                  <div className="w-12 text-right text-[12px] font-semibold text-slate-700">
                     {item.label}
-                    <span className="ml-1 text-white/65">{item.count}</span>
+                    <span className="ml-1 text-slate-400">{item.count}</span>
                   </div>
                 </div>
               ))}
@@ -121,7 +117,7 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
             emptyMessage="아직 최근 활동이 없습니다. 수강 등록이나 AI 요청이 발생하면 여기에 표시됩니다."
           />
 
-          <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <h3 className="text-[15px] font-bold text-slate-900">운영 핵심 수치</h3>
@@ -131,19 +127,19 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
             </div>
 
             <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              <article className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">전체 사용자</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedUsers.length}</div>
               </article>
-              <article className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">전체 강의</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedCourses.length}</div>
               </article>
-              <article className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">활성 수강</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedDashboard.active_enrollments ?? 0}</div>
               </article>
-              <article className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">AI 요청</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedInsights.summary.total_requests ?? 0}</div>
               </article>
@@ -152,14 +148,14 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
         </div>
 
         <div className="space-y-6">
-          <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
               <i className="ri-team-line text-indigo-600" />
               최근 사용자
             </h3>
             <div className="mt-4 space-y-2">
               {resolvedUsers.slice(0, 5).map((user) => (
-                <div key={user.id} className="flex items-center gap-3 rounded-[22px] border border-slate-200 bg-slate-50 px-4 py-3">
+                <div key={user.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
                   <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-indigo-100 text-[13px] font-bold text-indigo-600">
                     {user.name.slice(0, 1)}
                   </div>
@@ -173,7 +169,7 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
             </div>
           </section>
 
-          <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
               <i className="ri-pie-chart-2-line text-indigo-600" />
               역할 비율
@@ -201,7 +197,7 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
           </section>
 
           {resolvedInsights ? (
-            <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+            <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
               <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
                 <i className="ri-lightbulb-flash-line text-indigo-600" />
                 AI 인사이트

--- a/frontend/src/features/lms/pages/AdminDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/AdminDashboardPage.tsx
@@ -67,37 +67,41 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
+      <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px] xl:items-end">
           <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
               <i className="ri-shield-star-line" />
               Admin Dashboard
             </div>
-            <h2 className="mt-4 text-[24px] font-bold text-slate-900 lg:text-[28px]">운영 관리자 대시보드</h2>
-            <p className="mt-2 max-w-2xl text-[14px] leading-6 text-slate-500">
+            <h2 className="mt-4 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[32px]">
+              사용자, 강의, AI 요청을
+              <br />
+              운영 관점에서 한 번에 봅니다.
+            </h2>
+            <p className="mt-3 max-w-2xl text-[14px] leading-7 text-white/78">
               {resolvedDashboard.next_action ?? '운영 통계와 AI 사용량을 확인하고 병목이 생긴 코스를 점검하세요.'}
             </p>
           </div>
 
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">역할 분포</div>
+          <div className="rounded-[28px] border border-white/10 bg-white/10 px-5 py-5 backdrop-blur">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/60">역할 분포</div>
             <div className="mt-4 space-y-3">
               {[
                 { label: '운영자', count: roleCounts.ADMIN, color: 'bg-amber-400' },
                 { label: '교강사', count: roleCounts.INSTRUCTOR, color: 'bg-emerald-400' },
-                { label: '수강생', count: roleCounts.STUDENT, color: 'bg-cyan-500' },
+                { label: '수강생', count: roleCounts.STUDENT, color: 'bg-indigo-400' },
               ].map((item) => (
                 <div key={item.label} className="flex items-center gap-3">
-                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200">
+                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-white/15">
                     <div
                       className={`h-full rounded-full ${item.color}`}
                       style={{ width: `${Math.max((item.count / Math.max(resolvedUsers.length, 1)) * 100, item.count > 0 ? 12 : 0)}%` }}
                     />
                   </div>
-                  <div className="w-12 text-right text-[12px] font-semibold text-slate-700">
+                  <div className="w-12 text-right text-[12px] font-semibold text-white">
                     {item.label}
-                    <span className="ml-1 text-slate-400">{item.count}</span>
+                    <span className="ml-1 text-white/65">{item.count}</span>
                   </div>
                 </div>
               ))}
@@ -117,29 +121,29 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
             emptyMessage="아직 최근 활동이 없습니다. 수강 등록이나 AI 요청이 발생하면 여기에 표시됩니다."
           />
 
-          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <h3 className="text-[15px] font-bold text-slate-900">운영 핵심 수치</h3>
                 <p className="mt-1 text-[12px] text-slate-500">사용자와 강의의 기본 규모를 운영 흐름에 맞게 정리합니다.</p>
               </div>
-              <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">{resolvedUsers.length}명</div>
+              <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">{resolvedUsers.length}명</div>
             </div>
 
             <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">전체 사용자</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedUsers.length}</div>
               </article>
-              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">전체 강의</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedCourses.length}</div>
               </article>
-              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">활성 수강</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedDashboard.active_enrollments ?? 0}</div>
               </article>
-              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">AI 요청</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedInsights.summary.total_requests ?? 0}</div>
               </article>
@@ -148,37 +152,37 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
         </div>
 
         <div className="space-y-6">
-          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-team-line text-cyan-700" />
+              <i className="ri-team-line text-indigo-600" />
               최근 사용자
             </h3>
             <div className="mt-4 space-y-2">
               {resolvedUsers.slice(0, 5).map((user) => (
-                <div key={user.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-cyan-100 text-[13px] font-bold text-cyan-700">
+                <div key={user.id} className="flex items-center gap-3 rounded-[22px] border border-slate-200 bg-slate-50 px-4 py-3">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-indigo-100 text-[13px] font-bold text-indigo-600">
                     {user.name.slice(0, 1)}
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-[13px] font-semibold text-slate-900">{user.name}</div>
                     <div className="mt-1 text-[11px] text-slate-500">{user.department}</div>
                   </div>
-                  <span className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-cyan-700">{user.role}</span>
+                  <span className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-indigo-600">{user.role}</span>
                 </div>
               ))}
             </div>
           </section>
 
-          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-pie-chart-2-line text-cyan-700" />
+              <i className="ri-pie-chart-2-line text-indigo-600" />
               역할 비율
             </h3>
             <div className="mt-4 space-y-3">
               {[
                 { label: '운영자', count: roleCounts.ADMIN, tone: 'bg-amber-500' },
                 { label: '교강사', count: roleCounts.INSTRUCTOR, tone: 'bg-emerald-500' },
-                { label: '수강생', count: roleCounts.STUDENT, tone: 'bg-cyan-500' },
+                { label: '수강생', count: roleCounts.STUDENT, tone: 'bg-indigo-500' },
               ].map((item) => (
                 <div key={item.label}>
                   <div className="mb-1 flex items-center justify-between text-[12px] text-slate-500">
@@ -197,9 +201,9 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
           </section>
 
           {resolvedInsights ? (
-            <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+            <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
               <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-                <i className="ri-lightbulb-flash-line text-cyan-700" />
+                <i className="ri-lightbulb-flash-line text-indigo-600" />
                 AI 인사이트
               </h3>
               <p className="mt-3 text-[13px] leading-6 text-slate-500">

--- a/frontend/src/features/lms/pages/AdminDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/AdminDashboardPage.tsx
@@ -67,12 +67,12 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
+      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-6 shadow-sm lg:px-8">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px] xl:items-end">
           <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">
+            <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
               <i className="ri-shield-star-line" />
-              Admin Dashboard
+              관리자 대시보드
             </div>
             <h2 className="mt-4 text-[24px] font-bold text-slate-900 lg:text-[28px]">운영 관리자 대시보드</h2>
             <p className="mt-2 max-w-2xl text-[14px] leading-6 text-slate-500">
@@ -80,13 +80,13 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
             </p>
           </div>
 
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
+          <div className="rounded-2xl border border-[#d6e6f5] bg-[#f4faff] px-5 py-5">
             <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">역할 분포</div>
             <div className="mt-4 space-y-3">
               {[
                 { label: '운영자', count: roleCounts.ADMIN, color: 'bg-amber-400' },
                 { label: '교강사', count: roleCounts.INSTRUCTOR, color: 'bg-emerald-400' },
-                { label: '수강생', count: roleCounts.STUDENT, color: 'bg-indigo-400' },
+                { label: '수강생', count: roleCounts.STUDENT, color: 'bg-cyan-400' },
               ].map((item) => (
                 <div key={item.label} className="flex items-center gap-3">
                   <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200">
@@ -117,29 +117,29 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
             emptyMessage="아직 최근 활동이 없습니다. 수강 등록이나 AI 요청이 발생하면 여기에 표시됩니다."
           />
 
-          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <h3 className="text-[15px] font-bold text-slate-900">운영 핵심 수치</h3>
                 <p className="mt-1 text-[12px] text-slate-500">사용자와 강의의 기본 규모를 운영 흐름에 맞게 정리합니다.</p>
               </div>
-              <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">{resolvedUsers.length}명</div>
+              <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">{resolvedUsers.length}명</div>
             </div>
 
             <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">전체 사용자</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedUsers.length}</div>
               </article>
-              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">전체 강의</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedCourses.length}</div>
               </article>
-              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">활성 수강</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedDashboard.active_enrollments ?? 0}</div>
               </article>
-              <article className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <article className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
                 <div className="text-[11px] font-semibold text-slate-400">AI 요청</div>
                 <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">{resolvedInsights.summary.total_requests ?? 0}</div>
               </article>
@@ -148,37 +148,37 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
         </div>
 
         <div className="space-y-6">
-          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-team-line text-indigo-600" />
+              <i className="ri-team-line text-cyan-700" />
               최근 사용자
             </h3>
             <div className="mt-4 space-y-2">
               {resolvedUsers.slice(0, 5).map((user) => (
-                <div key={user.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-indigo-100 text-[13px] font-bold text-indigo-600">
+                <div key={user.id} className="flex items-center gap-3 rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-4 py-3">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-cyan-100 text-[13px] font-bold text-cyan-700">
                     {user.name.slice(0, 1)}
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-[13px] font-semibold text-slate-900">{user.name}</div>
                     <div className="mt-1 text-[11px] text-slate-500">{user.department}</div>
                   </div>
-                  <span className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-indigo-600">{user.role}</span>
+                  <span className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-cyan-700">{user.role}</span>
                 </div>
               ))}
             </div>
           </section>
 
-          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <section className="rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-pie-chart-2-line text-indigo-600" />
+              <i className="ri-pie-chart-2-line text-cyan-700" />
               역할 비율
             </h3>
             <div className="mt-4 space-y-3">
               {[
                 { label: '운영자', count: roleCounts.ADMIN, tone: 'bg-amber-500' },
                 { label: '교강사', count: roleCounts.INSTRUCTOR, tone: 'bg-emerald-500' },
-                { label: '수강생', count: roleCounts.STUDENT, tone: 'bg-indigo-500' },
+                { label: '수강생', count: roleCounts.STUDENT, tone: 'bg-cyan-500' },
               ].map((item) => (
                 <div key={item.label}>
                   <div className="mb-1 flex items-center justify-between text-[12px] text-slate-500">
@@ -197,9 +197,9 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
           </section>
 
           {resolvedInsights ? (
-            <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+            <section className="rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
               <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-                <i className="ri-lightbulb-flash-line text-indigo-600" />
+                <i className="ri-lightbulb-flash-line text-cyan-700" />
                 AI 인사이트
               </h3>
               <p className="mt-3 text-[13px] leading-6 text-slate-500">

--- a/frontend/src/features/lms/pages/AdminInstructorsPage.tsx
+++ b/frontend/src/features/lms/pages/AdminInstructorsPage.tsx
@@ -44,6 +44,14 @@ export function AdminInstructorsPage({ instructors, courses }: AdminInstructorsP
 
   return (
     <div className="space-y-5">
+      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-5 shadow-sm">
+        <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
+          <i className="ri-user-star-line" />
+          Instructor Detail
+        </div>
+        <h2 className="mt-3 text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">강사 운영 상세</h2>
+        <p className="mt-1 text-[13px] text-slate-600">강사별 담당 과목과 소속을 빠르게 비교해 운영 우선순위를 조정합니다.</p>
+      </section>
       <AdminFilterBar
         title="강사 관리"
         subtitle="담당 과목, 소속, 이름을 기준으로 찾아보고 운영 우선순위가 높은 강사를 빠르게 확인합니다."
@@ -72,7 +80,7 @@ export function AdminInstructorsPage({ instructors, courses }: AdminInstructorsP
             return (
               <article key={instructor.id} className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
                 <div className="flex items-start gap-3">
-                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-violet-100 text-[16px] font-bold text-violet-600">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-cyan-100 text-[16px] font-bold text-cyan-700">
                     {instructor.name[0]}
                   </div>
                   <div className="min-w-0 flex-1">

--- a/frontend/src/features/lms/pages/AdminStatsPage.tsx
+++ b/frontend/src/features/lms/pages/AdminStatsPage.tsx
@@ -71,21 +71,23 @@ function getTokenTotal(logs: Array<{ input_tokens: number; output_tokens: number
 export function AdminStatsPage({ dashboard, courses, users, insights, aiLogs }: AdminStatsPageProps) {
   return (
     <div className="space-y-5">
-      <section className="overflow-hidden rounded-[28px] border border-cyan-200 bg-[linear-gradient(135deg,#ecfeff_0%,#f0fdfa_56%,#f8fafc_100%)] p-3 sm:p-4">
-        <AdminStatsOverviewCards dashboard={dashboard} courses={courses} users={users} insights={insights} aiLogs={aiLogs} />
+      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-6 shadow-sm lg:px-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
+              <i className="ri-bar-chart-box-line" />
+              Admin Stats
+            </div>
+            <h2 className="mt-3 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">운영 통계 상세</h2>
+            <p className="mt-1 text-[13px] text-slate-600">사용자/강의/AI 로그를 비교해 운영 병목과 이상치를 빠르게 확인합니다.</p>
+          </div>
+        </div>
       </section>
-      <section className="rounded-[28px] border border-cyan-100 bg-white p-3 shadow-sm sm:p-4">
-        <AdminStatsComparisonPanel aiLogs={aiLogs} />
-      </section>
-      <section className="rounded-[28px] border border-teal-100 bg-white p-3 shadow-sm sm:p-4">
-        <AdminStatsOperationalPanel courses={courses} users={users} insights={insights} aiLogs={aiLogs} />
-      </section>
-      <section className="rounded-[28px] border border-cyan-100 bg-white p-3 shadow-sm sm:p-4">
-        <AdminStatsDistributionPanel aiLogs={aiLogs} />
-      </section>
-      <section className="rounded-[28px] border border-cyan-100 bg-white p-3 shadow-sm sm:p-4">
-        <AdminStatsLogPanel aiLogs={aiLogs} />
-      </section>
+      <AdminStatsOverviewCards dashboard={dashboard} courses={courses} users={users} insights={insights} aiLogs={aiLogs} />
+      <AdminStatsComparisonPanel aiLogs={aiLogs} />
+      <AdminStatsOperationalPanel courses={courses} users={users} insights={insights} aiLogs={aiLogs} />
+      <AdminStatsDistributionPanel aiLogs={aiLogs} />
+      <AdminStatsLogPanel aiLogs={aiLogs} />
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/AdminUsersPage.tsx
+++ b/frontend/src/features/lms/pages/AdminUsersPage.tsx
@@ -13,13 +13,13 @@ type RoleFilter = 'all' | AuthUser['role'];
 const roleBadgeClasses: Record<AuthUser['role'], string> = {
   ADMIN: 'bg-amber-100 text-amber-700',
   INSTRUCTOR: 'bg-emerald-100 text-emerald-600',
-  STUDENT: 'bg-cyan-100 text-cyan-700',
+  STUDENT: 'bg-indigo-100 text-indigo-600',
 };
 
 const roleToneClasses: Record<AuthUser['role'], string> = {
   ADMIN: 'border-amber-200 bg-amber-50 text-amber-700',
   INSTRUCTOR: 'border-emerald-200 bg-emerald-50 text-emerald-600',
-  STUDENT: 'border-cyan-200 bg-cyan-50 text-cyan-700',
+  STUDENT: 'border-indigo-200 bg-indigo-50 text-indigo-600',
 };
 
 export function AdminUsersPage({ users }: AdminUsersPageProps) {
@@ -51,7 +51,7 @@ export function AdminUsersPage({ users }: AdminUsersPageProps) {
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] border border-cyan-200 bg-[linear-gradient(135deg,#0f172a_0%,#0e7490_48%,#0f766e_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
+      <section className="overflow-hidden rounded-[32px] border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
@@ -97,7 +97,7 @@ export function AdminUsersPage({ users }: AdminUsersPageProps) {
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="이름, 이메일, 학과, 역할 검색"
-              className="min-h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-400 focus:ring-2 focus:ring-cyan-100"
+              className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-400"
             />
           </label>
 
@@ -114,8 +114,7 @@ export function AdminUsersPage({ users }: AdminUsersPageProps) {
                   key={item.key}
                   type="button"
                   onClick={() => setRoleFilter(item.key as RoleFilter)}
-                  aria-pressed={active}
-                  className={`min-h-10 rounded-full px-4 py-2 text-[12px] font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 ${
+                  className={`rounded-full px-4 py-2 text-[12px] font-semibold transition ${
                     active ? 'bg-cyan-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:border-cyan-200 hover:text-cyan-700'
                   }`}
                 >

--- a/frontend/src/features/lms/pages/AssignmentCheckPage.tsx
+++ b/frontend/src/features/lms/pages/AssignmentCheckPage.tsx
@@ -75,7 +75,7 @@ export function AssignmentCheckPage({ courses }: AssignmentCheckPageProps) {
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
+      <section className="overflow-hidden rounded-[32px] border border-cyan-100 bg-[linear-gradient(135deg,#03162a_0%,#005d93_48%,#0bc5ea_100%)] px-6 py-6 text-white shadow-[0_22px_50px_rgba(4,49,84,0.24)] lg:px-8 lg:py-8">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
@@ -113,7 +113,7 @@ export function AssignmentCheckPage({ courses }: AssignmentCheckPageProps) {
         </div>
       </section>
 
-      <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+      <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
           <label className="block">
             <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
@@ -121,7 +121,7 @@ export function AssignmentCheckPage({ courses }: AssignmentCheckPageProps) {
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="과제명, 강의명, 강사명, 피드백 검색"
-              className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-indigo-400"
+              className="h-11 w-full rounded-2xl border border-[#cce0f2] bg-[#f4faff] px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-[#7e94ad] focus:border-cyan-400"
             />
           </label>
 
@@ -139,7 +139,9 @@ export function AssignmentCheckPage({ courses }: AssignmentCheckPageProps) {
                   type="button"
                   onClick={() => setReviewStatus(item.key as ReviewStatus)}
                   className={`rounded-full px-4 py-2 text-[12px] font-semibold transition ${
-                    active ? 'bg-indigo-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:border-indigo-200 hover:text-indigo-600'
+                    active
+                      ? 'bg-[linear-gradient(135deg,#00b8e6_0%,#0077b6_100%)] text-white'
+                      : 'border border-[#cce0f2] bg-white text-[#4a6885] hover:border-cyan-300 hover:text-cyan-700'
                   }`}
                 >
                   {item.label}
@@ -150,13 +152,13 @@ export function AssignmentCheckPage({ courses }: AssignmentCheckPageProps) {
         </div>
       </section>
 
-      <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+      <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h3 className="text-[15px] font-bold text-slate-900">과제 목록</h3>
             <p className="mt-1 text-[12px] text-slate-500">상태별 아이콘과 점수, 제출 시점을 함께 확인합니다.</p>
           </div>
-          <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">검색 결과 {filteredAssignments.length}개</div>
+          <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">검색 결과 {filteredAssignments.length}개</div>
         </div>
 
         <div className="mt-4 space-y-3">
@@ -164,7 +166,7 @@ export function AssignmentCheckPage({ courses }: AssignmentCheckPageProps) {
             filteredAssignments.map((item) => {
               const meta = statusMeta[item.status];
               return (
-                <article key={item.id} className="rounded-[26px] border border-slate-200 bg-slate-50 px-4 py-4">
+                <article key={item.id} className="rounded-[26px] border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
                   <div className="flex flex-col gap-4 lg:flex-row lg:items-center">
                     <div className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl border ${meta.tone} bg-white text-[20px]`}>
                       <i className={meta.icon} />

--- a/frontend/src/features/lms/pages/CommunityPage.tsx
+++ b/frontend/src/features/lms/pages/CommunityPage.tsx
@@ -191,7 +191,7 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="제목, 강의명, 강사명, 클립 제목 검색"
-              className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-indigo-400"
+              className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-400"
             />
           </label>
 
@@ -209,7 +209,7 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
                   type="button"
                   onClick={() => setFilter(item.key as FeedFilter)}
                   className={`rounded-full px-4 py-2 text-[12px] font-semibold transition ${
-                    active ? 'bg-indigo-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:border-indigo-200 hover:text-indigo-600'
+                    active ? 'bg-cyan-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:border-cyan-200 hover:text-cyan-700'
                   }`}
                 >
                   {item.label}
@@ -279,7 +279,7 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
                     type="button"
                     onClick={() => setPreviewItem(selectedItem)}
                     disabled={!selectedItem}
-                    className="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] font-semibold text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     미리보기
                   </button>
@@ -290,7 +290,7 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
                       setDetailTab('video');
                     }}
                     disabled={!selectedItem}
-                    className="flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 text-[18px] text-slate-500 transition hover:border-indigo-200 hover:text-indigo-600 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 text-[18px] text-slate-500 transition hover:border-cyan-200 hover:text-cyan-700 disabled:cursor-not-allowed disabled:opacity-50"
                     title="다시 보기"
                   >
                     <i className="ri-refresh-line" />
@@ -428,7 +428,7 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
                   {selectedItem.clips.length > 0 ? (
                     selectedItem.clips.slice(0, 4).map((clip, index) => (
                       <div key={`${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`} className="flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3">
-                        <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-indigo-100 text-[11px] font-bold text-indigo-600">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-cyan-100 text-[11px] font-bold text-cyan-700">
                           {index + 1}
                         </div>
                         <div className="min-w-0 flex-1">
@@ -453,7 +453,7 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
                 <button
                   type="button"
                   onClick={() => setPreviewItem(selectedItem)}
-                  className="mt-4 w-full rounded-full bg-indigo-600 px-4 py-3 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                  className="mt-4 w-full rounded-full bg-cyan-600 px-4 py-3 text-[12px] font-semibold text-white transition hover:bg-cyan-500"
                 >
                   전체 보기
                 </button>

--- a/frontend/src/features/lms/pages/CourseCreatePage.tsx
+++ b/frontend/src/features/lms/pages/CourseCreatePage.tsx
@@ -1,4 +1,4 @@
-﻿import { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { CourseCard, CourseCreateRequest, CourseDetail, LectureDetail } from '@myway/shared';
 import { CourseCreateCard } from '../components/CourseCreateCard';
 import { LectureStudioPage } from './LectureStudioPage';
@@ -146,7 +146,7 @@ export function CourseCreatePage({
 
   return (
     <div className="space-y-5">
-      <section className="rounded-3xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_58%,#4338ca_100%)] px-6 py-6 text-white shadow-[0_1px_3px_rgba(15,23,42,0.08)]">
+      <section className="rounded-3xl border border-cyan-100 bg-[linear-gradient(135deg,#03162a_0%,#005d93_48%,#0bc5ea_100%)] px-6 py-6 text-white shadow-[0_22px_50px_rgba(4,49,84,0.24)]">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-2xl">
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
@@ -179,7 +179,7 @@ export function CourseCreatePage({
         </div>
       </section>
 
-      <section className="rounded-3xl border border-slate-200 bg-white p-2 shadow-sm">
+      <section className="rounded-3xl border border-[#d6e6f5] bg-white p-2 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <div className="grid gap-2 md:grid-cols-2">
           {tabList.map((tab) => {
             const active = activeTab === tab.id;
@@ -208,7 +208,7 @@ export function CourseCreatePage({
         </div>
       </section>
 
-      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+      <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-4 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <div className="text-[12px] font-semibold uppercase tracking-[0.12em] text-slate-400">진행 단계</div>
@@ -232,7 +232,7 @@ export function CourseCreatePage({
               onCreate={onCreateCourse}
             />
 
-            <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+            <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
               <h2 className="text-[15px] font-bold text-slate-900">자동 전사 안내</h2>
               <p className="mt-1 text-[12px] leading-6 text-slate-500">
                 첫 차시 영상이 준비되어 있으면, 강의가 개설된 뒤 곧바로 업로드와 오디오 추출, STT 전사가 자동으로 이어집니다.
@@ -245,7 +245,7 @@ export function CourseCreatePage({
                     type="file"
                     accept="video/*"
                     onChange={(event) => setVideoFile(event.target.files?.[0] ?? null)}
-                    className="block w-full cursor-pointer rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-cyan-600 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white"
+                    className="block w-full cursor-pointer rounded-2xl border border-dashed border-[#b9d7ef] bg-[#f4faff] px-4 py-3 text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-cyan-600 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white"
                   />
                   <div className="text-[11px] leading-5 text-slate-500">
                     선택된 영상은 개설 후 자동 처리 단계로 넘어갑니다. 업로드가 끝나면 오디오 추출과 STT가 이어집니다.
@@ -273,7 +273,7 @@ export function CourseCreatePage({
           </div>
 
           <aside className="space-y-5">
-            <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+            <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
               <h2 className="text-[15px] font-bold text-slate-900">입력된 개설 정보</h2>
               <div className="mt-4 space-y-3 text-[12px] leading-6 text-slate-600">
                 <div className="rounded-2xl bg-slate-50 px-4 py-3">강의명: {pendingSummary.title}</div>
@@ -284,9 +284,9 @@ export function CourseCreatePage({
               </div>
             </section>
 
-            <section className="rounded-3xl border border-dashed border-cyan-200 bg-cyan-50 px-5 py-5 text-[12px] leading-6 text-indigo-900">
+            <section className="rounded-3xl border border-dashed border-cyan-200 bg-cyan-50 px-5 py-5 text-[12px] leading-6 text-cyan-900">
               <div className="font-bold">권한 안내</div>
-              <p className="mt-2 text-indigo-800">
+              <p className="mt-2 text-cyan-800">
                 {canManageCurrent
                   ? '현재 계정은 강의 개설 권한이 있습니다.'
                   : '현재 계정은 강의 개설 권한이 없습니다. 관리자 또는 강사 계정으로 전환해 주세요.'}
@@ -317,7 +317,7 @@ export function CourseCreatePage({
                 type="button"
                 onClick={() => void handleFinalizeCreate()}
                 disabled={busy}
-                className="rounded-full bg-cyan-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-cyan-500 disabled:cursor-not-allowed disabled:opacity-70"
+                className="rounded-full bg-[linear-gradient(135deg,#00b8e6_0%,#0077b6_100%)] px-4 py-2 text-[12px] font-semibold text-white transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-70"
               >
                 {busy ? '개설 중...' : '강의 개설하고 스튜디오 열기'}
               </button>
@@ -326,7 +326,7 @@ export function CourseCreatePage({
 
           <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.75fr)]">
             <div className="space-y-5">
-              <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+              <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
                 <h3 className="text-[14px] font-bold text-slate-900">강의 개설 전 확인</h3>
                 <div className="mt-4 grid gap-3 sm:grid-cols-2">
                   <div className="rounded-2xl bg-slate-50 px-4 py-3 text-[12px] leading-6 text-slate-600">제목: {pendingSummary.title}</div>
@@ -334,7 +334,7 @@ export function CourseCreatePage({
                   <div className="rounded-2xl bg-slate-50 px-4 py-3 text-[12px] leading-6 text-slate-600">난이도: {pendingSummary.difficulty}</div>
                   <div className="rounded-2xl bg-slate-50 px-4 py-3 text-[12px] leading-6 text-slate-600">첫 차시 수: {pendingSummary.lectureCount}개</div>
                 </div>
-                <div className="mt-4 rounded-2xl border border-dashed border-cyan-200 bg-cyan-50 px-4 py-4 text-[12px] leading-6 text-indigo-900">
+                <div className="mt-4 rounded-2xl border border-dashed border-cyan-200 bg-cyan-50 px-4 py-4 text-[12px] leading-6 text-cyan-900">
                   강의 개설 버튼을 누르면 입력값으로 실제 강의가 만들어지고, 첫 차시 영상이 있으면 업로드와 오디오 추출이 자동으로 이어집니다.
                 </div>
               </section>
@@ -347,7 +347,7 @@ export function CourseCreatePage({
                   onSelectCourse={onSelectCourse}
                 />
               ) : (
-                <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+                <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
                   <h3 className="text-[14px] font-bold text-slate-900">스튜디오 대기 상태</h3>
                   <p className="mt-2 text-[12px] leading-6 text-slate-500">
                     아직 개설된 강의가 없습니다. 위의 버튼으로 강의를 개설해야 스튜디오 설정이 활성화됩니다.
@@ -357,7 +357,7 @@ export function CourseCreatePage({
             </div>
 
             <aside className="space-y-5">
-              <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+              <section className="rounded-3xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
                 <h2 className="text-[15px] font-bold text-slate-900">자동 처리 순서</h2>
                 <div className="mt-4 space-y-3 text-[12px] leading-6 text-slate-600">
                   <div className="rounded-2xl bg-slate-50 px-4 py-3">1. 강의 개설</div>
@@ -367,7 +367,7 @@ export function CourseCreatePage({
                 </div>
               </section>
 
-              <section className="rounded-3xl border border-dashed border-cyan-200 bg-cyan-50 px-5 py-5 text-[12px] leading-6 text-indigo-900">
+              <section className="rounded-3xl border border-dashed border-cyan-200 bg-cyan-50 px-5 py-5 text-[12px] leading-6 text-cyan-900">
                 <div className="font-bold">현재 상태</div>
                 <p className="mt-2 text-indigo-800">{workspaceNote}</p>
                 <div className="mt-3 rounded-2xl bg-white/70 px-4 py-3 text-slate-600">
@@ -383,4 +383,3 @@ export function CourseCreatePage({
     </div>
   );
 }
-

--- a/frontend/src/features/lms/pages/CoursesPage.tsx
+++ b/frontend/src/features/lms/pages/CoursesPage.tsx
@@ -39,15 +39,15 @@ export function CoursesPage({
 
   return (
     <div className="space-y-5">
-      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8">
+      <section className="overflow-hidden rounded-[28px] border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <span className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">강의 상세</span>
-            <h3 className="mt-3 text-[26px] font-extrabold tracking-[-0.05em] lg:text-[32px]">선택한 강의의 상세 정보와 차시를 한 화면에서 봅니다.</h3>
-            <p className="mt-2 text-[13px] leading-6 text-white/78">차시, 공지, 자료, 시청으로 이어지는 핵심 흐름을 유지합니다.</p>
+            <span className="inline-flex rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-700">강의 상세</span>
+            <h3 className="mt-3 text-[24px] font-extrabold text-slate-900 lg:text-[28px]">선택한 강의의 상세 정보와 차시를 한 화면에서 봅니다.</h3>
+            <p className="mt-2 text-[13px] leading-6 text-slate-600">차시, 공지, 자료, 시청으로 이어지는 핵심 흐름을 유지합니다.</p>
           </div>
           {selectedCourse ? (
-            <div className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
+            <div className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-700">
               현재 선택: {selectedCourse.title}
             </div>
           ) : null}

--- a/frontend/src/features/lms/pages/CoursesPage.tsx
+++ b/frontend/src/features/lms/pages/CoursesPage.tsx
@@ -38,21 +38,21 @@ export function CoursesPage({
   }, [selectedCourse?.id]);
 
   return (
-    <div className="space-y-4">
-      <section className="overflow-hidden rounded-[26px] border border-slate-200 bg-white px-6 py-5 shadow-sm lg:px-8">
+    <div className="space-y-5">
+      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <span className="inline-flex rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-700">강의 상세</span>
-            <h3 className="mt-3 text-[22px] font-bold text-slate-900 lg:text-[26px]">선택한 강의의 상세 정보와 차시를 한 화면에서 봅니다.</h3>
-            <p className="mt-2 text-[13px] leading-6 text-slate-600">차시, 공지, 자료, 시청으로 이어지는 핵심 흐름을 유지합니다.</p>
+            <span className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">강의 상세</span>
+            <h3 className="mt-3 text-[26px] font-extrabold tracking-[-0.05em] lg:text-[32px]">선택한 강의의 상세 정보와 차시를 한 화면에서 봅니다.</h3>
+            <p className="mt-2 text-[13px] leading-6 text-white/78">차시, 공지, 자료, 시청으로 이어지는 핵심 흐름을 유지합니다.</p>
           </div>
           {selectedCourse ? (
-            <div className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-700">
+            <div className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
               현재 선택: {selectedCourse.title}
             </div>
           ) : null}
         </div>
-        <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+        <div className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
           {selectedCourse ? (
             <CourseExploreDetailPanel
               course={selectedCourse}

--- a/frontend/src/features/lms/pages/CoursesPage.tsx
+++ b/frontend/src/features/lms/pages/CoursesPage.tsx
@@ -39,15 +39,15 @@ export function CoursesPage({
 
   return (
     <div className="space-y-5">
-      <section className="overflow-hidden rounded-[28px] border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
+      <section className="overflow-hidden rounded-[28px] border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-6 shadow-sm lg:px-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <span className="inline-flex rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-700">강의 상세</span>
-            <h3 className="mt-3 text-[24px] font-extrabold text-slate-900 lg:text-[28px]">선택한 강의의 상세 정보와 차시를 한 화면에서 봅니다.</h3>
-            <p className="mt-2 text-[13px] leading-6 text-slate-600">차시, 공지, 자료, 시청으로 이어지는 핵심 흐름을 유지합니다.</p>
+            <span className="inline-flex rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">강의 상세</span>
+            <h3 className="mt-3 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900 lg:text-[28px]">강의 정보와 차시를 레퍼런스 톤으로 집중해서 확인합니다.</h3>
+            <p className="mt-2 text-[13px] leading-6 text-slate-600">차시, 공지, 자료, 시청으로 이어지는 흐름은 유지하고 시각 밀도만 정리했습니다.</p>
           </div>
           {selectedCourse ? (
-            <div className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-700">
+            <div className="rounded-full border border-cyan-100 bg-white px-3 py-1 text-[11px] font-semibold text-cyan-700">
               현재 선택: {selectedCourse.title}
             </div>
           ) : null}

--- a/frontend/src/features/lms/pages/HomePage.tsx
+++ b/frontend/src/features/lms/pages/HomePage.tsx
@@ -35,7 +35,7 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
   const averageProgress =
     dashboard?.average_progress ?? Math.round(courses.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courses.length, 1));
   const categories = [...new Set(courses.map((item) => item.category))];
-  const tags = [...new Set(courses.flatMap((course) => course.tags))].slice(0, 5);
+  const tags = [...new Set(courses.flatMap((course) => (Array.isArray(course.tags) ? course.tags : [])))].slice(0, 5);
   const continueCourse = highlightedLecture
     ? courses.find((course) => course.id === highlightedLecture.course_id) ?? courses[0] ?? null
     : courses[0] ?? null;
@@ -43,46 +43,42 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-8 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8 lg:py-10">
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
         <div className="pointer-events-none absolute right-0 top-0 h-full w-1/2 bg-[radial-gradient(circle_at_70%_30%,rgba(168,85,247,0.30),transparent_55%)]" />
         <div className="relative z-10 max-w-2xl">
-          <span className="inline-flex rounded-full bg-white/10 px-4 py-2 text-[12px] font-semibold text-white/90 backdrop-blur">
+          <span className="inline-flex rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">
             AI 기반 학습 플랫폼 · {session.user.name}
           </span>
-          <h2 className="mt-6 text-[2.45rem] font-extrabold tracking-[-0.06em] leading-[1.05] text-white lg:text-[4rem]">
-            찾기 쉽고,
-            <br />
-            보기 쉬운 학습 화면
-          </h2>
-          <p className="mt-5 max-w-xl text-[15px] leading-7 text-white/78">
+          <h2 className="mt-4 text-[26px] font-bold text-slate-900 lg:text-[30px]">학습 홈</h2>
+          <p className="mt-2 max-w-xl text-[14px] leading-6 text-slate-500">
             강의, 스크립트, 타임스탬프, 숏폼, AI 챗봇까지 한 곳에서 이어집니다.
             홈에서 시작해 바로 학습 흐름으로 들어가세요.
           </p>
 
-          <div className="mt-8 flex flex-wrap gap-3">
+          <div className="mt-5 flex flex-wrap gap-2">
             <button
               type="button"
               onClick={() => onNavigate('courses')}
-              className="rounded-full bg-white px-5 py-3 text-[13px] font-semibold text-indigo-700 shadow-[0_12px_28px_rgba(15,23,42,0.14)] transition hover:-translate-y-0.5"
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-[13px] font-semibold text-white transition hover:bg-indigo-500"
             >
               강의 탐색하기
             </button>
             <button
               type="button"
               onClick={() => onNavigate('dashboard')}
-              className="rounded-full border border-white/25 bg-white/10 px-5 py-3 text-[13px] font-semibold text-white backdrop-blur transition hover:bg-white/15"
+              className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-[13px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
             >
               로그인 후 계속
             </button>
           </div>
 
-          <div className="mt-8 flex flex-wrap gap-2">
+          <div className="mt-4 flex flex-wrap gap-2">
             {tags.length > 0 ? tags.map((tag) => (
-              <span key={tag} className="rounded-full bg-white/10 px-3 py-1.5 text-[11px] font-medium text-white/85 backdrop-blur">
+              <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-medium text-slate-600">
                 #{tag}
               </span>
             )) : (
-              <span className="rounded-full bg-white/10 px-3 py-1.5 text-[11px] font-medium text-white/75 backdrop-blur">
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-medium text-slate-600">
                 추천 태그가 없습니다.
               </span>
             )}
@@ -96,7 +92,7 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
             key={action.page}
             type="button"
             onClick={() => onNavigate(action.page)}
-            className="group rounded-[28px] border border-[var(--app-border)] bg-white px-5 py-5 text-left shadow-[0_1px_3px_rgba(15,23,42,0.05)] transition hover:-translate-y-0.5 hover:border-[var(--app-border-focus)] hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)]"
+            className="group rounded-2xl border border-slate-200 bg-white px-5 py-5 text-left shadow-sm transition hover:border-indigo-200"
           >
             <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-50 text-[22px] text-indigo-600 transition group-hover:bg-indigo-600 group-hover:text-white">
               <i className={action.icon} />
@@ -108,25 +104,25 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
       </section>
 
       <section className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(340px,0.85fr)]">
-        <div className="rounded-[30px] border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm">
+        <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h3 className="text-[15px] font-bold text-[var(--app-text)]">지금 이어볼 강의</h3>
               <p className="mt-1 text-[12px] text-[var(--app-text-muted)]">로그인 후 처음 보는 홈에서도 바로 다음 학습으로 이동합니다.</p>
             </div>
             <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">
-              {dashboard?.courses.filter((course) => course.enrolled).length ?? 0}개 수강 중
+              {dashboard?.courses?.filter((course) => course.enrolled).length ?? 0}개 수강 중
             </div>
           </div>
 
           {highlightedLecture && continueCourse ? (
             <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-              <div className="rounded-[26px] bg-[linear-gradient(135deg,#070b1b_0%,#1d4ed8_60%,#312e81_100%)] px-5 py-5 text-white">
-                <div className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90">
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
+                <div className="inline-flex rounded-full bg-indigo-100 px-3 py-1 text-[11px] font-semibold text-indigo-700">
                   홈 시작
                 </div>
-                <div className="mt-4 text-[22px] font-extrabold tracking-[-0.04em]">{highlightedLecture.title}</div>
-                <div className="mt-2 text-[13px] leading-6 text-white/75">
+                <div className="mt-4 text-[20px] font-bold text-slate-900">{highlightedLecture.title}</div>
+                <div className="mt-2 text-[13px] leading-6 text-slate-500">
                   {highlightedLecture.course_title} · {highlightedLecture.course_instructor}
                 </div>
                 <div className="mt-6 flex flex-wrap gap-2">
@@ -136,21 +132,21 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
                       onSelectCourse(highlightedLecture.course_id);
                       onNavigate('courses');
                     }}
-                    className="rounded-full bg-white px-4 py-2 text-[12px] font-semibold text-indigo-700 transition hover:bg-indigo-50"
+                    className="rounded-lg bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                   >
                     내 강의 보기
                   </button>
                   <button
                     type="button"
                     onClick={() => onNavigate('ai-chat')}
-                    className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-white/15"
+                    className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
                   >
                     챗봇으로 질문
                   </button>
                 </div>
               </div>
 
-              <div className="rounded-[26px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-5">
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
                 <div className="flex items-center justify-between">
                   <div>
                     <div className="text-[12px] font-semibold text-indigo-600">진도</div>
@@ -196,7 +192,7 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
         </div>
 
         <div className="space-y-4">
-          <div className="rounded-[30px] border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm">
+          <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <h3 className="text-[15px] font-bold text-[var(--app-text)]">학습 요약</h3>
@@ -235,7 +231,7 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
             </div>
           </div>
 
-          <div className="rounded-[30px] border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm">
+          <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <h3 className="text-[15px] font-bold text-[var(--app-text)]">추천 카테고리</h3>
             <div className="mt-4 flex flex-wrap gap-2">
               {categories.length > 0 ? categories.map((category) => (

--- a/frontend/src/features/lms/pages/HomePage.tsx
+++ b/frontend/src/features/lms/pages/HomePage.tsx
@@ -34,8 +34,8 @@ function circularProgress(value: number) {
 export function HomePage({ session, dashboard, courses, highlightedLecture, onNavigate, onSelectCourse }: HomePageProps) {
   const averageProgress =
     dashboard?.average_progress ?? Math.round(courses.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courses.length, 1));
-  const categories = [...new Set(courses.map((item) => item.category).filter((category): category is string => Boolean(category)))];
-  const tags = [...new Set(courses.flatMap((course) => (Array.isArray(course.tags) ? course.tags : [])))].slice(0, 5);
+  const categories = [...new Set(courses.map((item) => item.category))];
+  const tags = [...new Set(courses.flatMap((course) => course.tags))].slice(0, 5);
   const continueCourse = highlightedLecture
     ? courses.find((course) => course.id === highlightedLecture.course_id) ?? courses[0] ?? null
     : courses[0] ?? null;
@@ -43,14 +43,14 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[30px] bg-[linear-gradient(135deg,#082f49_0%,#0f766e_54%,#1f2937_100%)] px-6 py-8 text-white shadow-[0_22px_48px_rgba(15,23,42,0.18)] lg:px-8 lg:py-10">
-        <div className="pointer-events-none absolute right-0 top-0 h-full w-1/2 bg-[radial-gradient(circle_at_70%_30%,rgba(34,211,238,0.24),transparent_55%)]" />
+      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-8 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8 lg:py-10">
+        <div className="pointer-events-none absolute right-0 top-0 h-full w-1/2 bg-[radial-gradient(circle_at_70%_30%,rgba(168,85,247,0.30),transparent_55%)]" />
         <div className="relative z-10 max-w-2xl">
           <span className="inline-flex rounded-full bg-white/10 px-4 py-2 text-[12px] font-semibold text-white/90 backdrop-blur">
             AI 기반 학습 플랫폼 · {session.user.name}
           </span>
-          <h2 className="mt-6 text-[2.25rem] font-extrabold tracking-[-0.04em] leading-[1.05] text-white lg:text-[3.4rem]">
-            찾기 쉽고
+          <h2 className="mt-6 text-[2.45rem] font-extrabold tracking-[-0.06em] leading-[1.05] text-white lg:text-[4rem]">
+            찾기 쉽고,
             <br />
             보기 쉬운 학습 화면
           </h2>
@@ -63,17 +63,17 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
             <button
               type="button"
               onClick={() => onNavigate('courses')}
-              className="min-h-11 rounded-xl bg-white px-5 py-3 text-[13px] font-semibold text-cyan-800 shadow-[0_12px_28px_rgba(15,23,42,0.14)] transition hover:-translate-y-0.5"
+              className="rounded-full bg-white px-5 py-3 text-[13px] font-semibold text-indigo-700 shadow-[0_12px_28px_rgba(15,23,42,0.14)] transition hover:-translate-y-0.5"
             >
               강의 탐색하기
             </button>
-              <button
-                type="button"
-                onClick={() => onNavigate('dashboard')}
-                className="min-h-11 rounded-xl border border-white/25 bg-white/10 px-5 py-3 text-[13px] font-semibold text-white backdrop-blur transition hover:bg-white/15"
-              >
-                대시보드 보기
-              </button>
+            <button
+              type="button"
+              onClick={() => onNavigate('dashboard')}
+              className="rounded-full border border-white/25 bg-white/10 px-5 py-3 text-[13px] font-semibold text-white backdrop-blur transition hover:bg-white/15"
+            >
+              로그인 후 계속
+            </button>
           </div>
 
           <div className="mt-8 flex flex-wrap gap-2">
@@ -96,9 +96,9 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
             key={action.page}
             type="button"
             onClick={() => onNavigate(action.page)}
-            className="group rounded-[28px] border border-[var(--app-border)] bg-white px-5 py-5 text-left shadow-[0_1px_3px_rgba(15,23,42,0.05)] transition hover:-translate-y-0.5 hover:border-cyan-200 hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)]"
+            className="group rounded-[28px] border border-[var(--app-border)] bg-white px-5 py-5 text-left shadow-[0_1px_3px_rgba(15,23,42,0.05)] transition hover:-translate-y-0.5 hover:border-[var(--app-border-focus)] hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)]"
           >
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-cyan-50 text-[22px] text-cyan-700 transition group-hover:bg-cyan-600 group-hover:text-white">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-50 text-[22px] text-indigo-600 transition group-hover:bg-indigo-600 group-hover:text-white">
               <i className={action.icon} />
             </div>
             <div className="mt-4 text-[14px] font-bold text-[var(--app-text)]">{action.label}</div>
@@ -114,14 +114,14 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
               <h3 className="text-[15px] font-bold text-[var(--app-text)]">지금 이어볼 강의</h3>
               <p className="mt-1 text-[12px] text-[var(--app-text-muted)]">로그인 후 처음 보는 홈에서도 바로 다음 학습으로 이동합니다.</p>
             </div>
-            <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
-              {dashboard?.courses?.filter((course) => course.enrolled).length ?? 0}개 수강 중
+            <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">
+              {dashboard?.courses.filter((course) => course.enrolled).length ?? 0}개 수강 중
             </div>
           </div>
 
           {highlightedLecture && continueCourse ? (
             <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-              <div className="rounded-[26px] bg-[linear-gradient(135deg,#082f49_0%,#0e7490_60%,#1f2937_100%)] px-5 py-5 text-white">
+              <div className="rounded-[26px] bg-[linear-gradient(135deg,#070b1b_0%,#1d4ed8_60%,#312e81_100%)] px-5 py-5 text-white">
                 <div className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90">
                   홈 시작
                 </div>
@@ -136,14 +136,14 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
                       onSelectCourse(highlightedLecture.course_id);
                       onNavigate('courses');
                     }}
-                    className="min-h-10 rounded-xl bg-white px-4 py-2 text-[12px] font-semibold text-cyan-800 transition hover:bg-cyan-50"
+                    className="rounded-full bg-white px-4 py-2 text-[12px] font-semibold text-indigo-700 transition hover:bg-indigo-50"
                   >
                     내 강의 보기
                   </button>
                   <button
                     type="button"
                     onClick={() => onNavigate('ai-chat')}
-                    className="min-h-10 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-white/15"
+                    className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-white/15"
                   >
                     챗봇으로 질문
                   </button>
@@ -153,7 +153,7 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
               <div className="rounded-[26px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-5">
                 <div className="flex items-center justify-between">
                   <div>
-                      <div className="text-[12px] font-semibold text-cyan-700">진도</div>
+                    <div className="text-[12px] font-semibold text-indigo-600">진도</div>
                     <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-[var(--app-text)]">
                       {continueCourse.progress_percent}%
                     </div>
@@ -166,7 +166,7 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
                   </div>
                 </div>
                 <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
-                  <div className="h-full rounded-full bg-cyan-500" style={{ width: `${Math.max(continueCourse.progress_percent, 8)}%` }} />
+                  <div className="h-full rounded-full bg-indigo-500" style={{ width: `${Math.max(continueCourse.progress_percent, 8)}%` }} />
                 </div>
                 <div className="mt-4 space-y-2">
                   <div className="rounded-2xl bg-white px-4 py-3">
@@ -209,7 +209,7 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
                   cy="18"
                   r="16"
                   fill="none"
-                  stroke="rgb(8, 145, 178)"
+                  stroke="rgb(79, 70, 229)"
                   strokeWidth="2.5"
                   strokeDasharray={`${progress.circumference} ${progress.circumference}`}
                   strokeDashoffset={progress.offset}
@@ -221,7 +221,7 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
               <div className="rounded-2xl bg-[var(--app-surface-soft)] px-4 py-3">
                 <div className="text-[11px] text-[var(--app-text-muted)]">수강 중</div>
                 <div className="mt-1 text-[18px] font-extrabold text-[var(--app-text)]">
-                  {dashboard?.courses?.filter((course) => course.enrolled).length ?? 0}
+                  {dashboard?.courses.filter((course) => course.enrolled).length ?? 0}
                 </div>
               </div>
               <div className="rounded-2xl bg-[var(--app-surface-soft)] px-4 py-3">

--- a/frontend/src/features/lms/pages/HomePage.tsx
+++ b/frontend/src/features/lms/pages/HomePage.tsx
@@ -1,6 +1,4 @@
-import type { CourseCard, Dashboard, LectureDetail, LoginResponse } from '@myway/shared';
-import { CourseExploreCard } from '../components/CourseExploreCard';
-import { CourseExploreFilters } from '../components/CourseExploreFilters';
+﻿import type { CourseCard, Dashboard, LectureDetail, LoginResponse } from '@myway/shared';
 import { StatePanel } from '../components/StatePanel';
 
 type HomePageProps = {
@@ -12,170 +10,247 @@ type HomePageProps = {
   onSelectCourse: (courseId: string) => void;
 };
 
-const quickActions = [
-  { page: 'courses' as const, label: '내 강의', icon: 'ri-book-open-line', hint: '수강 중인 강의와 진도 확인' },
-  { page: 'shortform' as const, label: '숏폼', icon: 'ri-scissors-cut-line', hint: '핵심 장면으로 다시 보기' },
-  { page: 'ai-chat' as const, label: 'AI 챗봇', icon: 'ri-robot-line', hint: '강의 질문 바로 하기' },
-  { page: 'dashboard' as const, label: '대시보드', icon: 'ri-dashboard-3-line', hint: '학습 현황을 다시 보기' },
-];
-
-function countUnique(values: string[]): number {
-  return new Set(values).size;
+function formatStudyHours(totalMinutes: number) {
+  if (totalMinutes <= 0) {
+    return '0시간';
+  }
+  return `${Math.round(totalMinutes / 60)}시간`;
 }
 
-function circularProgress(value: number) {
-  const radius = 16;
-  const circumference = 2 * Math.PI * radius;
-  const progress = Math.max(Math.min(value, 100), 0);
-  const offset = circumference - (progress / 100) * circumference;
-  return { circumference, offset, progress };
+function getPopularKeywords(courses: CourseCard[]) {
+  const keywords = courses.flatMap((course) => [course.category, ...(Array.isArray(course.tags) ? course.tags : [])]);
+  return [...new Set(keywords)].filter(Boolean).slice(0, 6);
+}
+
+function courseVisualClasses(palette: CourseCard['thumbnail_palette']) {
+  if (palette === 'emerald') return 'from-emerald-900 via-emerald-700 to-teal-500';
+  if (palette === 'violet') return 'from-violet-950 via-purple-700 to-fuchsia-500';
+  if (palette === 'amber') return 'from-amber-950 via-amber-700 to-orange-400';
+  return 'from-blue-950 via-cyan-800 to-sky-500';
 }
 
 export function HomePage({ session, dashboard, courses, highlightedLecture, onNavigate, onSelectCourse }: HomePageProps) {
   const averageProgress =
     dashboard?.average_progress ?? Math.round(courses.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courses.length, 1));
-  const categories = [...new Set(courses.map((item) => item.category))];
-  const tags = [...new Set(courses.flatMap((course) => (Array.isArray(course.tags) ? course.tags : [])))].slice(0, 5);
+  const enrolledCourses = dashboard?.courses?.filter((course) => course.enrolled).length ?? 0;
+  const totalLectures = courses.reduce((sum, course) => sum + course.lecture_count, 0);
+  const totalCompletedLectures = courses.reduce((sum, course) => sum + course.completed_lectures, 0);
+  const totalStudyMinutes = courses.reduce(
+    (sum, course) => sum + Math.round(course.total_duration_minutes * (Math.max(course.progress_percent, 0) / 100)),
+    0,
+  );
+  const achievements = Math.max(Math.round(totalCompletedLectures / 3), 0);
+  const popularKeywords = getPopularKeywords(courses);
   const continueCourse = highlightedLecture
     ? courses.find((course) => course.id === highlightedLecture.course_id) ?? courses[0] ?? null
     : courses[0] ?? null;
-  const progress = circularProgress(averageProgress);
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
-        <div className="pointer-events-none absolute right-0 top-0 h-full w-1/2 bg-[radial-gradient(circle_at_70%_30%,rgba(168,85,247,0.30),transparent_55%)]" />
-        <div className="relative z-10 max-w-2xl">
-          <span className="inline-flex rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">
-            AI 기반 학습 플랫폼 · {session.user.name}
-          </span>
-          <h2 className="mt-4 text-[26px] font-bold text-slate-900 lg:text-[30px]">학습 홈</h2>
-          <p className="mt-2 max-w-xl text-[14px] leading-6 text-slate-500">
-            강의, 스크립트, 타임스탬프, 숏폼, AI 챗봇까지 한 곳에서 이어집니다.
-            홈에서 시작해 바로 학습 흐름으로 들어가세요.
-          </p>
+      <section className="relative overflow-hidden rounded-[26px] border border-cyan-200/35 bg-[radial-gradient(circle_at_15%_10%,rgba(34,211,238,0.28),transparent_32%),radial-gradient(circle_at_75%_30%,rgba(14,116,144,0.45),transparent_45%),linear-gradient(120deg,#031d3a_0%,#05345f_55%,#0a4168_100%)] p-6 text-white shadow-[0_20px_60px_rgba(8,47,73,0.45)] lg:p-8">
+        <div className="pointer-events-none absolute -right-16 top-10 h-64 w-64 rounded-full border border-cyan-300/30" />
+        <div className="pointer-events-none absolute right-16 top-24 h-44 w-44 rounded-full border border-cyan-300/15" />
+        <div className="pointer-events-none absolute bottom-8 right-10 h-20 w-20 rounded-2xl border border-cyan-200/25 bg-cyan-300/10 backdrop-blur" />
 
-          <div className="mt-5 flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={() => onNavigate('courses')}
-              className="rounded-lg bg-indigo-600 px-4 py-2 text-[13px] font-semibold text-white transition hover:bg-indigo-500"
-            >
-              강의 탐색하기
-            </button>
-            <button
-              type="button"
-              onClick={() => onNavigate('dashboard')}
-              className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-[13px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
-            >
-              로그인 후 계속
-            </button>
+        <div className="relative z-10 grid items-center gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(260px,0.9fr)]">
+          <div>
+            <span className="inline-flex rounded-full border border-cyan-200/40 bg-white/10 px-3 py-1 text-[11px] font-semibold tracking-[0.03em] text-cyan-100">
+              AI Learning Home · {session.user.name}
+            </span>
+            <h2 className="mt-5 text-[34px] font-extrabold leading-[1.2] tracking-[-0.03em] text-white lg:text-[46px]">
+              AI로 배우고,
+              <br />
+              성장하는 실력
+            </h2>
+            <p className="mt-4 max-w-xl text-[15px] leading-7 text-cyan-50/90">
+              2026년, 학습부터 실전까지 이어지는 개인 맞춤형 러닝 허브. 강의 탐색부터 AI 질문, 숏폼 복습까지 한 흐름으로 시작하세요.
+            </p>
+
+            <div className="mt-6 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => onNavigate('courses')}
+                className="rounded-xl bg-cyan-300 px-5 py-2.5 text-[13px] font-bold text-cyan-950 transition hover:bg-cyan-200"
+              >
+                강의 탐색 시작
+              </button>
+              <button
+                type="button"
+                onClick={() => onNavigate('ai-chat')}
+                className="rounded-xl border border-cyan-100/30 bg-white/10 px-5 py-2.5 text-[13px] font-semibold text-cyan-50 backdrop-blur transition hover:bg-white/20"
+              >
+                AI 도우미 열기
+              </button>
+            </div>
           </div>
 
-          <div className="mt-4 flex flex-wrap gap-2">
-            {tags.length > 0 ? tags.map((tag) => (
-              <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-medium text-slate-600">
-                #{tag}
-              </span>
-            )) : (
-              <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-medium text-slate-600">
-                추천 태그가 없습니다.
-              </span>
-            )}
+          <div className="relative mx-auto w-full max-w-[360px]">
+            <div className="absolute inset-0 rounded-[28px] bg-cyan-300/15 blur-2xl" />
+            <div className="relative rounded-[28px] border border-cyan-100/25 bg-white/10 p-6 backdrop-blur">
+              <div className="mx-auto flex h-28 w-28 items-center justify-center rounded-[26px] border border-cyan-200/35 bg-gradient-to-br from-cyan-200/95 to-cyan-400/70 text-[48px] font-black text-slate-900 shadow-[0_20px_40px_rgba(34,211,238,0.35)]">
+                AI
+              </div>
+              <div className="mt-5 grid grid-cols-2 gap-3">
+                <div className="rounded-2xl border border-cyan-100/20 bg-slate-950/35 px-3 py-2">
+                  <div className="text-[11px] text-cyan-100/80">진행률</div>
+                  <div className="mt-1 text-[18px] font-extrabold text-cyan-100">{averageProgress}%</div>
+                </div>
+                <div className="rounded-2xl border border-cyan-100/20 bg-slate-950/35 px-3 py-2">
+                  <div className="text-[11px] text-cyan-100/80">수강 강의</div>
+                  <div className="mt-1 text-[18px] font-extrabold text-cyan-100">{enrolledCourses}개</div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>
 
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        {quickActions.map((action) => (
-          <button
-            key={action.page}
-            type="button"
-            onClick={() => onNavigate(action.page)}
-            className="group rounded-2xl border border-slate-200 bg-white px-5 py-5 text-left shadow-sm transition hover:border-indigo-200"
-          >
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-50 text-[22px] text-indigo-600 transition group-hover:bg-indigo-600 group-hover:text-white">
-              <i className={action.icon} />
+      <section className="relative -mt-2 rounded-[22px] border border-cyan-200/20 bg-[linear-gradient(145deg,#0a2f56_0%,#0b3c63_45%,#11496f_100%)] p-5 text-cyan-50 shadow-[0_16px_36px_rgba(8,47,73,0.35)] lg:p-6">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(220px,0.65fr)] lg:items-center">
+          <div>
+            <h3 className="text-[28px] font-extrabold tracking-[-0.02em]">원하는 강의를 찾아보세요</h3>
+            <div className="mt-4 flex items-center rounded-2xl border border-cyan-100/30 bg-white/95 px-4 py-3 text-slate-700">
+              <i className="ri-search-line text-[18px] text-slate-500" />
+              <input
+                type="text"
+                value="강의명, 키워드, 스킬 등을 검색해보세요"
+                readOnly
+                className="ml-3 w-full bg-transparent text-[14px] text-slate-700 outline-none"
+                aria-label="강의 검색"
+              />
+              <button
+                type="button"
+                onClick={() => onNavigate('courses')}
+                className="rounded-lg bg-cyan-500 px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-cyan-600"
+              >
+                이동
+              </button>
             </div>
-            <div className="mt-4 text-[14px] font-bold text-[var(--app-text)]">{action.label}</div>
-            <div className="mt-1 text-[12px] leading-6 text-[var(--app-text-muted)]">{action.hint}</div>
-          </button>
-        ))}
-      </section>
-
-      <section className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(340px,0.85fr)]">
-        <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <h3 className="text-[15px] font-bold text-[var(--app-text)]">지금 이어볼 강의</h3>
-              <p className="mt-1 text-[12px] text-[var(--app-text-muted)]">로그인 후 처음 보는 홈에서도 바로 다음 학습으로 이동합니다.</p>
-            </div>
-            <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">
-              {dashboard?.courses?.filter((course) => course.enrolled).length ?? 0}개 수강 중
+            <div className="mt-3 flex flex-wrap gap-2">
+              {(popularKeywords.length > 0 ? popularKeywords : ['프롬프트 엔지니어링', 'ChatGPT 활용', '파이썬']).map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => onNavigate('courses')}
+                  className="rounded-full border border-cyan-100/25 bg-white/10 px-3 py-1 text-[11px] font-medium text-cyan-50/95 transition hover:bg-white/20"
+                >
+                  {tag}
+                </button>
+              ))}
             </div>
           </div>
 
+          <div className="rounded-2xl border border-cyan-100/25 bg-white/10 px-4 py-4 backdrop-blur">
+            <div className="text-[12px] font-semibold text-cyan-100/85">AI 맞춤 추천</div>
+            <div className="mt-2 text-[15px] font-bold text-white">{session.user.name}님에게 맞는 코스</div>
+            <p className="mt-1 text-[12px] leading-6 text-cyan-100/80">학습 기록과 관심 카테고리를 기반으로 오늘의 추천 강의를 준비했습니다.</p>
+            <button
+              type="button"
+              onClick={() => onNavigate('courses')}
+              className="mt-3 inline-flex items-center gap-1 rounded-lg border border-cyan-200/35 bg-cyan-300/20 px-3 py-1.5 text-[12px] font-semibold text-cyan-100 transition hover:bg-cyan-300/30"
+            >
+              추천 강의 보기
+              <i className="ri-arrow-right-s-line" />
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-[24px] font-extrabold tracking-[-0.02em] text-slate-900">내 학습 현황</h3>
+          <button
+            type="button"
+            onClick={() => onNavigate('dashboard')}
+            className="inline-flex items-center gap-1 text-[12px] font-semibold text-cyan-700 transition hover:text-cyan-900"
+          >
+            학습 통계 전체 보기
+            <i className="ri-arrow-right-s-line" />
+          </button>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm">
+            <div className="text-[12px] font-semibold text-slate-500">학습 진행률</div>
+            <div className="mt-2 text-[36px] font-black tracking-[-0.03em] text-slate-900">{averageProgress}%</div>
+            <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100">
+              <div className="h-full rounded-full bg-cyan-500" style={{ width: `${Math.max(averageProgress, 6)}%` }} />
+            </div>
+            <div className="mt-2 text-[11px] text-slate-500">전체 진도 {totalCompletedLectures} / {Math.max(totalLectures, 0)} 강의</div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm">
+            <div className="text-[12px] font-semibold text-slate-500">연속 학습일</div>
+            <div className="mt-2 flex items-end justify-between">
+              <div className="text-[36px] font-black tracking-[-0.03em] text-slate-900">{Math.max(enrolledCourses * 3, 1)}일</div>
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600">
+                <i className="ri-fire-line text-[20px]" />
+              </span>
+            </div>
+            <div className="mt-2 text-[11px] text-slate-500">최근 학습 흐름 유지 중</div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm">
+            <div className="text-[12px] font-semibold text-slate-500">학습 시간</div>
+            <div className="mt-2 flex items-end justify-between">
+              <div className="text-[36px] font-black tracking-[-0.03em] text-slate-900">{formatStudyHours(totalStudyMinutes)}</div>
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-cyan-100 text-cyan-600">
+                <i className="ri-time-line text-[20px]" />
+              </span>
+            </div>
+            <div className="mt-2 text-[11px] text-slate-500">누적 기반 환산 시간</div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm">
+            <div className="text-[12px] font-semibold text-slate-500">획득 배지</div>
+            <div className="mt-2 flex items-end justify-between">
+              <div className="text-[36px] font-black tracking-[-0.03em] text-slate-900">{achievements}개</div>
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600">
+                <i className="ri-trophy-line text-[20px]" />
+              </span>
+            </div>
+            <div className="mt-2 text-[11px] text-slate-500">다음 배지까지 1개</div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+        <div>
+          <div className="flex items-center justify-between">
+            <h3 className="text-[16px] font-bold text-slate-900">지금 이어볼 강의</h3>
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">학습 재개</span>
+          </div>
+
           {highlightedLecture && continueCourse ? (
-            <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
-                <div className="inline-flex rounded-full bg-indigo-100 px-3 py-1 text-[11px] font-semibold text-indigo-700">
-                  홈 시작
-                </div>
-                <div className="mt-4 text-[20px] font-bold text-slate-900">{highlightedLecture.title}</div>
-                <div className="mt-2 text-[13px] leading-6 text-slate-500">
-                  {highlightedLecture.course_title} · {highlightedLecture.course_instructor}
-                </div>
-                <div className="mt-6 flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      onSelectCourse(highlightedLecture.course_id);
-                      onNavigate('courses');
-                    }}
-                    className="rounded-lg bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
-                  >
-                    내 강의 보기
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onNavigate('ai-chat')}
-                    className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
-                  >
-                    챗봇으로 질문
-                  </button>
-                </div>
+            <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
+              <div className="text-[11px] font-semibold text-cyan-700">CONTINUE</div>
+              <div className="mt-2 text-[20px] font-bold tracking-[-0.02em] text-slate-900">{highlightedLecture.title}</div>
+              <div className="mt-1 text-[13px] text-slate-500">{highlightedLecture.course_title} · {highlightedLecture.course_instructor}</div>
+              <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
+                <div className="h-full rounded-full bg-cyan-500" style={{ width: `${Math.max(continueCourse.progress_percent, 8)}%` }} />
+              </div>
+              <div className="mt-2 text-[12px] text-slate-500">
+                {continueCourse.completed_lectures}/{continueCourse.lecture_count}차시 완료 · {continueCourse.progress_percent}% 진행
               </div>
 
-              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <div className="text-[12px] font-semibold text-indigo-600">진도</div>
-                    <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-[var(--app-text)]">
-                      {continueCourse.progress_percent}%
-                    </div>
-                  </div>
-                  <div className="text-right text-[11px] text-[var(--app-text-muted)]">
-                    <div>
-                      {continueCourse.completed_lectures}/{continueCourse.lecture_count}차시
-                    </div>
-                    <div>{Math.round(continueCourse.total_duration_minutes * (continueCourse.progress_percent / 100))}분 진행</div>
-                  </div>
-                </div>
-                <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
-                  <div className="h-full rounded-full bg-indigo-500" style={{ width: `${Math.max(continueCourse.progress_percent, 8)}%` }} />
-                </div>
-                <div className="mt-4 space-y-2">
-                  <div className="rounded-2xl bg-white px-4 py-3">
-                    <div className="text-[11px] font-semibold text-[var(--app-text-muted)]">카테고리</div>
-                    <div className="mt-1 text-[13px] font-semibold text-[var(--app-text)]">{continueCourse.category}</div>
-                  </div>
-                  <div className="rounded-2xl bg-white px-4 py-3">
-                    <div className="text-[11px] font-semibold text-[var(--app-text-muted)]">다음 행동</div>
-                    <div className="mt-1 text-[13px] font-semibold text-[var(--app-text)]">
-                      {highlightedLecture.next_lecture_id ? '다음 차시로 이동' : '복습 또는 숏폼 제작'}
-                    </div>
-                  </div>
-                </div>
+              <div className="mt-5 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    onSelectCourse(highlightedLecture.course_id);
+                    onNavigate('courses');
+                  }}
+                  className="rounded-lg bg-cyan-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-cyan-500"
+                >
+                  강의로 이동
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onNavigate('shortform')}
+                  className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-300 hover:text-cyan-700"
+                >
+                  숏폼 복습
+                </button>
               </div>
             </div>
           ) : (
@@ -191,83 +266,59 @@ export function HomePage({ session, dashboard, courses, highlightedLecture, onNa
           )}
         </div>
 
-        <div className="space-y-4">
-          <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <h3 className="text-[15px] font-bold text-[var(--app-text)]">학습 요약</h3>
-                <p className="mt-1 text-[12px] text-[var(--app-text-muted)]">홈에서 한 번에 현재 상태를 확인합니다.</p>
-              </div>
-              <svg className="h-16 w-16 -rotate-90" viewBox="0 0 36 36">
-                <circle cx="18" cy="18" r="16" fill="none" stroke="rgba(15,23,42,0.08)" strokeWidth="2.5" />
-                <circle
-                  cx="18"
-                  cy="18"
-                  r="16"
-                  fill="none"
-                  stroke="rgb(79, 70, 229)"
-                  strokeWidth="2.5"
-                  strokeDasharray={`${progress.circumference} ${progress.circumference}`}
-                  strokeDashoffset={progress.offset}
-                  strokeLinecap="round"
-                />
-              </svg>
-            </div>
-            <div className="mt-4 grid grid-cols-3 gap-3">
-              <div className="rounded-2xl bg-[var(--app-surface-soft)] px-4 py-3">
-                <div className="text-[11px] text-[var(--app-text-muted)]">수강 중</div>
-                <div className="mt-1 text-[18px] font-extrabold text-[var(--app-text)]">
-                  {dashboard?.courses.filter((course) => course.enrolled).length ?? 0}
-                </div>
-              </div>
-              <div className="rounded-2xl bg-[var(--app-surface-soft)] px-4 py-3">
-                <div className="text-[11px] text-[var(--app-text-muted)]">평균 진도</div>
-                <div className="mt-1 text-[18px] font-extrabold text-[var(--app-text)]">{averageProgress}%</div>
-              </div>
-              <div className="rounded-2xl bg-[var(--app-surface-soft)] px-4 py-3">
-                <div className="text-[11px] text-[var(--app-text-muted)]">카테고리</div>
-                <div className="mt-1 text-[18px] font-extrabold text-[var(--app-text)]">{categories.length}</div>
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
-            <h3 className="text-[15px] font-bold text-[var(--app-text)]">추천 카테고리</h3>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {categories.length > 0 ? categories.map((category) => (
-                <span key={category} className="rounded-full bg-[var(--app-surface-soft)] px-3 py-1.5 text-[12px] font-semibold text-[var(--app-text-secondary)]">
-                  {category}
-                </span>
-              )) : (
-                <span className="rounded-full bg-[var(--app-surface-soft)] px-3 py-1.5 text-[12px] font-semibold text-[var(--app-text-secondary)]">
-                  강의가 없습니다.
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
       </section>
 
       <section className="space-y-4">
-        <CourseExploreFilters
-          categories={categories}
-          activeCategory=""
-          onCategoryChange={() => undefined}
-          activeStatus="all"
-          onStatusChange={() => undefined}
-          resultCount={courses.length}
-        />
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-[24px] font-extrabold tracking-[-0.02em] text-slate-900">추천 강의</h3>
+          <button
+            type="button"
+            onClick={() => onNavigate('courses')}
+            className="inline-flex items-center gap-1 text-[12px] font-semibold text-cyan-700 transition hover:text-cyan-900"
+          >
+            전체 보기
+            <i className="ri-arrow-right-s-line" />
+          </button>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
           {courses.slice(0, 6).map((course) => (
-            <CourseExploreCard
+            <button
               key={course.id}
-              course={course}
-              selected={false}
-              onSelect={(courseId) => {
-                onSelectCourse(courseId);
+              type="button"
+              onClick={() => {
+                onSelectCourse(course.id);
                 onNavigate('courses');
               }}
-            />
+              className="group overflow-hidden rounded-2xl border border-slate-200 bg-white text-left shadow-sm transition hover:-translate-y-1 hover:shadow-xl"
+            >
+              <div className={`relative h-32 bg-gradient-to-br ${courseVisualClasses(course.thumbnail_palette)}`}>
+                <div className="absolute left-3 top-3 rounded-full bg-rose-500 px-2 py-0.5 text-[10px] font-bold text-white">
+                  {course.difficulty === 'advanced' ? 'BEST' : 'NEW'}
+                </div>
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.28),transparent_45%)]" />
+                <div className="absolute bottom-3 right-3 rounded-full bg-white/20 px-2 py-0.5 text-[10px] font-semibold text-white">
+                  {course.category}
+                </div>
+              </div>
+              <div className="space-y-2 px-3 py-3">
+                <div className="line-clamp-1 text-[15px] font-bold tracking-[-0.02em] text-slate-900">{course.title}</div>
+                <div className="line-clamp-1 text-[12px] text-slate-500">{course.description}</div>
+                <div className="flex items-center gap-2 text-[11px] text-slate-500">
+                  <span className="rounded-full bg-cyan-50 px-2 py-0.5 font-semibold text-cyan-700">
+                    {course.difficulty === 'beginner' ? '입문' : course.difficulty === 'intermediate' ? '중급' : '고급'}
+                  </span>
+                  <span>
+                    {Math.max(course.total_duration_minutes, 0) > 60
+                      ? `${Math.round(course.total_duration_minutes / 60)}시간`
+                      : `${course.total_duration_minutes}분`}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-[11px] text-slate-500">
+                  <span>★ {Number.isFinite(course.rating) ? course.rating.toFixed(1) : '4.8'}</span>
+                  <span>수강 {Number.isFinite(course.student_count) ? course.student_count : 0}</span>
+                </div>
+              </div>
+            </button>
           ))}
         </div>
       </section>

--- a/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
@@ -90,10 +90,10 @@ export function InstructorDashboardPage({ dashboard, courses, insights }: Instru
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
+      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-6 shadow-sm lg:px-8">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px] xl:items-end">
           <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">
+            <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
               <i className="ri-presentation-line" />
               Instructor Dashboard
             </div>

--- a/frontend/src/features/lms/pages/LectureStudioPage.tsx
+++ b/frontend/src/features/lms/pages/LectureStudioPage.tsx
@@ -169,10 +169,10 @@ export function LectureStudioPage({ courses, selectedCourse, highlightedLecture,
 
   return (
     <div className="space-y-5">
-      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 px-6 py-6 text-white shadow-sm">
+      <section className="rounded-3xl border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-indigo-200">Instructor Studio</div>
+            <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-cyan-200">Instructor Studio</div>
             <h1 className="mt-2 text-[26px] font-extrabold tracking-[-0.04em]">강의 제작 스튜디오</h1>
             <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-300">
               수강 인원, 강의실, 온라인/오프라인, 과제, 시험, 퀴즈, AI 연계 옵션까지 한 화면에서 조정하는 강사 전용 제작 공간입니다.

--- a/frontend/src/features/lms/pages/LectureWatchPage.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CourseCard, CourseDetail, LectureDetail, LectureTranscript } from '@myway/shared';
 import { CourseSessionTimeline } from '../components/CourseSessionTimeline';
 import { LectureSideChatPanel } from '../components/LectureSideChatPanel';
@@ -119,7 +119,7 @@ export function LectureWatchPage({
 
   return (
     <div className="space-y-5">
-      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)]">
+      <section className="overflow-hidden rounded-[32px] border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(8,47,73,0.28)]">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="min-w-0 flex-1">
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
@@ -142,7 +142,7 @@ export function LectureWatchPage({
           <div className="border-b border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-5">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="min-w-0">
-                <div className="text-[12px] font-semibold text-cyan-600">내 강의 / 영상 시청</div>
+                <div className="text-[12px] font-semibold text-cyan-700">내 강의 / 영상 시청</div>
                 <h2 className="mt-1 text-[22px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{selectedCourse.title}</h2>
                 <p className="mt-2 text-[13px] leading-6 text-[var(--app-text-muted)]">
                   {selectedCourse.category} · {selectedCourse.difficulty} · {selectedCourse.lecture_count}차시 · {selectedCourse.progress_percent}% 진행
@@ -219,13 +219,13 @@ export function LectureWatchPage({
 
             <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
               <div className="rounded-[24px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-5">
-                <div className="text-[12px] font-semibold text-cyan-600">현재 차시</div>
+                    <div className="text-[12px] font-semibold text-cyan-700">현재 차시</div>
                 <div className="mt-1 text-[18px] font-extrabold tracking-[-0.03em] text-[var(--app-text)]">{currentLecture?.title ?? '차시를 선택하세요'}</div>
                 <p className="mt-3 text-[13px] leading-7 text-[var(--app-text-muted)]">
                   {highlightedLecture?.transcript_excerpt ?? currentLecture?.content_text ?? '선택한 차시의 핵심 내용과 메모를 이곳에서 확인합니다.'}
                 </p>
                 {transcript?.duration_ms ? (
-                  <div className="mt-3 inline-flex rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
+                  <div className="mt-3 inline-flex rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-700">
                     실제 재생 길이 {formatTimecode(transcript.duration_ms)}
                   </div>
                 ) : null}
@@ -288,7 +288,7 @@ export function LectureWatchPage({
               <button
                 type="button"
                 onClick={() => onEnroll(selectedCourse.id)}
-                className="mt-4 w-full rounded-full bg-cyan-600 px-4 py-3 text-[12px] font-semibold text-white transition hover:bg-cyan-500"
+                className="mt-4 w-full rounded-full bg-indigo-600 px-4 py-3 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
               >
                 수강 신청하기
               </button>
@@ -310,7 +310,7 @@ export function LectureWatchPage({
                         onClick={() => setActivePanelTab(tab.key as RightTab)}
                         className={`flex flex-1 items-center justify-center gap-2 rounded-2xl px-3 py-2.5 text-[12px] font-semibold transition ${
                           active
-                            ? 'bg-cyan-600 text-white shadow-sm'
+                            ? 'bg-indigo-600 text-white shadow-sm'
                             : 'border border-[var(--app-border)] bg-[var(--app-surface-soft)] text-[var(--app-text-muted)] hover:text-[var(--app-text)]'
                         }`}
                       >
@@ -326,7 +326,7 @@ export function LectureWatchPage({
                 {activePanelTab === 'sessions' ? (
                   <div className="space-y-4">
                     <div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
-                      <div className="text-[12px] font-semibold text-cyan-600">다음 차시 선택</div>
+                      <div className="text-[12px] font-semibold text-indigo-600">다음 차시 선택</div>
                       <div className="mt-1 text-[14px] font-bold text-[var(--app-text)]">현재 강의의 차시 목록을 바로 전환합니다.</div>
                       <p className="mt-2 text-[12px] leading-6 text-[var(--app-text-muted)]">
                         원하는 주차를 눌러 선택하고, 이어서 영상 시청과 챗봇 질문으로 연결할 수 있습니다.
@@ -347,7 +347,7 @@ export function LectureWatchPage({
                 {activePanelTab === 'script' ? (
                   <div className="space-y-4">
                     <div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
-                      <div className="text-[12px] font-semibold text-cyan-600">스크립트</div>
+                      <div className="text-[12px] font-semibold text-indigo-600">스크립트</div>
                       <div className="mt-1 text-[16px] font-bold text-[var(--app-text)]">타임스탬프 기준으로 바로 찾아볼 수 있습니다.</div>
                       <p className="mt-2 text-[12px] leading-6 text-[var(--app-text-muted)]">
                         필요한 구간의 시작 시간을 눌러 복사하거나, 차시 이동 전에 먼저 확인할 수 있습니다.
@@ -366,7 +366,7 @@ export function LectureWatchPage({
                                 onClick={() => {
                                   void navigator.clipboard.writeText(formatTimecode(segment.start_ms));
                                 }}
-                                className="rounded-full bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white transition hover:bg-cyan-600"
+                                className="rounded-full bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white transition hover:bg-indigo-600"
                               >
                                 {formatTimecode(segment.start_ms)} - {formatTimecode(segment.end_ms)}
                               </button>
@@ -397,4 +397,3 @@ export function LectureWatchPage({
     </div>
   );
 }
-

--- a/frontend/src/features/lms/pages/MediaPipelinePage.tsx
+++ b/frontend/src/features/lms/pages/MediaPipelinePage.tsx
@@ -348,7 +348,7 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
 
   return (
     <div className="space-y-5">
-      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 px-6 py-6 text-white shadow-sm">
+      <section className="rounded-3xl border border-cyan-100 bg-[linear-gradient(135deg,#03162a_0%,#005d93_48%,#0bc5ea_100%)] px-6 py-6 text-white shadow-[0_22px_50px_rgba(4,49,84,0.24)]">
         <div className="inline-flex rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white/80">
           Cloudflare R2 · Workers AI · media pipeline
         </div>
@@ -370,14 +370,14 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
         />
 
         <section className="grid gap-3 lg:grid-cols-[1.15fr_0.85fr]">
-          <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">대상 강의</div>
                 <div className="mt-1 text-lg font-bold text-slate-900">{selectedLecture?.title ?? displayCourse.title}</div>
                 <div className="mt-1 text-sm text-slate-500">{displayCourse.title} · {displayCourse.instructor_name}</div>
               </div>
-              <div className="rounded-2xl bg-slate-50 px-4 py-3 text-right">
+              <div className="rounded-2xl bg-[#f4faff] px-4 py-3 text-right">
                 <div className="text-xs text-slate-400">업로드 가능한 파일</div>
                 <div className="mt-1 text-sm font-semibold text-slate-900">3분 ~ 1시간 내외 영상</div>
               </div>
@@ -389,7 +389,7 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
                 <select
                   value={lectureId}
                   onChange={(event) => setLectureId(event.target.value)}
-                  className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-indigo-400"
+                  className="w-full rounded-2xl border border-[#cce0f2] bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-cyan-400"
                 >
                   {lectureOptions.map((lecture) => (
                     <option key={lecture.id} value={lecture.id}>
@@ -405,7 +405,7 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
                   value={audioUrl}
                   onChange={(event) => setAudioUrl(event.target.value)}
                   placeholder="이미 추출된 audio_url이 있으면 바로 입력"
-                  className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-indigo-400"
+                  className="w-full rounded-2xl border border-[#cce0f2] bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-cyan-400"
                 />
                 </label>
               </div>
@@ -416,7 +416,7 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
                   type="file"
                   accept="video/*"
                   onChange={(event) => setVideoFile(event.target.files?.[0] ?? null)}
-                  className="block w-full cursor-pointer rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-indigo-600 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white"
+                  className="block w-full cursor-pointer rounded-2xl border border-dashed border-[#b9d7ef] bg-[#f4faff] px-4 py-3 text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-cyan-600 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white"
                 />
                 {videoFile ? (
                   <div className="text-xs text-slate-500">
@@ -432,7 +432,7 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
                 type="button"
                 onClick={handleSubmit}
                 disabled={busy || demoMode}
-                className="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-70"
+                className="inline-flex items-center gap-2 rounded-full bg-[linear-gradient(135deg,#00b8e6_0%,#0077b6_100%)] px-5 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(0,119,182,0.35)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-70"
               >
                   <i className={`${busy ? 'ri-loader-4-line animate-spin' : 'ri-upload-2-line'}`} />
                 {busy ? '진행 중' : demoMode ? '데모 모드' : '업로드 및 추출 요청'}
@@ -441,22 +441,22 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
             </div>
           </div>
 
-          <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <div className="text-sm font-semibold text-slate-900">현재 선택 정보</div>
             <div className="mt-3 space-y-3 text-sm text-slate-600">
-              <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="rounded-2xl bg-[#f4faff] p-4">
                 <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">강의</div>
                 <div className="mt-1 font-semibold text-slate-900">{selectedLecture?.title ?? '선택된 강의 없음'}</div>
               </div>
-              <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="rounded-2xl bg-[#f4faff] p-4">
                 <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">영상 업로드 결과</div>
                 <div className="mt-1 break-all font-semibold text-slate-900">{uploadResult?.video_url ?? '아직 없음'}</div>
               </div>
-              <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="rounded-2xl bg-[#f4faff] p-4">
                 <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">전사 결과</div>
                 <div className="mt-1 font-semibold text-slate-900">{latestExtraction?.transcript_id ?? pipeline?.transcript_id ?? '아직 없음'}</div>
               </div>
-              <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="rounded-2xl bg-[#f4faff] p-4">
                 <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">처리 서비스 job</div>
                 <div className="mt-1 font-semibold text-slate-900">{latestExtraction?.processing_job_id ?? '아직 없음'}</div>
                 {latestExtraction?.processing_error ? (

--- a/frontend/src/features/lms/pages/MyCoursesPage.tsx
+++ b/frontend/src/features/lms/pages/MyCoursesPage.tsx
@@ -17,6 +17,11 @@ type ViewMode = 'grid' | 'list';
 type StatusFilter = 'all' | 'progress' | 'completed';
 type SortMode = 'progress' | 'title' | 'duration';
 
+const primaryButtonClass =
+  'inline-flex h-10 items-center rounded-xl bg-indigo-600 px-4 text-[12px] font-semibold text-white transition hover:bg-indigo-500';
+const secondaryButtonClass =
+  'inline-flex h-10 items-center rounded-xl border border-slate-200 bg-white px-4 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600';
+
 export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse, onNavigate }: MyCoursesPageProps) {
   const [managedCourses, setManagedCourses] = useState<CourseCard[]>([]);
   const [loading, setLoading] = useState(true);
@@ -57,6 +62,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
   const visibleCourses = currentCourses.length > 0 ? currentCourses : demoCourses;
   const primaryCourse = selectedCourse ?? visibleCourses[0] ?? null;
   const categories = ['all', ...new Set(visibleCourses.map((course) => course.category))];
+  const primaryCourseTags = Array.isArray(primaryCourse?.tags) ? primaryCourse.tags : [];
 
   const filteredCourses = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -166,7 +172,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
             <button
               type="button"
               onClick={() => onNavigate(session.user.role === 'STUDENT' ? 'dashboard' : 'course-create')}
-              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
+              className={secondaryButtonClass}
             >
               {session.user.role === 'STUDENT' ? '대시보드로 이동' : '새 강의 개설'}
             </button>
@@ -174,7 +180,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
               <button
                 type="button"
                 onClick={() => onNavigate('lecture-studio')}
-                className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                className={primaryButtonClass}
               >
                 제작 스튜디오
               </button>
@@ -184,7 +190,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
 
         {primaryCourse ? (
           <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-            <div className="rounded-[26px] bg-[linear-gradient(135deg,#eff6ff_0%,#eef2ff_50%,#f5f3ff_100%)] px-5 py-5">
+            <div className="rounded-[26px] border border-slate-200 bg-slate-50 px-5 py-5">
               <div className="text-[12px] font-semibold text-indigo-600">선택 강의 미리보기</div>
               <div className="mt-1 text-[20px] font-extrabold tracking-[-0.03em] text-slate-900">{primaryCourse.title}</div>
               <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-600">
@@ -200,7 +206,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                     onSelectCourse(primaryCourse.id);
                     onNavigate('courses');
                   }}
-                  className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                  className={primaryButtonClass}
                 >
                   상세/진도율 보기
                 </button>
@@ -210,7 +216,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                     onSelectCourse(primaryCourse.id);
                     onNavigate('lecture-watch');
                   }}
-                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
+                  className={secondaryButtonClass}
                 >
                   차시 시청으로 이동
                 </button>
@@ -232,7 +238,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                 <div className="rounded-2xl bg-slate-50 px-4 py-3">
                   <div className="text-[11px] font-semibold text-slate-400">태그</div>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {primaryCourse.tags.slice(0, 3).map((tag) => (
+                    {primaryCourseTags.slice(0, 3).map((tag) => (
                       <span key={tag} className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-indigo-600">
                         #{tag}
                       </span>
@@ -245,7 +251,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
         ) : null}
 
         <div className="mt-5 rounded-[26px] border border-slate-200 bg-slate-50 px-4 py-4">
-          <div className="grid gap-3 lg:grid-cols-[minmax(180px,1fr)_minmax(160px,180px)_minmax(160px,180px)_minmax(180px,220px)]">
+          <div className="grid gap-3 lg:grid-cols-[minmax(180px,1fr)_minmax(160px,180px)_minmax(160px,180px)_minmax(240px,280px)]">
             <label className="block">
               <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
               <input
@@ -287,12 +293,12 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
             <div className="flex items-end justify-between gap-2">
               <div className="block">
                 <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">뷰</span>
-                <div className="flex rounded-2xl border border-slate-200 bg-white p-1">
+                <div className="flex rounded-xl border border-slate-200 bg-white p-1">
                   <button
                     type="button"
                     onClick={() => setViewMode('grid')}
                     className={`rounded-xl px-3 py-2 text-[12px] font-semibold ${
-                      viewMode === 'grid' ? 'bg-indigo-600 text-white' : 'text-slate-500'
+                      viewMode === 'grid' ? 'bg-indigo-600 text-white' : 'text-slate-500 hover:text-slate-700'
                     }`}
                   >
                     그리드
@@ -301,47 +307,36 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                     type="button"
                     onClick={() => setViewMode('list')}
                     className={`rounded-xl px-3 py-2 text-[12px] font-semibold ${
-                      viewMode === 'list' ? 'bg-indigo-600 text-white' : 'text-slate-500'
+                      viewMode === 'list' ? 'bg-indigo-600 text-white' : 'text-slate-500 hover:text-slate-700'
                     }`}
                   >
                     리스트
                   </button>
                 </div>
               </div>
-              <button
-                type="button"
-                onClick={() => setStatusFilter(statusFilter === 'all' ? 'progress' : statusFilter === 'progress' ? 'completed' : 'all')}
-                className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
-              >
-                {statusFilter === 'all' ? '전체' : statusFilter === 'progress' ? '진행 중' : '완료'}
-              </button>
+              <div className="block">
+                <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">상태</span>
+                <div className="flex rounded-xl border border-slate-200 bg-white p-1">
+                  {(['all', 'progress', 'completed'] as const).map((status) => (
+                    <button
+                      key={status}
+                      type="button"
+                      onClick={() => setStatusFilter(status)}
+                      className={`rounded-xl px-3 py-2 text-[12px] font-semibold ${
+                        statusFilter === status ? 'bg-indigo-600 text-white' : 'text-slate-500 hover:text-slate-700'
+                      }`}
+                    >
+                      {status === 'all' ? '전체' : status === 'progress' ? '진행 중' : '완료'}
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
         </div>
 
         <div className="mt-4 flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => setStatusFilter('all')}
-            className={`rounded-full px-3.5 py-1.5 text-[12px] font-semibold ${statusFilter === 'all' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-500'}`}
-          >
-            전체
-          </button>
-          <button
-            type="button"
-            onClick={() => setStatusFilter('progress')}
-            className={`rounded-full px-3.5 py-1.5 text-[12px] font-semibold ${statusFilter === 'progress' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-500'}`}
-          >
-            진행 중
-          </button>
-          <button
-            type="button"
-            onClick={() => setStatusFilter('completed')}
-            className={`rounded-full px-3.5 py-1.5 text-[12px] font-semibold ${statusFilter === 'completed' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-500'}`}
-          >
-            완료
-          </button>
-          <div className="ml-auto rounded-full bg-indigo-50 px-3.5 py-1.5 text-[12px] font-semibold text-indigo-600">
+          <div className="ml-auto rounded-xl bg-indigo-50 px-3.5 py-1.5 text-[12px] font-semibold text-indigo-600">
             검색 결과 {filteredCourses.length}개
           </div>
         </div>
@@ -406,7 +401,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                       <button
                         type="button"
                         onClick={() => onSelectCourse(course.id)}
-                        className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                        className={primaryButtonClass}
                       >
                         선택
                       </button>
@@ -416,7 +411,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                           onSelectCourse(course.id);
                           onNavigate('lecture-watch');
                         }}
-                        className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
+                        className={secondaryButtonClass}
                       >
                         시청하기
                       </button>

--- a/frontend/src/features/lms/pages/MyCoursesPage.tsx
+++ b/frontend/src/features/lms/pages/MyCoursesPage.tsx
@@ -108,7 +108,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
+      <section className="overflow-hidden rounded-[32px] border border-cyan-200/20 bg-[radial-gradient(circle_at_15%_10%,rgba(34,211,238,0.2),transparent_28%),linear-gradient(135deg,#08203a_0%,#12436a_52%,#1b587a_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl">
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
@@ -197,7 +197,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                 {primaryCourse.category} · {primaryCourse.lecture_count}차시 · {primaryCourse.progress_percent}% 진행
               </p>
               <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
-                <div className="h-2 rounded-full bg-indigo-500" style={{ width: `${Math.max(primaryCourse.progress_percent, 8)}%` }} />
+                <div className="h-2 rounded-full bg-cyan-500" style={{ width: `${Math.max(primaryCourse.progress_percent, 8)}%` }} />
               </div>
               <div className="mt-4 flex flex-wrap gap-2">
                 <button

--- a/frontend/src/features/lms/pages/MyCoursesPage.tsx
+++ b/frontend/src/features/lms/pages/MyCoursesPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CourseCard, CourseDetail, LoginResponse } from '@myway/shared';
 import { CourseExploreCard } from '../components/CourseExploreCard';
 import { StatePanel } from '../components/StatePanel';
@@ -16,11 +16,6 @@ type MyCoursesPageProps = {
 type ViewMode = 'grid' | 'list';
 type StatusFilter = 'all' | 'progress' | 'completed';
 type SortMode = 'progress' | 'title' | 'duration';
-
-const primaryButtonClass =
-  'inline-flex h-10 items-center rounded-xl bg-cyan-600 px-4 text-[12px] font-semibold text-white transition hover:bg-cyan-500';
-const secondaryButtonClass =
-  'inline-flex h-10 items-center rounded-xl border border-slate-200 bg-white px-4 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-600';
 
 export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse, onNavigate }: MyCoursesPageProps) {
   const [managedCourses, setManagedCourses] = useState<CourseCard[]>([]);
@@ -61,7 +56,6 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
   const currentCourses = session.user.role === 'STUDENT' ? enrolledCourses : instructorCourses;
   const visibleCourses = currentCourses.length > 0 ? currentCourses : demoCourses;
   const primaryCourse = selectedCourse ?? visibleCourses[0] ?? null;
-  const primaryCourseTags = Array.isArray(primaryCourse?.tags) ? primaryCourse.tags : [];
   const categories = ['all', ...new Set(visibleCourses.map((course) => course.category))];
 
   const filteredCourses = useMemo(() => {
@@ -69,9 +63,8 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
 
     return visibleCourses
       .filter((course) => {
-        const courseTags = Array.isArray(course.tags) ? course.tags : [];
         const queryMatch = query
-          ? [course.title, course.category, course.description, course.instructor_name, ...courseTags].join(' ').toLowerCase().includes(query)
+          ? [course.title, course.category, course.description, course.instructor_name, ...course.tags].join(' ').toLowerCase().includes(query)
           : true;
         const categoryMatch = activeCategory === 'all' ? true : course.category === activeCategory;
         const statusMatch =
@@ -108,7 +101,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
   const publishedLabel = session.user.role === 'STUDENT' ? '완료 강의' : '공개 강의';
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-6">
       <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl">
@@ -159,7 +152,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
         </article>
       </section>
 
-      <section className="rounded-[28px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+      <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <h3 className="text-[15px] font-bold text-slate-900">{session.user.role === 'STUDENT' ? '수강 중인 강의' : '관리 중인 강의'}</h3>
@@ -173,7 +166,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
             <button
               type="button"
               onClick={() => onNavigate(session.user.role === 'STUDENT' ? 'dashboard' : 'course-create')}
-              className={secondaryButtonClass}
+              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
             >
               {session.user.role === 'STUDENT' ? '대시보드로 이동' : '새 강의 개설'}
             </button>
@@ -181,7 +174,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
               <button
                 type="button"
                 onClick={() => onNavigate('lecture-studio')}
-                className={primaryButtonClass}
+                className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
               >
                 제작 스튜디오
               </button>
@@ -190,15 +183,15 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
         </div>
 
         {primaryCourse ? (
-          <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-            <div className="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-5">
-              <div className="text-[12px] font-semibold text-cyan-600">선택 강의 미리보기</div>
+          <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+            <div className="rounded-[26px] bg-[linear-gradient(135deg,#eff6ff_0%,#eef2ff_50%,#f5f3ff_100%)] px-5 py-5">
+              <div className="text-[12px] font-semibold text-indigo-600">선택 강의 미리보기</div>
               <div className="mt-1 text-[20px] font-extrabold tracking-[-0.03em] text-slate-900">{primaryCourse.title}</div>
               <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-600">
                 {primaryCourse.category} · {primaryCourse.lecture_count}차시 · {primaryCourse.progress_percent}% 진행
               </p>
               <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
-                <div className="h-2 rounded-full bg-cyan-500" style={{ width: `${Math.max(primaryCourse.progress_percent, 8)}%` }} />
+                <div className="h-2 rounded-full bg-indigo-500" style={{ width: `${Math.max(primaryCourse.progress_percent, 8)}%` }} />
               </div>
               <div className="mt-4 flex flex-wrap gap-2">
                 <button
@@ -207,7 +200,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                     onSelectCourse(primaryCourse.id);
                     onNavigate('courses');
                   }}
-                  className={primaryButtonClass}
+                  className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                 >
                   상세/진도율 보기
                 </button>
@@ -217,14 +210,14 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                     onSelectCourse(primaryCourse.id);
                     onNavigate('lecture-watch');
                   }}
-                  className={secondaryButtonClass}
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
                 >
                   차시 시청으로 이동
                 </button>
               </div>
             </div>
 
-            <div className="rounded-[24px] border border-slate-200 bg-white px-5 py-5">
+            <div className="rounded-[26px] border border-slate-200 bg-white px-5 py-5">
               <div className="text-[12px] font-semibold text-slate-500">현재 역할</div>
               <div className="mt-1 text-[18px] font-extrabold tracking-[-0.03em] text-slate-900">{session.user.role}</div>
               <div className="mt-4 space-y-2">
@@ -239,8 +232,8 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                 <div className="rounded-2xl bg-slate-50 px-4 py-3">
                   <div className="text-[11px] font-semibold text-slate-400">태그</div>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {primaryCourseTags.slice(0, 3).map((tag) => (
-                      <span key={tag} className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-cyan-600">
+                    {primaryCourse.tags.slice(0, 3).map((tag) => (
+                      <span key={tag} className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-indigo-600">
                         #{tag}
                       </span>
                     ))}
@@ -251,15 +244,15 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
           </div>
         ) : null}
 
-        <div className="mt-5 rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
-          <div className="grid gap-3 lg:grid-cols-[minmax(180px,1fr)_minmax(160px,180px)_minmax(160px,180px)_minmax(240px,280px)]">
+        <div className="mt-5 rounded-[26px] border border-slate-200 bg-slate-50 px-4 py-4">
+          <div className="grid gap-3 lg:grid-cols-[minmax(180px,1fr)_minmax(160px,180px)_minmax(160px,180px)_minmax(180px,220px)]">
             <label className="block">
               <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
               <input
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
                 placeholder="강좌명, 강사, 태그 검색"
-                className="h-11 w-full rounded-2xl border border-slate-200 bg-white px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-400"
+                className="h-11 w-full rounded-2xl border border-slate-200 bg-white px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-indigo-400"
               />
             </label>
 
@@ -268,7 +261,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
               <select
                 value={activeCategory}
                 onChange={(event) => setActiveCategory(event.target.value)}
-                className="h-11 w-full rounded-2xl border border-slate-200 bg-white px-4 text-[13px] text-slate-900 outline-none transition focus:border-cyan-400"
+                className="h-11 w-full rounded-2xl border border-slate-200 bg-white px-4 text-[13px] text-slate-900 outline-none transition focus:border-indigo-400"
               >
                 {categories.map((category) => (
                   <option key={category} value={category}>
@@ -283,7 +276,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
               <select
                 value={sortMode}
                 onChange={(event) => setSortMode(event.target.value as SortMode)}
-                className="h-11 w-full rounded-2xl border border-slate-200 bg-white px-4 text-[13px] text-slate-900 outline-none transition focus:border-cyan-400"
+                className="h-11 w-full rounded-2xl border border-slate-200 bg-white px-4 text-[13px] text-slate-900 outline-none transition focus:border-indigo-400"
               >
                 <option value="progress">진도순</option>
                 <option value="title">제목순</option>
@@ -294,12 +287,12 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
             <div className="flex items-end justify-between gap-2">
               <div className="block">
                 <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">뷰</span>
-                <div className="flex rounded-xl border border-slate-200 bg-white p-0.5">
+                <div className="flex rounded-2xl border border-slate-200 bg-white p-1">
                   <button
                     type="button"
                     onClick={() => setViewMode('grid')}
-                    className={`h-9 rounded-lg px-3 text-[11px] font-semibold ${
-                      viewMode === 'grid' ? 'bg-cyan-600 text-white' : 'text-slate-500 hover:text-slate-700'
+                    className={`rounded-xl px-3 py-2 text-[12px] font-semibold ${
+                      viewMode === 'grid' ? 'bg-indigo-600 text-white' : 'text-slate-500'
                     }`}
                   >
                     그리드
@@ -307,37 +300,48 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                   <button
                     type="button"
                     onClick={() => setViewMode('list')}
-                    className={`h-9 rounded-lg px-3 text-[11px] font-semibold ${
-                      viewMode === 'list' ? 'bg-cyan-600 text-white' : 'text-slate-500 hover:text-slate-700'
+                    className={`rounded-xl px-3 py-2 text-[12px] font-semibold ${
+                      viewMode === 'list' ? 'bg-indigo-600 text-white' : 'text-slate-500'
                     }`}
                   >
                     리스트
                   </button>
                 </div>
               </div>
-              <div className="block">
-                <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">상태</span>
-                <div className="flex rounded-xl border border-slate-200 bg-white p-0.5">
-                  {(['all', 'progress', 'completed'] as const).map((status) => (
-                    <button
-                      key={status}
-                      type="button"
-                      onClick={() => setStatusFilter(status)}
-                      className={`h-9 rounded-lg px-3 text-[11px] font-semibold ${
-                        statusFilter === status ? 'bg-cyan-600 text-white' : 'text-slate-500 hover:text-slate-700'
-                      }`}
-                    >
-                      {status === 'all' ? '전체' : status === 'progress' ? '진행 중' : '완료'}
-                    </button>
-                  ))}
-                </div>
-              </div>
+              <button
+                type="button"
+                onClick={() => setStatusFilter(statusFilter === 'all' ? 'progress' : statusFilter === 'progress' ? 'completed' : 'all')}
+                className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
+              >
+                {statusFilter === 'all' ? '전체' : statusFilter === 'progress' ? '진행 중' : '완료'}
+              </button>
             </div>
           </div>
         </div>
 
         <div className="mt-4 flex flex-wrap gap-2">
-          <div className="ml-auto rounded-xl bg-cyan-50 px-3.5 py-1.5 text-[12px] font-semibold text-cyan-600">
+          <button
+            type="button"
+            onClick={() => setStatusFilter('all')}
+            className={`rounded-full px-3.5 py-1.5 text-[12px] font-semibold ${statusFilter === 'all' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-500'}`}
+          >
+            전체
+          </button>
+          <button
+            type="button"
+            onClick={() => setStatusFilter('progress')}
+            className={`rounded-full px-3.5 py-1.5 text-[12px] font-semibold ${statusFilter === 'progress' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-500'}`}
+          >
+            진행 중
+          </button>
+          <button
+            type="button"
+            onClick={() => setStatusFilter('completed')}
+            className={`rounded-full px-3.5 py-1.5 text-[12px] font-semibold ${statusFilter === 'completed' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-500'}`}
+          >
+            완료
+          </button>
+          <div className="ml-auto rounded-full bg-indigo-50 px-3.5 py-1.5 text-[12px] font-semibold text-indigo-600">
             검색 결과 {filteredCourses.length}개
           </div>
         </div>
@@ -357,7 +361,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
             />
           </div>
         ) : viewMode === 'grid' ? (
-          <div className="mt-4 grid gap-3 md:grid-cols-2">
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
             {filteredCourses.map((course) => (
               <CourseExploreCard
                 key={course.id}
@@ -378,8 +382,8 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
               return (
                 <article
                   key={course.id}
-                  className={`flex flex-col gap-3 rounded-[24px] border px-5 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.04)] lg:flex-row lg:items-center ${
-                    active ? 'border-cyan-300 bg-cyan-50 ring-2 ring-cyan-100' : 'border-slate-200 bg-white'
+                  className={`flex flex-col gap-4 rounded-[26px] border px-5 py-5 shadow-[0_1px_3px_rgba(15,23,42,0.04)] lg:flex-row lg:items-center ${
+                    active ? 'border-indigo-300 bg-indigo-50 ring-2 ring-indigo-100' : 'border-slate-200 bg-white'
                   }`}
                 >
                   <div className="flex h-24 w-full flex-shrink-0 items-center justify-center rounded-[24px] bg-[linear-gradient(135deg,#4f46e5,#2563eb,#7c3aed)] text-white lg:w-44">
@@ -393,7 +397,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                           {course.category} · {course.instructor_name} · {course.lecture_count}차시
                         </div>
                       </div>
-                      <span className="rounded-full bg-cyan-100 px-2.5 py-1 text-[11px] font-semibold text-cyan-600">
+                      <span className="rounded-full bg-indigo-100 px-2.5 py-1 text-[11px] font-semibold text-indigo-600">
                         {course.progress_percent}%
                       </span>
                     </div>
@@ -402,7 +406,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                       <button
                         type="button"
                         onClick={() => onSelectCourse(course.id)}
-                        className={primaryButtonClass}
+                        className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                       >
                         선택
                       </button>
@@ -412,7 +416,7 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
                           onSelectCourse(course.id);
                           onNavigate('lecture-watch');
                         }}
-                        className={secondaryButtonClass}
+                        className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
                       >
                         시청하기
                       </button>
@@ -427,4 +431,3 @@ export function MyCoursesPage({ session, courses, selectedCourse, onSelectCourse
     </div>
   );
 }
-

--- a/frontend/src/features/lms/pages/MyShortformsPage.tsx
+++ b/frontend/src/features/lms/pages/MyShortformsPage.tsx
@@ -1,6 +1,15 @@
-import { useEffect, useState } from 'react';
+﻿import { useEffect, useMemo, useState } from 'react';
 import type { CourseCard, CourseDetail, CustomCourseLibraryItem, ShortformLibraryItem } from '@myway/shared';
-import { copyCustomCourseDraft, loadCustomCourseLibrary, loadShortformLibrary, retryShortformExportDraft, saveShortformDraft, shareCustomCourseDraft, shareShortformDraft, toggleShortformLikeDraft } from '../../../lib/api';
+import {
+  copyCustomCourseDraft,
+  loadCustomCourseLibrary,
+  loadShortformLibrary,
+  retryShortformExportDraft,
+  saveShortformDraft,
+  shareCustomCourseDraft,
+  shareShortformDraft,
+  toggleShortformLikeDraft,
+} from '../../../lib/api';
 import { resolvePlayableVideoUrl } from '../../../lib/video-url';
 
 type MyShortformsPageProps = {
@@ -9,14 +18,25 @@ type MyShortformsPageProps = {
   sessionToken: string | null;
 };
 
+type LibraryTab = 'videos' | 'courses';
+
 function badgeClass(ownership: string): string {
-  return ownership === 'owned' ? 'bg-indigo-100 text-indigo-600' : 'bg-amber-100 text-amber-700';
+  return ownership === 'owned' ? 'bg-cyan-100 text-cyan-700' : 'bg-amber-100 text-amber-700';
+}
+
+function exportBadgeClass(status: string): string {
+  if (status === 'COMPLETED') return 'bg-emerald-100 text-emerald-700';
+  if (status === 'FAILED') return 'bg-rose-100 text-rose-700';
+  if (status === 'PROCESSING') return 'bg-amber-100 text-amber-700';
+  return 'bg-slate-100 text-slate-500';
 }
 
 export function MyShortformsPage({ courses, selectedCourse, sessionToken }: MyShortformsPageProps) {
   const [customCourses, setCustomCourses] = useState<CustomCourseLibraryItem[]>([]);
   const [shortformLibrary, setShortformLibrary] = useState<ShortformLibraryItem[]>([]);
   const [status, setStatus] = useState('라이브러리를 불러오는 중입니다.');
+  const [query, setQuery] = useState('');
+  const [tab, setTab] = useState<LibraryTab>('videos');
 
   async function refreshLibrary() {
     const [customCourseData, shortformData] = await Promise.all([
@@ -74,72 +94,123 @@ export function MyShortformsPage({ courses, selectedCourse, sessionToken }: MySh
   const ownedVideos = shortformLibrary.filter((video) => video.ownership === 'owned');
   const savedVideos = shortformLibrary.filter((video) => video.ownership === 'saved');
 
+  const filteredCourses = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return customCourses.filter((course) => {
+      if (!q) return true;
+      return [course.title, course.description, course.course_id].join(' ').toLowerCase().includes(q);
+    });
+  }, [customCourses, query]);
+
+  const filteredVideos = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return shortformLibrary.filter((video) => {
+      if (!q) return true;
+      return [video.title, video.description, video.course_id].join(' ').toLowerCase().includes(q);
+    });
+  }, [shortformLibrary, query]);
+
   return (
     <div className="space-y-5">
-      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-        <div className="flex flex-wrap items-start justify-between gap-4">
+      <section className="overflow-hidden rounded-3xl border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-5 py-5 text-white">
+        <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <h2 className="text-[15px] font-bold text-slate-900">내 숏폼 라이브러리</h2>
-            <p className="mt-1 text-[12px] text-slate-500">
-              owned/copied/saved 상태를 분리해서 개인 코스와 숏폼 재사용 흐름을 한곳에서 확인합니다.
-            </p>
+            <h2 className="text-[20px] font-extrabold tracking-[-0.03em]">내 숏폼 라이브러리</h2>
+            <p className="mt-2 text-[12px] leading-6 text-cyan-50/85">내 숏폼, 저장 숏폼, 개인 코스를 검색/관리하고 바로 공유할 수 있습니다.</p>
+            <div className="mt-2 text-[11px] text-cyan-100/80">{selectedCourse?.title ?? courses[0]?.title ?? '전체 강의'}</div>
           </div>
-          <div className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-500">
-            {selectedCourse?.title ?? courses[0]?.title ?? '전체 강의'}
+          <div className="rounded-xl border border-cyan-100/25 bg-white/10 px-4 py-3 text-[12px] text-cyan-50/90">
+            <div>내 숏폼 {ownedVideos.length}개 · 저장 {savedVideos.length}개</div>
+            <div className="mt-1">개인 코스 {customCourses.length}개</div>
           </div>
         </div>
-        <p className="mt-3 text-[12px] leading-6 text-slate-500">{status}</p>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+        <div className="grid gap-3 lg:grid-cols-[1fr_auto] lg:items-end">
+          <label className="block">
+            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="숏폼 제목, 설명, 코스 ID 검색"
+              className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] outline-none focus:border-cyan-300"
+            />
+          </label>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setTab('videos')}
+              className={`rounded-full px-4 py-2 text-[12px] font-semibold ${tab === 'videos' ? 'bg-cyan-600 text-white' : 'border border-slate-200 text-slate-600'}`}
+            >
+              숏폼
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab('courses')}
+              className={`rounded-full px-4 py-2 text-[12px] font-semibold ${tab === 'courses' ? 'bg-cyan-600 text-white' : 'border border-slate-200 text-slate-600'}`}
+            >
+              개인 코스
+            </button>
+          </div>
+        </div>
+        <p className="mt-3 text-[12px] text-slate-500">{status}</p>
       </section>
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-4">
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{customCourses.length}</div>
-          <div className="mt-1 text-[12px] text-slate-500">개인 코스</div>
-        </article>
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{ownedVideos.length}</div>
-          <div className="mt-1 text-[12px] text-slate-500">내 숏폼</div>
-        </article>
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{savedVideos.length}</div>
-          <div className="mt-1 text-[12px] text-slate-500">저장한 숏폼</div>
-        </article>
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{copiedCourses.length}</div>
-          <div className="mt-1 text-[12px] text-slate-500">복사한 코스</div>
-        </article>
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{customCourses.length}</div><div className="mt-1 text-[12px] text-slate-500">개인 코스</div></article>
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{ownedVideos.length}</div><div className="mt-1 text-[12px] text-slate-500">내 숏폼</div></article>
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{savedVideos.length}</div><div className="mt-1 text-[12px] text-slate-500">저장 숏폼</div></article>
+        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{copiedCourses.length}</div><div className="mt-1 text-[12px] text-slate-500">복사 코스</div></article>
       </section>
 
-      <section className="grid grid-cols-1 gap-5 xl:grid-cols-2">
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <h3 className="text-[15px] font-bold text-slate-900">개인 코스</h3>
+      {tab === 'videos' ? (
+        <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+          <h3 className="text-[15px] font-bold text-slate-900">숏폼 라이브러리</h3>
           <div className="mt-4 space-y-3">
-            {customCourses.length > 0 ? (
-              customCourses.map((course) => (
-                <div key={course.id} className="rounded-2xl border border-slate-200 px-4 py-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <div className="flex flex-wrap gap-2">
-                        <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClass(course.ownership)}`}>{course.ownership}</span>
-                        <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">
-                          {course.clip_count} 클립
-                        </span>
-                      </div>
-                      <div className="mt-2 text-[14px] font-bold text-slate-900">{course.title}</div>
-                      <p className="mt-1 text-[12px] leading-6 text-slate-500">{course.description}</p>
+            {filteredVideos.length > 0 ? (
+              filteredVideos.map((video) => {
+                const playable = resolvePlayableVideoUrl(video.export_result_url ?? undefined) ?? (video.video_url && !video.video_url.startsWith('/static/shortforms/') ? resolvePlayableVideoUrl(video.video_url) : null);
+                return (
+                  <div key={video.id} className="rounded-2xl border border-slate-200 px-4 py-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClass(video.ownership)}`}>{video.ownership}</span>
+                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${exportBadgeClass(video.export_status)}`}>export {video.export_status}</span>
+                      <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">{video.total_segments} 세그먼트</span>
                     </div>
-                    <div className="text-right text-[11px] text-slate-400">
-                      <div>{course.total_duration_ms / 1000}s</div>
-                      <div>{course.share_count} 공유</div>
+                    <div className="mt-2 text-[14px] font-bold text-slate-900">{video.title}</div>
+                    <p className="mt-1 text-[12px] leading-6 text-slate-500">{video.description}</p>
+                    {playable ? <video className="mt-3 w-full rounded-2xl border border-slate-200 bg-black" controls preload="metadata" src={playable ?? undefined} /> : null}
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button type="button" onClick={() => void handleSaveShortform(video.id)} className="rounded-full bg-emerald-600 px-3 py-1.5 text-[11px] font-semibold text-white">저장</button>
+                      <button type="button" onClick={() => void handleLikeShortform(video.id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">좋아요</button>
+                      <button type="button" onClick={() => void handleShareShortform(video.id, video.course_id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">공유</button>
+                      {video.export_status === 'FAILED' ? <button type="button" onClick={() => void handleRetryExport(video.id)} className="rounded-full border border-rose-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-rose-600">export 재시도</button> : null}
                     </div>
                   </div>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    <button type="button" onClick={() => void handleShareCourse(course.id)} className="rounded-full bg-indigo-600 px-3 py-1.5 text-[11px] font-semibold text-white">
-                      공유
-                    </button>
-                    <button type="button" onClick={() => void handleCopyCourse(course.id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">
-                      복사
-                    </button>
+                );
+              })
+            ) : (
+              <p className="text-[13px] leading-6 text-slate-500">숏폼 라이브러리가 아직 없습니다.</p>
+            )}
+          </div>
+        </section>
+      ) : (
+        <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+          <h3 className="text-[15px] font-bold text-slate-900">개인 코스 라이브러리</h3>
+          <div className="mt-4 space-y-3">
+            {filteredCourses.length > 0 ? (
+              filteredCourses.map((course) => (
+                <div key={course.id} className="rounded-2xl border border-slate-200 px-4 py-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClass(course.ownership)}`}>{course.ownership}</span>
+                    <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">{course.clip_count} 클립</span>
+                  </div>
+                  <div className="mt-2 text-[14px] font-bold text-slate-900">{course.title}</div>
+                  <p className="mt-1 text-[12px] leading-6 text-slate-500">{course.description}</p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button type="button" onClick={() => void handleShareCourse(course.id)} className="rounded-full bg-cyan-600 px-3 py-1.5 text-[11px] font-semibold text-white">공유</button>
+                    <button type="button" onClick={() => void handleCopyCourse(course.id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">복사</button>
                   </div>
                 </div>
               ))
@@ -147,101 +218,8 @@ export function MyShortformsPage({ courses, selectedCourse, sessionToken }: MySh
               <p className="text-[13px] leading-6 text-slate-500">개인 코스가 아직 없습니다.</p>
             )}
           </div>
-        </article>
-
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <h3 className="text-[15px] font-bold text-slate-900">숏폼 라이브러리</h3>
-          <div className="mt-4 space-y-3">
-            {shortformLibrary.length > 0 ? (
-              shortformLibrary.map((video) => (
-                <div key={video.id} className="rounded-2xl border border-slate-200 px-4 py-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <div className="flex flex-wrap gap-2">
-                        <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClass(video.ownership)}`}>{video.ownership}</span>
-                        <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">
-                          {video.total_segments} 세그먼트
-                        </span>
-                      </div>
-                      <div className="mt-2 text-[14px] font-bold text-slate-900">{video.title}</div>
-                      <p className="mt-1 text-[12px] leading-6 text-slate-500">{video.description}</p>
-                      {(resolvePlayableVideoUrl(video.export_result_url ?? undefined) ??
-                        (video.video_url && !video.video_url.startsWith('/static/shortforms/') ? resolvePlayableVideoUrl(video.video_url) : null)) ? (
-                        <video
-                          className="mt-3 w-full rounded-2xl border border-slate-200 bg-black"
-                          controls
-                          preload="metadata"
-                          src={resolvePlayableVideoUrl(video.export_result_url ?? undefined) ?? resolvePlayableVideoUrl(video.video_url) ?? undefined}
-                        />
-                      ) : null}
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${video.export_status === 'COMPLETED' ? 'bg-emerald-100 text-emerald-700' : video.export_status === 'FAILED' ? 'bg-rose-100 text-rose-700' : video.export_status === 'PROCESSING' ? 'bg-amber-100 text-amber-700' : 'bg-slate-100 text-slate-500'}`}>
-                          export {video.export_status}
-                        </span>
-                        <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">
-                          retry {video.export_retry_count}
-                        </span>
-                      </div>
-                      <div className="mt-2 text-[11px] leading-5 text-slate-400">
-                        {resolvePlayableVideoUrl(video.export_result_url ?? undefined) ?? resolvePlayableVideoUrl(video.video_url) ?? video.video_url}
-                      </div>
-                      {video.export_error_message ? <p className="mt-1 text-[11px] leading-5 text-rose-600">{video.export_error_message}</p> : null}
-                    </div>
-                    <div className="text-right text-[11px] text-slate-400">
-                      <div>{video.view_count} 조회</div>
-                      <div>{video.like_count} 좋아요</div>
-                    </div>
-                  </div>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    <button type="button" onClick={() => void handleSaveShortform(video.id)} className="rounded-full bg-emerald-600 px-3 py-1.5 text-[11px] font-semibold text-white">
-                      저장
-                    </button>
-                    <button type="button" onClick={() => void handleLikeShortform(video.id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">
-                      좋아요
-                    </button>
-                    <button type="button" onClick={() => void handleShareShortform(video.id, video.course_id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">
-                      공유
-                    </button>
-                    {video.export_status === 'FAILED' ? (
-                      <button type="button" onClick={() => void handleRetryExport(video.id)} className="rounded-full border border-rose-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-rose-600">
-                        export 재시도
-                      </button>
-                    ) : null}
-                  </div>
-                </div>
-              ))
-            ) : (
-              <p className="text-[13px] leading-6 text-slate-500">숏폼 라이브러리가 아직 없습니다.</p>
-            )}
-          </div>
-        </article>
-      </section>
-
-      <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <h3 className="text-[15px] font-bold text-slate-900">소유한 개인 코스</h3>
-          <div className="mt-4 space-y-2">
-            {ownedCourses.length > 0 ? ownedCourses.map((course) => (
-              <div key={course.id} className="rounded-2xl border border-slate-200 px-4 py-3">
-                <div className="text-[13px] font-semibold text-slate-900">{course.title}</div>
-                <div className="mt-1 text-[12px] text-slate-500">{course.clip_count}개 클립 · {course.course_id}</div>
-              </div>
-            )) : <p className="text-[13px] leading-6 text-slate-500">소유한 개인 코스가 없습니다.</p>}
-          </div>
-        </article>
-
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <h3 className="text-[15px] font-bold text-slate-900">저장한 숏폼</h3>
-          <div className="mt-4 space-y-2">
-            {savedVideos.length > 0 ? savedVideos.map((video) => (
-              <div key={video.id} className="rounded-2xl border border-slate-200 px-4 py-3">
-                <div className="text-[13px] font-semibold text-slate-900">{video.title}</div>
-                <div className="mt-1 text-[12px] text-slate-500">{video.save_folder ?? 'default'} · {video.save_note ?? '메모 없음'}</div>
-              </div>
-            )) : <p className="text-[13px] leading-6 text-slate-500">저장한 숏폼이 없습니다.</p>}
-          </div>
-        </article>
-      </section>
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/PublicHomePage.tsx
+++ b/frontend/src/features/lms/pages/PublicHomePage.tsx
@@ -1,7 +1,5 @@
-import { useMemo, useRef, useState } from 'react';
+﻿import { useMemo, useRef, useState } from 'react';
 import type { CourseCard } from '@myway/shared';
-import { AiNoticeBanner } from '../components/AiNoticeBanner';
-import { CourseExploreCard } from '../components/CourseExploreCard';
 import { CourseExploreFilters } from '../components/CourseExploreFilters';
 
 type PublicHomePageProps = {
@@ -11,10 +9,11 @@ type PublicHomePageProps = {
 };
 
 const navItems = [
-  { label: '강의', icon: 'ri-book-open-line' },
-  { label: '숏폼', icon: 'ri-scissors-cut-line' },
-  { label: '챗봇', icon: 'ri-robot-line' },
-  { label: '로드맵', icon: 'ri-route-line' },
+  { label: '홈', icon: 'ri-home-5-line' },
+  { label: '강의 탐색', icon: 'ri-book-open-line' },
+  { label: 'AI 도구', icon: 'ri-robot-line' },
+  { label: '학습 로드맵', icon: 'ri-route-line' },
+  { label: '커뮤니티', icon: 'ri-group-line' },
 ];
 
 function countUnique(values: string[]): number {
@@ -25,14 +24,19 @@ function scrollToElement(element: HTMLElement | null) {
   element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
+function thumbnailGradient(palette: CourseCard['thumbnail_palette']) {
+  if (palette === 'emerald') return 'from-emerald-900 via-emerald-700 to-teal-500';
+  if (palette === 'violet') return 'from-violet-950 via-purple-700 to-fuchsia-500';
+  if (palette === 'amber') return 'from-amber-950 via-amber-700 to-orange-400';
+  return 'from-blue-950 via-cyan-800 to-sky-500';
+}
+
 export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePageProps) {
   const coursesRef = useRef<HTMLElement | null>(null);
-  const shortformRef = useRef<HTMLElement | null>(null);
   const roadmapRef = useRef<HTMLElement | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState('');
   const [activeStatus, setActiveStatus] = useState<'all' | 'available' | 'enrolled'>('all');
-  const [notice, setNotice] = useState('학습 흐름은 탐색 > 비교 > 등록 > 학습 > 숏폼 생성 순서로 설계되어 있습니다.');
 
   const categories = useMemo(() => [...new Set(courseCards.map((item) => item.category))], [courseCards]);
 
@@ -42,26 +46,29 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
     return courseCards.filter((course) => {
       const tags = Array.isArray(course.tags) ? course.tags : [];
       const queryMatch = query
-        ? [course.title, course.description, course.category, course.instructor_name, ...tags]
-            .join(' ')
-            .toLowerCase()
-            .includes(query)
+        ? [course.title, course.description, course.category, course.instructor_name, ...tags].join(' ').toLowerCase().includes(query)
         : true;
       const categoryMatch = activeCategory ? course.category === activeCategory : true;
       const statusMatch =
-        activeStatus === 'all' ? true : activeStatus === 'available' ? !course.enrolled : course.enrolled;
+        activeStatus === 'all'
+          ? true
+          : activeStatus === 'available'
+            ? !course.enrolled
+            : course.enrolled;
 
       return queryMatch && categoryMatch && statusMatch;
     });
   }, [activeCategory, activeStatus, courseCards, searchQuery]);
 
-  const featuredCourses = filteredCourses.slice(0, 6);
+  const featuredCourses = filteredCourses.slice(0, 5);
   const featuredTags = useMemo(() => {
     const counts = new Map<string, number>();
 
     courseCards.forEach((course) => {
       const tags = Array.isArray(course.tags) ? course.tags : [];
-      tags.forEach((tag) => counts.set(tag, (counts.get(tag) ?? 0) + 1));
+      tags.forEach((tag) => {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      });
     });
 
     return [...counts.entries()]
@@ -73,122 +80,84 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
   const totalProgress = Math.round(
     courseCards.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courseCards.length, 1),
   );
+  const tagCount = countUnique(courseCards.flatMap((course) => (Array.isArray(course.tags) ? course.tags : [])));
 
   return (
-    <div className="min-h-screen bg-[var(--app-bg)] pb-24 lg:pb-8">
-      <a href="#courses" className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-50 rounded-xl bg-white px-3 py-2 text-sm font-semibold text-slate-900">
-        강의 목록으로 건너뛰기
-      </a>
-
-      <header className="sticky top-0 z-30 border-b border-slate-200/80 bg-white/92 backdrop-blur-xl">
-        <div className="mx-auto flex h-16 max-w-[1320px] items-center justify-between gap-3 px-4 sm:px-6 lg:px-10">
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-500 to-teal-600 text-white shadow-[0_8px_20px_rgba(13,148,136,0.35)]">
-              <i className="ri-graduation-cap-fill text-[20px]" />
-            </div>
-            <div>
-              <div className="text-[16px] font-extrabold tracking-[-0.03em] text-slate-900">내맘대로클래스</div>
-              <div className="text-[11px] text-slate-500">AI Learning Workspace</div>
-            </div>
+    <div className="min-h-screen bg-[#eef2f7]">
+      <header className="sticky top-0 z-30 border-b border-cyan-100/20 bg-[linear-gradient(90deg,#113454,#174667_50%,#1b4f71)] text-cyan-50 backdrop-blur">
+        <div className="mx-auto flex h-16 max-w-[1320px] items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-cyan-300/20 text-cyan-200">
+              <i className="ri-bubble-chart-fill text-[18px]" />
+            </span>
+            <div className="text-[31px] font-black tracking-[-0.02em]">내맘대로</div>
           </div>
 
-          <nav className="hidden items-center gap-6 text-[13px] font-semibold text-slate-600 lg:flex">
+          <nav className="hidden items-center gap-6 text-[13px] font-semibold text-cyan-50/85 lg:flex">
             {navItems.map((item) => (
               <button
                 key={item.label}
                 type="button"
                 onClick={() => {
-                  if (item.label === '강의') {
+                  if (item.label === '강의 탐색') {
                     scrollToElement(coursesRef.current);
                     return;
                   }
-                  if (item.label === '숏폼') {
-                    scrollToElement(shortformRef.current);
+                  if (item.label === '학습 로드맵') {
+                    scrollToElement(roadmapRef.current);
                     return;
                   }
-                  if (item.label === '챗봇') {
+                  if (item.label === 'AI 도구' || item.label === '커뮤니티') {
                     onOpenLogin();
-                    return;
                   }
-                  scrollToElement(roadmapRef.current);
                 }}
-                className="min-h-10 rounded-xl px-3 transition hover:bg-slate-100 hover:text-slate-900"
+                className="transition hover:text-cyan-200"
               >
-                <span className="flex items-center gap-2">
-                  <i className={`${item.icon} text-base`} />
-                  {item.label}
-                </span>
+                {item.label}
               </button>
             ))}
           </nav>
 
-          <button
-            type="button"
-            onClick={onOpenLogin}
-            disabled={busy}
-            className="min-h-11 rounded-xl bg-slate-900 px-4 text-[12px] font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {busy ? '처리 중...' : '로그인'}
-          </button>
+          <div className="flex items-center gap-2">
+            <button type="button" onClick={onOpenLogin} className="rounded-full border border-cyan-100/30 px-4 py-2 text-[12px] font-semibold text-cyan-50 hover:bg-white/10">
+              로그인
+            </button>
+            <button type="button" onClick={onOpenLogin} className="rounded-full bg-cyan-300 px-4 py-2 text-[12px] font-bold text-cyan-950 hover:bg-cyan-200">
+              시작하기
+            </button>
+          </div>
         </div>
       </header>
 
-      <main className="mx-auto max-w-[1400px] space-y-6 px-4 py-6 sm:px-6 lg:px-10">
-        <section className="relative overflow-hidden rounded-[28px] border border-slate-200 bg-[linear-gradient(120deg,#082f49_0%,#0f766e_54%,#1f2937_100%)] p-6 text-white shadow-[0_20px_60px_rgba(8,47,73,0.25)] sm:p-8 lg:p-10">
-          <div className="pointer-events-none absolute -right-8 -top-10 h-56 w-56 rounded-full bg-cyan-300/20 blur-3xl" />
-          <div className="pointer-events-none absolute bottom-[-70px] left-1/3 h-56 w-56 rounded-full bg-emerald-300/20 blur-3xl" />
-
-          <div className="relative z-10 grid gap-6 lg:grid-cols-[1.25fr_0.75fr] lg:items-end">
+      <main className="mx-auto max-w-[1320px] space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+        <section className="overflow-hidden rounded-[26px] border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.26),transparent_30%),radial-gradient(circle_at_80%_30%,rgba(15,118,110,0.34),transparent_42%),linear-gradient(125deg,#05213f_0%,#0c365f_56%,#115078_100%)] p-6 text-white shadow-[0_24px_58px_rgba(10,30,64,0.36)] lg:p-8">
+          <div className="grid items-center gap-8 lg:grid-cols-[1.2fr_0.8fr]">
             <div>
-              <p className="inline-flex rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[11px] font-semibold tracking-[0.08em] text-white/90">
-                2026 UX 기준 반영
-              </p>
-              <h1 className="mt-4 text-[2rem] font-extrabold tracking-[-0.04em] leading-tight sm:text-[2.4rem] lg:text-[2.9rem]">
-                먼저 해야 할 행동이
-                <br />
-                바로 보이는 학습 UI
-              </h1>
-              <p className="mt-4 max-w-2xl text-[14px] leading-7 text-white/85 sm:text-[15px]">
-                첫 화면에서 탐색, 비교, 등록, 학습 시작까지 한 단계씩 이어지도록 구성했습니다. 중요한 정보는 위로 올리고,
-                보조 정보는 카드 단위로 분리해 스캔 속도를 높였습니다.
+              <h1 className="text-[40px] font-black tracking-[-0.04em] lg:text-[56px]">AI로 배우고,<br />성장하는 실력</h1>
+              <p className="mt-4 max-w-xl text-[15px] leading-7 text-cyan-50/90">
+                2026년, 당신의 커리어를 바꿀 가장 확실한 선택. 로그인 전에도 인기 강의와 AI 추천 흐름을 먼저 경험해보세요.
               </p>
               <div className="mt-6 flex flex-wrap gap-3">
-                <button
-                  type="button"
-                  onClick={() => scrollToElement(coursesRef.current)}
-                  className="min-h-11 rounded-xl bg-white px-5 text-[13px] font-bold text-slate-900 shadow-[0_10px_24px_rgba(0,0,0,0.2)]"
-                >
+                <button type="button" onClick={() => scrollToElement(coursesRef.current)} className="rounded-xl bg-cyan-300 px-5 py-2.5 text-[13px] font-bold text-cyan-950 hover:bg-cyan-200">
                   강의 탐색 시작
                 </button>
-                <button
-                  type="button"
-                  onClick={onOpenLogin}
-                  className="min-h-11 rounded-xl border border-white/30 bg-white/10 px-5 text-[13px] font-semibold text-white backdrop-blur"
-                >
-                  개인 대시보드 열기
+                <button type="button" onClick={onOpenLogin} className="rounded-xl border border-cyan-100/30 bg-white/10 px-5 py-2.5 text-[13px] font-semibold text-cyan-50 hover:bg-white/20">
+                  로그인 후 계속
                 </button>
               </div>
             </div>
-
-            <div className="grid gap-3 rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur">
-              <div className="text-[11px] uppercase tracking-[0.14em] text-white/75">Live Metrics</div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="rounded-xl bg-white/10 p-3">
-                  <div className="text-[11px] text-white/70">평균 진도</div>
-                  <div className="mt-1 text-[22px] font-extrabold">{totalProgress}%</div>
-                </div>
-                <div className="rounded-xl bg-white/10 p-3">
-                  <div className="text-[11px] text-white/70">활성 강의</div>
-                  <div className="mt-1 text-[22px] font-extrabold">{courseCards.length}</div>
-                </div>
-                <div className="rounded-xl bg-white/10 p-3">
-                  <div className="text-[11px] text-white/70">카테고리</div>
-                  <div className="mt-1 text-[22px] font-extrabold">{categories.length}</div>
-                </div>
-                <div className="rounded-xl bg-white/10 p-3">
-                  <div className="text-[11px] text-white/70">핵심 태그</div>
-                  <div className="mt-1 text-[22px] font-extrabold">
-                    {countUnique(courseCards.flatMap((course) => (Array.isArray(course.tags) ? course.tags : [])))}
+            <div className="relative mx-auto w-full max-w-[360px]">
+              <div className="absolute inset-0 rounded-[30px] bg-cyan-300/20 blur-2xl" />
+              <div className="relative rounded-[30px] border border-cyan-100/25 bg-white/10 p-5 backdrop-blur">
+                <div className="mx-auto flex h-28 w-28 items-center justify-center rounded-[24px] border border-cyan-200/35 bg-gradient-to-br from-cyan-200/95 to-cyan-400/75 text-[46px] font-black text-slate-900">AI</div>
+                <div className="mt-5 grid grid-cols-2 gap-3 text-cyan-50">
+                  <div className="rounded-2xl border border-cyan-100/20 bg-slate-900/35 px-3 py-2">
+                    <div className="text-[11px] text-cyan-100/80">평균 진도</div>
+                    <div className="mt-1 text-[18px] font-extrabold">{totalProgress}%</div>
+                  </div>
+                  <div className="rounded-2xl border border-cyan-100/20 bg-slate-900/35 px-3 py-2">
+                    <div className="text-[11px] text-cyan-100/80">강의 수</div>
+                    <div className="mt-1 text-[18px] font-extrabold">{courseCards.length}개</div>
                   </div>
                 </div>
               </div>
@@ -196,38 +165,41 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
           </div>
         </section>
 
-        <section className="grid gap-4 rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm lg:grid-cols-[1.2fr_0.8fr]">
-          <div>
-            <h2 className="text-[18px] font-extrabold tracking-[-0.03em] text-slate-900">강의 빠른 검색</h2>
-            <p className="mt-1 text-[13px] text-slate-600">강좌명, 카테고리, 태그, 강사명으로 즉시 필터링됩니다.</p>
-            <div className="relative mt-4">
-              <i className="ri-search-line pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" />
-              <input
-                value={searchQuery}
-                onChange={(event) => setSearchQuery(event.target.value)}
-                placeholder="예: React, 데이터 분석, 김강사"
-                className="h-12 w-full rounded-xl border border-slate-200 bg-slate-50 pl-11 pr-4 text-[14px] text-slate-900 outline-none placeholder:text-slate-400 focus:border-cyan-500 focus:bg-white"
-              />
+        <section ref={roadmapRef} className="rounded-[22px] border border-cyan-200/20 bg-[linear-gradient(145deg,#0a2f56_0%,#0b3c63_45%,#11496f_100%)] p-5 text-cyan-50 shadow-[0_14px_36px_rgba(8,47,73,0.35)] lg:p-6">
+          <div className="grid gap-6 lg:grid-cols-[1.35fr_0.65fr] lg:items-center">
+            <div>
+              <h2 className="text-[28px] font-extrabold tracking-[-0.02em]">원하는 강의를 찾아보세요</h2>
+              <div className="mt-4 flex items-center rounded-2xl border border-cyan-100/30 bg-white/95 px-4 py-3 text-slate-700">
+                <i className="ri-search-line text-[18px] text-slate-500" />
+                <input
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="강의명, 키워드, 스킬 등을 검색해보세요"
+                  className="ml-3 w-full bg-transparent text-[14px] outline-none placeholder:text-slate-400"
+                />
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {(featuredTags.length > 0 ? featuredTags : ['프롬프트 엔지니어링', 'ChatGPT 활용', '파이썬']).map((tag) => (
+                  <button key={tag} type="button" onClick={() => setSearchQuery(tag)} className="rounded-full border border-cyan-100/25 bg-white/10 px-3 py-1 text-[11px] font-medium text-cyan-50/95 hover:bg-white/20">
+                    {tag}
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
 
-          <div className="grid gap-2 rounded-2xl bg-slate-50 p-4">
-            <div className="text-[12px] font-semibold text-slate-500">인기 태그</div>
-            <div className="flex flex-wrap gap-2">
-              {featuredTags.length > 0 ? (
-                featuredTags.map((tag) => (
-                  <span key={tag} className="min-h-8 rounded-full border border-slate-200 bg-white px-3 py-1 text-[12px] font-semibold text-slate-700">
-                    #{tag}
-                  </span>
-                ))
-              ) : (
-                <span className="text-[12px] text-slate-500">추천 태그가 없습니다.</span>
-              )}
+            <div className="rounded-2xl border border-cyan-100/25 bg-white/10 px-4 py-4 backdrop-blur">
+              <div className="text-[12px] font-semibold text-cyan-100/85">AI 맞춤 추천</div>
+              <div className="mt-2 text-[15px] font-bold text-white">학습 목표 기반 코스 추천</div>
+              <p className="mt-1 text-[12px] leading-6 text-cyan-100/80">로그인하면 강의 상세, 챗봇 학습, 숏폼 복습까지 한번에 연결됩니다.</p>
+              <button type="button" onClick={onOpenLogin} className="mt-3 inline-flex items-center gap-1 rounded-lg border border-cyan-200/35 bg-cyan-300/20 px-3 py-1.5 text-[12px] font-semibold text-cyan-100 hover:bg-cyan-300/30">
+                로그인 후 추천 보기
+                <i className="ri-arrow-right-s-line" />
+              </button>
             </div>
           </div>
         </section>
 
-        <section ref={roadmapRef} className="space-y-4">
+        <section ref={coursesRef} className="space-y-4">
           <CourseExploreFilters
             categories={categories}
             activeCategory={activeCategory}
@@ -236,99 +208,55 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
             onStatusChange={setActiveStatus}
             resultCount={filteredCourses.length}
           />
-          <AiNoticeBanner
-            title="추천 학습 흐름"
-            description={notice}
-            tone="indigo"
-            meta={`${totalProgress}% 평균 진도 · ${featuredCourses.length}개 추천 카드`}
-          />
-        </section>
 
-        <section id="courses" ref={coursesRef} className="space-y-4">
-          <div className="flex flex-wrap items-end justify-between gap-3">
-            <div>
-              <h2 className="text-[20px] font-extrabold tracking-[-0.03em] text-slate-900">추천 강의</h2>
-              <p className="mt-1 text-[13px] text-slate-600">카드 선택 시 상세 학습 흐름으로 연결됩니다.</p>
-            </div>
-            <button
-              type="button"
-              onClick={onOpenLogin}
-              className="min-h-11 rounded-xl border border-slate-300 bg-white px-4 text-[12px] font-semibold text-slate-700 hover:bg-slate-50"
-            >
-              학습 계속하기
+          <div className="flex items-center justify-between">
+            <h2 className="text-[24px] font-extrabold tracking-[-0.02em] text-slate-900">추천 강의</h2>
+            <button type="button" onClick={onOpenLogin} className="inline-flex items-center gap-1 text-[12px] font-semibold text-cyan-700 hover:text-cyan-900">
+              전체 보기
+              <i className="ri-arrow-right-s-line" />
             </button>
           </div>
 
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
             {featuredCourses.length > 0 ? (
               featuredCourses.map((course) => (
-                <CourseExploreCard
+                <button
                   key={course.id}
-                  course={course}
-                  selected={false}
-                  onSelect={() => {
-                    setNotice('로그인 후 강의 상세, 영상 보기, 챗봇, 숏폼 제작 기능을 사용할 수 있습니다.');
-                    onOpenLogin();
-                  }}
-                />
+                  type="button"
+                  onClick={onOpenLogin}
+                  className="group overflow-hidden rounded-2xl border border-slate-200 bg-white text-left shadow-sm transition hover:-translate-y-1 hover:shadow-xl"
+                >
+                  <div className={`relative h-32 bg-gradient-to-br ${thumbnailGradient(course.thumbnail_palette)}`}>
+                    <div className="absolute left-3 top-3 rounded-full bg-rose-500 px-2 py-0.5 text-[10px] font-bold text-white">
+                      {course.difficulty === 'advanced' ? 'BEST' : 'NEW'}
+                    </div>
+                    <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.28),transparent_45%)]" />
+                    <div className="absolute bottom-3 right-3 rounded-full bg-white/20 px-2 py-0.5 text-[10px] font-semibold text-white">{course.category}</div>
+                  </div>
+                  <div className="space-y-2 px-3 py-3">
+                    <div className="line-clamp-1 text-[15px] font-bold tracking-[-0.02em] text-slate-900">{course.title}</div>
+                    <div className="line-clamp-1 text-[12px] text-slate-500">{course.description}</div>
+                    <div className="flex items-center gap-2 text-[11px] text-slate-500">
+                      <span className="rounded-full bg-cyan-50 px-2 py-0.5 font-semibold text-cyan-700">
+                        {course.difficulty === 'beginner' ? '입문' : course.difficulty === 'intermediate' ? '중급' : '고급'}
+                      </span>
+                      <span>{Math.max(course.total_duration_minutes, 0) > 60 ? `${Math.round(course.total_duration_minutes / 60)}시간` : `${course.total_duration_minutes}분`}</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-[11px] text-slate-500">
+                      <span>★ {Number.isFinite(course.rating) ? course.rating.toFixed(1) : '4.8'}</span>
+                      <span>수강 {Number.isFinite(course.student_count) ? course.student_count : 0}</span>
+                    </div>
+                  </div>
+                </button>
               ))
             ) : (
-              <div className="md:col-span-2 xl:col-span-3 rounded-3xl border border-slate-200 bg-white px-5 py-8 text-center text-[13px] leading-6 text-slate-500 shadow-sm">
+              <div className="md:col-span-2 xl:col-span-5 rounded-3xl border border-slate-200 bg-white px-5 py-8 text-center text-[13px] leading-6 text-slate-500 shadow-sm">
                 검색 결과가 없습니다. 검색어, 카테고리, 수강 상태를 바꿔 보세요.
               </div>
             )}
           </div>
         </section>
-
-        <section ref={shortformRef} className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <h3 className="text-[18px] font-extrabold tracking-[-0.03em] text-slate-900">숏폼 제작 스튜디오</h3>
-              <p className="mt-1 text-[13px] text-slate-600">강의 학습 후 주요 구간만 추출해 숏폼으로 전환할 수 있습니다.</p>
-            </div>
-            <button
-              type="button"
-              onClick={onOpenLogin}
-              className="min-h-11 rounded-xl bg-cyan-600 px-4 text-[12px] font-semibold text-white hover:bg-cyan-500"
-            >
-              숏폼 만들기
-            </button>
-          </div>
-        </section>
       </main>
-
-      <nav className="fixed bottom-3 left-1/2 z-40 w-[calc(100%-1rem)] max-w-md -translate-x-1/2 rounded-2xl border border-slate-200 bg-white/95 p-2 shadow-lg backdrop-blur lg:hidden">
-        <ul className="grid grid-cols-4 gap-1">
-          {navItems.map((item) => (
-            <li key={item.label}>
-              <button
-                type="button"
-                onClick={() => {
-                  if (item.label === '강의') {
-                    scrollToElement(coursesRef.current);
-                    return;
-                  }
-                  if (item.label === '숏폼') {
-                    scrollToElement(shortformRef.current);
-                    return;
-                  }
-                  if (item.label === '챗봇') {
-                    onOpenLogin();
-                    return;
-                  }
-                  scrollToElement(roadmapRef.current);
-                }}
-                className="min-h-12 w-full rounded-xl text-[11px] font-semibold text-slate-600 hover:bg-slate-100"
-              >
-                <span className="flex flex-col items-center gap-1">
-                  <i className={`${item.icon} text-[18px]`} />
-                  {item.label}
-                </span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      </nav>
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/QuizGenPage.tsx
+++ b/frontend/src/features/lms/pages/QuizGenPage.tsx
@@ -37,7 +37,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1d4ed8_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
+      <section className="overflow-hidden rounded-[32px] border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
@@ -76,7 +76,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
         <div className="space-y-6">
           <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-book-open-line text-indigo-600" />
+              <i className="ri-book-open-line text-cyan-700" />
               강의 선택
             </h3>
             <div className="mt-4 space-y-2">
@@ -88,10 +88,10 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
                     type="button"
                     onClick={() => setSelectedCourseId(course.id)}
                     className={`flex w-full items-center gap-3 rounded-[24px] border px-4 py-4 text-left transition ${
-                      active ? 'border-indigo-300 bg-indigo-50 ring-2 ring-indigo-100' : 'border-slate-200 bg-slate-50 hover:border-indigo-200 hover:bg-white'
+                      active ? 'border-cyan-300 bg-cyan-50 ring-2 ring-cyan-100' : 'border-slate-200 bg-slate-50 hover:border-cyan-200 hover:bg-white'
                     }`}
                   >
-                    <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-indigo-100 text-[20px] text-indigo-600">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-cyan-100 text-[20px] text-cyan-700">
                       <i className="ri-play-circle-line" />
                     </div>
                     <div className="min-w-0 flex-1">
@@ -100,7 +100,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
                         {course.category} · {course.instructor_name} · {course.lecture_count}차시
                       </div>
                     </div>
-                    <div className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-indigo-600">{course.progress_percent}%</div>
+                    <div className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-cyan-700">{course.progress_percent}%</div>
                   </button>
                 );
               })}
@@ -109,7 +109,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
 
           <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-settings-3-line text-indigo-600" />
+              <i className="ri-settings-3-line text-cyan-700" />
               생성 조건
             </h3>
             <div className="mt-4 space-y-4">
@@ -125,7 +125,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
                   step={1}
                   value={questionCount}
                   onChange={(event) => setQuestionCount(Number(event.target.value))}
-                  className="w-full accent-indigo-600"
+                  className="w-full accent-cyan-600"
                 />
               </div>
 
@@ -140,7 +140,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
                         type="button"
                         onClick={() => setDifficulty(item)}
                         className={`rounded-2xl px-3 py-3 text-[12px] font-semibold transition ${
-                          active ? 'bg-indigo-600 text-white' : 'border border-slate-200 bg-slate-50 text-slate-600 hover:border-indigo-200 hover:text-indigo-600'
+                          active ? 'bg-cyan-600 text-white' : 'border border-slate-200 bg-slate-50 text-slate-600 hover:border-cyan-200 hover:text-cyan-700'
                         }`}
                       >
                         {difficultyLabels[item]}
@@ -165,7 +165,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
                           )
                         }
                         className={`rounded-full px-3 py-1.5 text-[12px] font-semibold transition ${
-                          active ? 'bg-indigo-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:border-indigo-200 hover:text-indigo-600'
+                          active ? 'bg-cyan-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:border-cyan-200 hover:text-cyan-700'
                         }`}
                       >
                         {type}
@@ -185,23 +185,23 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
                 <h3 className="text-[15px] font-bold text-slate-900">생성 미리보기</h3>
                 <p className="mt-1 text-[12px] text-slate-500">선택한 강의와 조건을 반영한 결과 구조를 먼저 보여줍니다.</p>
               </div>
-              <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">{estimatedMinutes}분 예상</div>
+              <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">{estimatedMinutes}분 예상</div>
             </div>
 
             {selectedCourse ? (
               <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
                 <div className="rounded-[26px] bg-[linear-gradient(135deg,#eff6ff_0%,#eef2ff_50%,#f5f3ff_100%)] px-5 py-5">
-                  <div className="text-[12px] font-semibold text-indigo-600">선택 강의</div>
+                  <div className="text-[12px] font-semibold text-cyan-700">선택 강의</div>
                   <div className="mt-1 text-[20px] font-extrabold tracking-[-0.03em] text-slate-900">{selectedCourse.title}</div>
                   <div className="mt-2 text-[13px] leading-6 text-slate-600">
                     {selectedCourse.category} · {selectedCourse.lecture_count}차시 · {selectedCourse.total_duration_minutes}분
                   </div>
                   <p className="mt-4 text-[13px] leading-7 text-slate-600">{coverageSummary}</p>
                   <div className="mt-5 flex flex-wrap gap-2">
-                    <button type="button" className="rounded-full bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500">
+                    <button type="button" className="rounded-full bg-cyan-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-cyan-500">
                       퀴즈 생성
                     </button>
-                    <button type="button" className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600">
+                    <button type="button" className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-700">
                       저장하기
                     </button>
                   </div>
@@ -223,7 +223,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
                       <div className="mt-1 flex flex-wrap gap-2">
                         {activeTypes.length ? (
                           activeTypes.map((type) => (
-                            <span key={type} className="rounded-full bg-indigo-50 px-2.5 py-1 text-[11px] font-semibold text-indigo-600">
+                            <span key={type} className="rounded-full bg-cyan-50 px-2.5 py-1 text-[11px] font-semibold text-cyan-700">
                               {type}
                             </span>
                           ))
@@ -250,7 +250,7 @@ export function QuizGenPage({ courses }: QuizGenPageProps) {
 
           <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-list-check-2 text-indigo-600" />
+              <i className="ri-list-check-2 text-cyan-700" />
               추천 구성
             </h3>
             <div className="mt-4 grid gap-3 md:grid-cols-2">

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -1,85 +1,36 @@
-import { lazy } from 'react';
+import { Suspense, lazy, type ReactNode } from 'react';
 import type { LoginResponse } from '@myway/shared';
 import { RolePageFallback } from '../components/RolePageFallback';
+import { AIChatPage } from './AIChatPage';
+import { AISummaryPage } from './AISummaryPage';
+import { AssignmentCheckPage } from './AssignmentCheckPage';
+import { CourseCreatePage } from './CourseCreatePage';
+import { CoursesPage } from './CoursesPage';
+import { InstructorDashboardPage } from './InstructorDashboardPage';
+import { LectureWatchPage } from './LectureWatchPage';
+import { LectureStudioPage } from './LectureStudioPage';
 import { HomePage } from './HomePage';
+import { MyCoursesPage } from './MyCoursesPage';
+import { QuizGenPage } from './QuizGenPage';
+import { StudentDashboardPage } from './StudentDashboardPage';
 import type { LmsDashboardProps, LmsPageId } from '../types';
 
-const MyCoursesPage = lazy(async () => {
-  const mod = await import('./MyCoursesPage');
-  return { default: mod.MyCoursesPage };
-});
-const CoursesPage = lazy(async () => {
-  const mod = await import('./CoursesPage');
-  return { default: mod.CoursesPage };
-});
-const LectureWatchPage = lazy(async () => {
-  const mod = await import('./LectureWatchPage');
-  return { default: mod.LectureWatchPage };
-});
-const CourseCreatePage = lazy(async () => {
-  const mod = await import('./CourseCreatePage');
-  return { default: mod.CourseCreatePage };
-});
-const MediaPipelinePage = lazy(async () => {
-  const mod = await import('./MediaPipelinePage');
-  return { default: mod.MediaPipelinePage };
-});
-const ShortformHubPage = lazy(async () => {
-  const mod = await import('./ShortformHubPage');
-  return { default: mod.ShortformHubPage };
-});
-const AIChatPage = lazy(async () => {
-  const mod = await import('./AIChatPage');
-  return { default: mod.AIChatPage };
-});
-const StudentDashboardPage = lazy(async () => {
-  const mod = await import('./StudentDashboardPage');
-  return { default: mod.StudentDashboardPage };
-});
-const InstructorDashboardPage = lazy(async () => {
-  const mod = await import('./InstructorDashboardPage');
-  return { default: mod.InstructorDashboardPage };
-});
-const AdminDashboardPage = lazy(async () => {
-  const mod = await import('./AdminDashboardPage');
-  return { default: mod.AdminDashboardPage };
-});
-const AdminUsersPage = lazy(async () => {
-  const mod = await import('./AdminUsersPage');
-  return { default: mod.AdminUsersPage };
-});
-const AdminInstructorsPage = lazy(async () => {
-  const mod = await import('./AdminInstructorsPage');
-  return { default: mod.AdminInstructorsPage };
-});
-const AdminAssignPage = lazy(async () => {
-  const mod = await import('./AdminAssignPage');
-  return { default: mod.AdminAssignPage };
-});
-const AdminStatsPage = lazy(async () => {
-  const mod = await import('./AdminStatsPage');
-  return { default: mod.AdminStatsPage };
-});
-const AdminAutomationPage = lazy(async () => {
-  const mod = await import('./AdminAutomationPage');
-  return { default: mod.AdminAutomationPage };
-});
-const LectureStudioPage = lazy(async () => {
-  const mod = await import('./LectureStudioPage');
-  return { default: mod.LectureStudioPage };
-});
-const AISummaryPage = lazy(async () => {
-  const mod = await import('./AISummaryPage');
-  return { default: mod.AISummaryPage };
-});
-const QuizGenPage = lazy(async () => {
-  const mod = await import('./QuizGenPage');
-  return { default: mod.QuizGenPage };
-});
-const AssignmentCheckPage = lazy(async () => {
-  const mod = await import('./AssignmentCheckPage');
-  return { default: mod.AssignmentCheckPage };
-});
+const AdminAssignPage = lazy(() => import('./AdminAssignPage').then((module) => ({ default: module.AdminAssignPage })));
+const AdminAutomationPage = lazy(() => import('./AdminAutomationPage').then((module) => ({ default: module.AdminAutomationPage })));
+const AdminDashboardPage = lazy(() => import('./AdminDashboardPage').then((module) => ({ default: module.AdminDashboardPage })));
+const AdminInstructorsPage = lazy(() => import('./AdminInstructorsPage').then((module) => ({ default: module.AdminInstructorsPage })));
+const AdminStatsPage = lazy(() => import('./AdminStatsPage').then((module) => ({ default: module.AdminStatsPage })));
+const AdminUsersPage = lazy(() => import('./AdminUsersPage').then((module) => ({ default: module.AdminUsersPage })));
+const MediaPipelinePage = lazy(() => import('./MediaPipelinePage').then((module) => ({ default: module.MediaPipelinePage })));
+const ShortformHubPage = lazy(() => import('./ShortformHubPage').then((module) => ({ default: module.ShortformHubPage })));
+
+function withSuspense(node: ReactNode): ReactNode {
+  return (
+    <Suspense fallback={<div className="rounded-2xl border border-slate-200 bg-white px-5 py-8 text-sm text-slate-500">화면을 불러오는 중입니다.</div>}>
+      {node}
+    </Suspense>
+  );
+}
 
 type RolePageRouterProps = Pick<
   LmsDashboardProps,
@@ -154,7 +105,7 @@ export function RolePageRouter({
   if (session.user.role === 'ADMIN') {
     switch (page) {
       case 'dashboard':
-        return <AdminDashboardPage dashboard={dashboard} users={demoUsers} courses={courseCards} insights={insights} />;
+        return withSuspense(<AdminDashboardPage dashboard={dashboard} users={demoUsers} courses={courseCards} insights={insights} />);
       case 'my-courses':
         return (
           <MyCoursesPage
@@ -213,28 +164,28 @@ export function RolePageRouter({
           />
         );
       case 'admin-users':
-        return <AdminUsersPage users={demoUsers} />;
+        return withSuspense(<AdminUsersPage users={demoUsers} />);
       case 'admin-instructors':
-        return <AdminInstructorsPage instructors={demoUsers.filter((user) => user.role === 'INSTRUCTOR')} courses={courseCards} />;
+        return withSuspense(<AdminInstructorsPage instructors={demoUsers.filter((user) => user.role === 'INSTRUCTOR')} courses={courseCards} />);
       case 'admin-assign':
-        return <AdminAssignPage users={demoUsers} courses={courseCards} />;
+        return withSuspense(<AdminAssignPage users={demoUsers} courses={courseCards} />);
       case 'admin-stats':
-        return <AdminStatsPage dashboard={dashboard} courses={courseCards} users={demoUsers} insights={insights} aiLogs={aiLogs} />;
+        return withSuspense(<AdminStatsPage dashboard={dashboard} courses={courseCards} users={demoUsers} insights={insights} aiLogs={aiLogs} />);
       case 'admin-automation':
-        return <AdminAutomationPage providerCatalog={providers} />;
+        return withSuspense(<AdminAutomationPage providerCatalog={providers} />);
       case 'media-pipeline':
-        return (
+        return withSuspense((
           <MediaPipelinePage
             selectedCourse={selectedCourse}
             highlightedLecture={highlightedLecture}
             sessionToken={sessionToken}
             viewerRole={session.user.role}
           />
-        );
+        ));
       case 'shortform':
       case 'my-shortforms':
       case 'community':
-        return (
+        return withSuspense((
           <ShortformHubPage
             session={session}
             highlightedLecture={highlightedLecture}
@@ -244,7 +195,7 @@ export function RolePageRouter({
             recommendations={recommendations}
             initialTab={shortformInitialTab}
           />
-        );
+        ));
       default:
         return (
           <RolePageFallback
@@ -342,14 +293,14 @@ export function RolePageRouter({
     }
 
     if (page === 'media-pipeline') {
-      return (
+      return withSuspense((
         <MediaPipelinePage
           selectedCourse={selectedCourse}
           highlightedLecture={highlightedLecture}
           sessionToken={sessionToken}
           viewerRole={session.user.role}
         />
-      );
+      ));
     }
 
     if (page === 'quiz-gen') {
@@ -367,7 +318,7 @@ export function RolePageRouter({
     }
 
     if (page === 'shortform' || page === 'my-shortforms' || page === 'community') {
-      return (
+      return withSuspense((
         <ShortformHubPage
           session={session}
           highlightedLecture={highlightedLecture}
@@ -377,7 +328,7 @@ export function RolePageRouter({
           recommendations={recommendations}
           initialTab={shortformInitialTab}
         />
-      );
+      ));
     }
 
     return (
@@ -434,7 +385,7 @@ export function RolePageRouter({
   }
 
   if (page === 'shortform' || page === 'my-shortforms' || page === 'community') {
-    return (
+    return withSuspense((
       <ShortformHubPage
         session={session}
         highlightedLecture={highlightedLecture}
@@ -444,7 +395,7 @@ export function RolePageRouter({
         recommendations={recommendations}
         initialTab={shortformInitialTab}
       />
-    );
+    ));
   }
 
   if (page === 'dashboard') {

--- a/frontend/src/features/lms/pages/ShortformHubPage.tsx
+++ b/frontend/src/features/lms/pages/ShortformHubPage.tsx
@@ -47,27 +47,27 @@ export function ShortformHubPage({
   const selectedCourseTitle = allowedSelectedCourse?.title ?? allowedCourses[0]?.title ?? '선택된 강의 없음';
 
   return (
-    <div className="space-y-5">
-      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8">
+    <div className="space-y-4">
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1e3a8a_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
               <i className="ri-scissors-cut-line" />
               숏폼 허브
             </div>
-            <h2 className="mt-3 text-[26px] font-extrabold tracking-[-0.05em] lg:text-[32px]">숏폼 제작, 내 숏폼, 커뮤니티를 한 화면에서 다룹니다.</h2>
-            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-white/78">
+            <h2 className="mt-3 text-[24px] font-bold lg:text-[28px]">숏폼 제작, 보관, 공유를 한 흐름으로 관리합니다.</h2>
+            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-white/80">
               아래 탭으로 전환하면 제작, 보관함, 커뮤니티가 같은 흐름 안에서 이어집니다. 학생은 수강 중인 강의만 제작할 수 있습니다.
             </p>
           </div>
-          <div className="rounded-2xl bg-white/10 px-4 py-3 text-[12px] text-white/75 backdrop-blur">
-            <div className="font-semibold text-white">{selectedCourseTitle}</div>
-            <div className="mt-1">현재 선택된 강의 기준으로 숏폼을 조립합니다.</div>
+          <div className="rounded-xl border border-white/15 bg-white/10 px-4 py-3 text-[12px] text-white/75 backdrop-blur">
+            <div className="text-[11px] text-white/70">현재 작업 강좌</div>
+            <div className="mt-1 font-semibold text-white">{selectedCourseTitle}</div>
           </div>
         </div>
       </section>
 
-      <section className="rounded-[30px] border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm">
+      <section className="rounded-2xl border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm">
         <div className="flex flex-wrap gap-2 border-b border-[var(--app-border)] pb-4">
           {tabs.map((tab) => {
             const active = activeTab === tab.key;
@@ -76,11 +76,11 @@ export function ShortformHubPage({
                 key={tab.key}
                 type="button"
                 onClick={() => setActiveTab(tab.key)}
-                className={`rounded-2xl border px-4 py-3 text-left transition ${
+                className={`min-w-[180px] rounded-xl border px-4 py-3 text-left transition ${
                   active ? 'border-indigo-600 bg-indigo-600 text-white shadow-sm' : 'border-[var(--app-border)] bg-white text-[var(--app-text-secondary)] hover:border-indigo-300 hover:bg-indigo-50'
                 }`}
               >
-                <div className="flex items-center gap-2 text-[13px] font-bold">
+                <div className="flex items-center gap-2 text-[13px] font-semibold">
                   <i className={`${tab.icon} text-[15px]`} />
                   {tab.label}
                 </div>

--- a/frontend/src/features/lms/pages/ShortformHubPage.tsx
+++ b/frontend/src/features/lms/pages/ShortformHubPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { AIRecommendationOverview, CourseCard, CourseDetail, LectureDetail, LoginResponse } from '@myway/shared';
 import { CommunityPage } from './CommunityPage';
 import { MyShortformsPage } from './MyShortformsPage';
@@ -48,27 +48,27 @@ export function ShortformHubPage({
 
   return (
     <div className="space-y-5">
-      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1e3a8a_52%,#312e81_100%)] px-6 py-5 text-white shadow-sm lg:px-8">
+      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#070b1b_0%,#1b2250_48%,#5b21b6_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(15,23,42,0.16)] lg:px-8">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
               <i className="ri-scissors-cut-line" />
               숏폼 허브
             </div>
-            <h2 className="mt-3 text-[24px] font-bold lg:text-[28px]">숏폼 제작, 보관, 공유를 한 흐름으로 관리합니다.</h2>
-            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-white/80">
+            <h2 className="mt-3 text-[26px] font-extrabold tracking-[-0.05em] lg:text-[32px]">숏폼 제작, 내 숏폼, 커뮤니티를 한 화면에서 다룹니다.</h2>
+            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-white/78">
               아래 탭으로 전환하면 제작, 보관함, 커뮤니티가 같은 흐름 안에서 이어집니다. 학생은 수강 중인 강의만 제작할 수 있습니다.
             </p>
           </div>
-          <div className="rounded-xl border border-white/15 bg-white/10 px-4 py-3 text-[12px] text-white/75 backdrop-blur">
-            <div className="text-[11px] text-white/70">현재 작업 강좌</div>
-            <div className="mt-1 font-semibold text-white">{selectedCourseTitle}</div>
+          <div className="rounded-2xl bg-white/10 px-4 py-3 text-[12px] text-white/75 backdrop-blur">
+            <div className="font-semibold text-white">{selectedCourseTitle}</div>
+            <div className="mt-1">현재 선택된 강의 기준으로 숏폼을 조립합니다.</div>
           </div>
         </div>
       </section>
 
-      <section className="rounded-2xl border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm">
-        <div className="flex flex-wrap gap-2 border-b border-[var(--app-border)] pb-3">
+      <section className="rounded-[30px] border border-[var(--app-border)] bg-white px-5 py-5 shadow-sm">
+        <div className="flex flex-wrap gap-2 border-b border-[var(--app-border)] pb-4">
           {tabs.map((tab) => {
             const active = activeTab === tab.key;
             return (
@@ -76,11 +76,11 @@ export function ShortformHubPage({
                 key={tab.key}
                 type="button"
                 onClick={() => setActiveTab(tab.key)}
-                className={`min-w-[180px] rounded-xl border px-4 py-2.5 text-left transition ${
-                  active ? 'border-cyan-600 bg-cyan-600 text-white shadow-sm' : 'border-[var(--app-border)] bg-white text-[var(--app-text-secondary)] hover:border-cyan-300 hover:bg-cyan-50'
+                className={`rounded-2xl border px-4 py-3 text-left transition ${
+                  active ? 'border-indigo-600 bg-indigo-600 text-white shadow-sm' : 'border-[var(--app-border)] bg-white text-[var(--app-text-secondary)] hover:border-indigo-300 hover:bg-indigo-50'
                 }`}
               >
-                <div className="flex items-center gap-2 text-[13px] font-semibold">
+                <div className="flex items-center gap-2 text-[13px] font-bold">
                   <i className={`${tab.icon} text-[15px]`} />
                   {tab.label}
                 </div>
@@ -118,4 +118,3 @@ export function ShortformHubPage({
     </div>
   );
 }
-

--- a/frontend/src/features/lms/pages/ShortformHubPage.tsx
+++ b/frontend/src/features/lms/pages/ShortformHubPage.tsx
@@ -48,7 +48,7 @@ export function ShortformHubPage({
 
   return (
     <div className="space-y-4">
-      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-[linear-gradient(135deg,#0f172a_0%,#1e3a8a_52%,#312e81_100%)] px-6 py-6 text-white shadow-sm lg:px-8">
+      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm lg:px-8">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">
@@ -77,7 +77,7 @@ export function ShortformHubPage({
                 type="button"
                 onClick={() => setActiveTab(tab.key)}
                 className={`min-w-[180px] rounded-xl border px-4 py-3 text-left transition ${
-                  active ? 'border-indigo-600 bg-indigo-600 text-white shadow-sm' : 'border-[var(--app-border)] bg-white text-[var(--app-text-secondary)] hover:border-indigo-300 hover:bg-indigo-50'
+                  active ? 'border-cyan-600 bg-cyan-600 text-white shadow-sm' : 'border-[var(--app-border)] bg-white text-[var(--app-text-secondary)] hover:border-cyan-300 hover:bg-cyan-50'
                 }`}
               >
                 <div className="flex items-center gap-2 text-[13px] font-semibold">

--- a/frontend/src/features/lms/pages/StudentDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/StudentDashboardPage.tsx
@@ -77,41 +77,35 @@ export function StudentDashboardPage({
       },
     ];
   const activities = dashboard?.recent_activities ?? [];
+  const recommendationItems = Array.isArray(recommendations?.recommendations) ? recommendations.recommendations : [];
   const nextAction = dashboard?.next_action ?? '로그인 후 개인 학습 흐름을 확인할 수 있습니다.';
   const continueCourse = highlightedLecture
     ? courses.find((course) => course.id === highlightedLecture.course_id) ?? courses[0] ?? null
     : courses[0] ?? null;
   const progress = circularProgress(averageProgress);
-  const recommendationItems = Array.isArray(recommendations?.recommendations)
-    ? recommendations.recommendations
-    : [];
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8 lg:py-8">
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)] lg:items-center">
           <div className="flex items-center gap-5">
-            <div className="relative flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-[30px] bg-[linear-gradient(135deg,#0891b2,#14b8a6)] text-white shadow-[0_18px_40px_rgba(8,145,178,0.26)]">
+            <div className="relative flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-[30px] bg-[linear-gradient(135deg,#6366f1,#22c55e)] text-white shadow-[0_18px_40px_rgba(79,70,229,0.22)]">
               <span className="text-[28px] font-extrabold">{session.user.name.slice(0, 1)}</span>
               <span className="absolute -bottom-2 -right-2 rounded-full border border-white bg-white p-1 text-[16px] text-indigo-600 shadow-sm">
                 <i className="ri-user-3-line" />
               </span>
             </div>
             <div className="min-w-0 flex-1">
-              <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
+              <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">
                 <i className="ri-dashboard-3-line" />
                 마이페이지
               </div>
-              <h2 className="mt-4 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[32px] text-slate-900">
-                {session.user.name}님, 오늘 학습을
-                <br />
-                이어갈 준비가 되어 있습니다.
-              </h2>
+              <h2 className="mt-4 text-[24px] font-bold lg:text-[28px] text-slate-900">{session.user.name}님의 학습 대시보드</h2>
               <p className="mt-3 max-w-2xl text-[14px] leading-7 text-slate-500">{nextAction}</p>
               <div className="mt-4 flex flex-wrap gap-2">
                 <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">{session.user.email}</span>
                 <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">{session.user.role}</span>
-                <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">수강 중 {courses.length}개</span>
+                <span className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-700">수강 중 {courses.length}개</span>
               </div>
             </div>
           </div>
@@ -125,7 +119,7 @@ export function StudentDashboardPage({
                   cy="18"
                   r="16"
                   fill="none"
-                  stroke="rgb(8, 145, 178)"
+                  stroke="rgb(79, 70, 229)"
                   strokeWidth="2.5"
                   strokeDasharray={`${progress.circumference} ${progress.circumference}`}
                   strokeDashoffset={progress.offset}
@@ -160,9 +154,9 @@ export function StudentDashboardPage({
             key={action.page}
             type="button"
             onClick={() => onNavigate(action.page)}
-            className="group rounded-[28px] border border-slate-200 bg-white px-5 py-5 text-left shadow-[0_1px_3px_rgba(15,23,42,0.04)] transition hover:-translate-y-0.5 hover:border-cyan-200 hover:shadow-[0_14px_30px_rgba(15,23,42,0.08)]"
+            className="group rounded-2xl border border-slate-200 bg-white px-5 py-5 text-left shadow-sm transition hover:border-indigo-200"
           >
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-cyan-50 text-[22px] text-cyan-700 transition group-hover:bg-cyan-600 group-hover:text-white">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-50 text-[22px] text-indigo-600 transition group-hover:bg-indigo-600 group-hover:text-white">
               <i className={action.icon} />
             </div>
             <div className="mt-4 text-[14px] font-bold text-slate-900">{action.label}</div>
@@ -173,7 +167,7 @@ export function StudentDashboardPage({
 
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">
         <div className="space-y-6">
-          <div className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <h3 className="text-[15px] font-bold text-slate-900">최근 학습</h3>
@@ -186,7 +180,7 @@ export function StudentDashboardPage({
                     onSelectCourse(highlightedLecture.course_id);
                     onNavigate('courses');
                   }}
-                  className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-700"
+                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
                 >
                   상세 열기
                 </button>
@@ -195,10 +189,10 @@ export function StudentDashboardPage({
 
             {highlightedLecture && continueCourse ? (
               <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-                <div className="rounded-[26px] bg-[linear-gradient(135deg,#082f49_0%,#0e7490_60%,#1f2937_100%)] px-5 py-5 text-white">
-                  <div className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90">지금 이어볼 강의</div>
-                  <div className="mt-4 text-[22px] font-extrabold tracking-[-0.04em]">{highlightedLecture.title}</div>
-                  <div className="mt-2 text-[13px] leading-6 text-white/75">
+                <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
+                  <div className="inline-flex rounded-full bg-indigo-100 px-3 py-1 text-[11px] font-semibold text-indigo-700">지금 이어볼 강의</div>
+                  <div className="mt-4 text-[20px] font-bold text-slate-900">{highlightedLecture.title}</div>
+                  <div className="mt-2 text-[13px] leading-6 text-slate-500">
                     {highlightedLecture.course_title} · {highlightedLecture.course_instructor}
                   </div>
                   <div className="mt-6 flex flex-wrap gap-2">
@@ -208,24 +202,24 @@ export function StudentDashboardPage({
                         onSelectCourse(highlightedLecture.course_id);
                         onNavigate('courses');
                       }}
-                      className="min-h-10 rounded-xl bg-white px-4 py-2 text-[12px] font-semibold text-cyan-800 transition hover:bg-cyan-50"
+                      className="rounded-lg bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
                     >
                       상세/진도율 보기
                     </button>
                     <button
                       type="button"
                       onClick={() => onNavigate('ai-chat')}
-                      className="min-h-10 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-white/15"
+                      className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
                     >
                       챗봇으로 질문
                     </button>
                   </div>
                 </div>
 
-                <div className="rounded-[26px] border border-slate-200 bg-slate-50 px-5 py-5">
+                <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
                   <div className="flex items-center justify-between">
                     <div>
-                      <div className="text-[12px] font-semibold text-cyan-700">진도</div>
+                      <div className="text-[12px] font-semibold text-indigo-600">진도</div>
                       <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">
                         {continueCourse.progress_percent}%
                       </div>
@@ -238,7 +232,7 @@ export function StudentDashboardPage({
                     </div>
                   </div>
                   <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
-                    <div className="h-full rounded-full bg-cyan-500" style={{ width: `${Math.max(continueCourse.progress_percent, 8)}%` }} />
+                    <div className="h-full rounded-full bg-indigo-500" style={{ width: `${Math.max(continueCourse.progress_percent, 8)}%` }} />
                   </div>
                   <div className="mt-4 space-y-2">
                     <div className="rounded-2xl bg-white px-4 py-3">
@@ -267,13 +261,13 @@ export function StudentDashboardPage({
             )}
           </div>
 
-          <div className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <h3 className="text-[15px] font-bold text-slate-900">수강 중인 강의</h3>
                 <p className="mt-1 text-[12px] text-slate-500">카드를 눌러 강의 상세로 이동합니다.</p>
               </div>
-              <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">{courses.length}개</div>
+              <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">{courses.length}개</div>
             </div>
             <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
               {courses.slice(0, 4).map((course) => (
@@ -300,10 +294,10 @@ export function StudentDashboardPage({
             emptyMessage="최근 활동이 아직 없습니다. 첫 수강 신청이나 강의 완료가 생기면 여기에 표시됩니다."
           />
 
-          {recommendationItems.length > 0 ? (
-            <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          {recommendationItems.length ? (
+            <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
               <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-                <i className="ri-robot-line text-cyan-700" />
+                <i className="ri-robot-line text-indigo-600" />
                 AI 추천
               </h3>
               <div className="mt-3 grid gap-3">

--- a/frontend/src/features/lms/pages/StudentDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/StudentDashboardPage.tsx
@@ -86,12 +86,12 @@ export function StudentDashboardPage({
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white px-6 py-6 shadow-sm lg:px-8">
+      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-6 shadow-sm lg:px-8">
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)] lg:items-center">
           <div className="flex items-center gap-5">
-            <div className="relative flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-[30px] bg-[linear-gradient(135deg,#6366f1,#22c55e)] text-white shadow-[0_18px_40px_rgba(79,70,229,0.22)]">
+              <div className="relative flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-[30px] bg-[linear-gradient(135deg,#0e7490,#06b6d4)] text-white shadow-[0_18px_40px_rgba(8,145,178,0.28)]">
               <span className="text-[28px] font-extrabold">{session.user.name.slice(0, 1)}</span>
-              <span className="absolute -bottom-2 -right-2 rounded-full border border-white bg-white p-1 text-[16px] text-indigo-600 shadow-sm">
+                <span className="absolute -bottom-2 -right-2 rounded-full border border-white bg-white p-1 text-[16px] text-cyan-700 shadow-sm">
                 <i className="ri-user-3-line" />
               </span>
             </div>
@@ -105,12 +105,12 @@ export function StudentDashboardPage({
               <div className="mt-4 flex flex-wrap gap-2">
                 <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">{session.user.email}</span>
                 <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">{session.user.role}</span>
-                <span className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-700">수강 중 {courses.length}개</span>
+                <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">수강 중 {courses.length}개</span>
               </div>
             </div>
           </div>
 
-          <div className="grid gap-3 rounded-[28px] border border-slate-200 bg-slate-50 p-4">
+          <div className="grid gap-3 rounded-[28px] border border-[#d3e6f6] bg-[linear-gradient(180deg,#fafdff_0%,#f1f8ff_100%)] p-4">
             <div className="flex items-center gap-4">
               <svg className="h-20 w-20 -rotate-90" viewBox="0 0 36 36">
                 <circle cx="18" cy="18" r="16" fill="none" stroke="rgba(15,23,42,0.08)" strokeWidth="2.5" />
@@ -119,7 +119,7 @@ export function StudentDashboardPage({
                   cy="18"
                   r="16"
                   fill="none"
-                  stroke="rgb(79, 70, 229)"
+                  stroke="rgb(14, 165, 233)"
                   strokeWidth="2.5"
                   strokeDasharray={`${progress.circumference} ${progress.circumference}`}
                   strokeDashoffset={progress.offset}
@@ -154,9 +154,9 @@ export function StudentDashboardPage({
             key={action.page}
             type="button"
             onClick={() => onNavigate(action.page)}
-            className="group rounded-2xl border border-slate-200 bg-white px-5 py-5 text-left shadow-sm transition hover:border-indigo-200"
+            className="group rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 text-left shadow-[0_14px_30px_rgba(6,31,57,0.08)] transition hover:border-cyan-300"
           >
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-50 text-[22px] text-indigo-600 transition group-hover:bg-indigo-600 group-hover:text-white">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-cyan-50 text-[22px] text-cyan-700 transition group-hover:bg-cyan-600 group-hover:text-white">
               <i className={action.icon} />
             </div>
             <div className="mt-4 text-[14px] font-bold text-slate-900">{action.label}</div>
@@ -167,7 +167,7 @@ export function StudentDashboardPage({
 
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">
         <div className="space-y-6">
-          <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <div className="rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <h3 className="text-[15px] font-bold text-slate-900">최근 학습</h3>
@@ -180,7 +180,7 @@ export function StudentDashboardPage({
                     onSelectCourse(highlightedLecture.course_id);
                     onNavigate('courses');
                   }}
-                  className="rounded-full border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
+                  className="rounded-full border border-[#cce0f2] bg-white px-4 py-2 text-[12px] font-semibold text-[#3e5d7b] transition hover:border-cyan-300 hover:text-cyan-700"
                 >
                   상세 열기
                 </button>
@@ -189,8 +189,8 @@ export function StudentDashboardPage({
 
             {highlightedLecture && continueCourse ? (
               <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-                <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
-                  <div className="inline-flex rounded-full bg-indigo-100 px-3 py-1 text-[11px] font-semibold text-indigo-700">지금 이어볼 강의</div>
+                <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-5 py-5">
+                  <div className="inline-flex rounded-full bg-cyan-100 px-3 py-1 text-[11px] font-semibold text-cyan-700">지금 이어볼 강의</div>
                   <div className="mt-4 text-[20px] font-bold text-slate-900">{highlightedLecture.title}</div>
                   <div className="mt-2 text-[13px] leading-6 text-slate-500">
                     {highlightedLecture.course_title} · {highlightedLecture.course_instructor}
@@ -202,24 +202,24 @@ export function StudentDashboardPage({
                         onSelectCourse(highlightedLecture.course_id);
                         onNavigate('courses');
                       }}
-                      className="rounded-lg bg-indigo-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-indigo-500"
+                      className="rounded-lg bg-[linear-gradient(135deg,#00b8e6_0%,#0077b6_100%)] px-4 py-2 text-[12px] font-semibold text-white transition hover:brightness-105"
                     >
                       상세/진도율 보기
                     </button>
                     <button
                       type="button"
                       onClick={() => onNavigate('ai-chat')}
-                      className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-indigo-200 hover:text-indigo-600"
+                      className="rounded-lg border border-[#cce0f2] bg-white px-4 py-2 text-[12px] font-semibold text-[#3e5d7b] transition hover:border-cyan-300 hover:text-cyan-700"
                     >
                       챗봇으로 질문
                     </button>
                   </div>
                 </div>
 
-                <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
+                <div className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] px-5 py-5">
                   <div className="flex items-center justify-between">
                     <div>
-                      <div className="text-[12px] font-semibold text-indigo-600">진도</div>
+                      <div className="text-[12px] font-semibold text-cyan-700">진도</div>
                       <div className="mt-1 text-[24px] font-extrabold tracking-[-0.04em] text-slate-900">
                         {continueCourse.progress_percent}%
                       </div>
@@ -232,7 +232,7 @@ export function StudentDashboardPage({
                     </div>
                   </div>
                   <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
-                    <div className="h-full rounded-full bg-indigo-500" style={{ width: `${Math.max(continueCourse.progress_percent, 8)}%` }} />
+                    <div className="h-full rounded-full bg-cyan-500" style={{ width: `${Math.max(continueCourse.progress_percent, 8)}%` }} />
                   </div>
                   <div className="mt-4 space-y-2">
                     <div className="rounded-2xl bg-white px-4 py-3">
@@ -261,13 +261,13 @@ export function StudentDashboardPage({
             )}
           </div>
 
-          <div className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+          <div className="rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <h3 className="text-[15px] font-bold text-slate-900">수강 중인 강의</h3>
                 <p className="mt-1 text-[12px] text-slate-500">카드를 눌러 강의 상세로 이동합니다.</p>
               </div>
-              <div className="rounded-full bg-indigo-50 px-3 py-1 text-[11px] font-semibold text-indigo-600">{courses.length}개</div>
+              <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">{courses.length}개</div>
             </div>
             <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
               {courses.slice(0, 4).map((course) => (
@@ -295,9 +295,9 @@ export function StudentDashboardPage({
           />
 
           {recommendationItems.length ? (
-            <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+            <section className="rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
               <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-                <i className="ri-robot-line text-indigo-600" />
+                <i className="ri-robot-line text-cyan-700" />
                 AI 추천
               </h3>
               <div className="mt-3 grid gap-3">

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,13 +9,27 @@ const frontendRoot = resolve(repoRoot, 'frontend');
 export default defineConfig({
   root: frontendRoot,
   plugins: [react()],
-   resolve: {
+  resolve: {
     alias: {
       '@myway/shared': resolve(repoRoot, 'packages/shared/src'),
     },
-    dedupe: ['react', 'react-dom'], 
+    dedupe: ['react', 'react-dom'],
   },
-  
+  build: {
+    chunkSizeWarningLimit: 550,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('/frontend/src/features/lms/pages/')) return 'lms-pages';
+          if (!id.includes('node_modules')) return;
+          if (id.includes('react') || id.includes('react-dom')) return 'react-vendor';
+          if (id.includes('recharts')) return 'charts-vendor';
+          if (id.includes('remixicon')) return 'icon-vendor';
+          return 'vendor';
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     host: '0.0.0.0',


### PR DESCRIPTION
# 변경 요약
LMS 전반(홈/강의/AI/숏폼/대시보드/관리자)의 UI를 레퍼런스 스타일(시안-딥블루 톤, 카드 계층, 모바일 하단 네비)로 일관 개편했습니다.

## 배경
기존 화면별 톤과 컴포넌트 계층이 달라 사용성이 떨어졌고, 브랜드/디자인 일관성이 부족해 레퍼런스 수준으로 통합 정리가 필요했습니다.

## 변경 내용
- 홈/로그인 전 메인/강의 상세/숏폼/커뮤니티/내 숏폼/대시보드/관리자 상세 화면 스타일 통일
- 공통 UI 컴포넌트(배너, 통계 카드, 타임라인, 필터바, 비교 카드, 챗 컴포넌트) 톤/여백/강조 체계 정리
- 모바일 하단 탭 네비 추가 및 헤더 스타일 통일
- 브랜드 표기 AIDU -> 내맘대로 변경
- PR 충돌 파일 전부 dev 최신 기준으로 재리베이스 후 해결

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 rontend/ 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 ackend/ 담당자 확인이 필요하다
- [ ] 문서 변경이면 docs/ 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 packages/shared/ 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트
- rontend/src/features/lms/** 전체에서 시안 계열 톤 통일이 의도대로 적용됐는지
- 강의/숏폼/관리자 화면에서 CTA 대비와 텍스트 가독성
- 모바일 뷰(AppShell, AppHeader)에서 하단 탭/상단 헤더 동작

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] docs/dev-logs/에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다