### PR TITLE
feat: 관리자 오케스트레이션 기반 LMS 상세 UX 고도화 및 Spring STT 연계

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -39,7 +39,8 @@ public class MediaController {
             String extraction_id,
             String status,
             String error_message,
-            Long event_version
+            Long event_version,
+            String audio_url
     ) {}
 
     private SessionView require(String auth) { return sessionService.me(auth); }
@@ -66,8 +67,9 @@ public class MediaController {
         if (!canManageMedia(session)) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "오디오 추출은 강사와 운영자만 사용할 수 있습니다."));
         if (body == null) return ResponseEntity.badRequest().body(ApiResponse.failure("INVALID_PAYLOAD", "요청 본문이 필요합니다."));
         String lectureId = text(body, "lecture_id");
+        String audioUrl = text(body, "audio_url");
         if (lectureId.isEmpty()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.createExtraction(lectureId), "오디오 추출 job이 생성되었습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.createExtraction(lectureId, audioUrl.isBlank() ? null : audioUrl), "오디오 추출 job이 생성되었습니다."));
     }
 
     @PostMapping("/transcribe")
@@ -91,8 +93,9 @@ public class MediaController {
         }
         String sttProvider = text(body, "stt_provider");
         String sttModel = text(body, "stt_model");
+        String audioUrl = text(body, "audio_url");
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(
-                featureStore.transcribe(lectureId, language, durationMs, sttProvider.isBlank() ? null : sttProvider, sttModel.isBlank() ? null : sttModel),
+                featureStore.transcribe(lectureId, language, durationMs, sttProvider.isBlank() ? null : sttProvider, sttModel.isBlank() ? null : sttModel, audioUrl.isBlank() ? null : audioUrl),
                 "트랜스크립트가 생성되었습니다."
         ));
     }
@@ -195,7 +198,8 @@ public class MediaController {
         long eventVersion = body.event_version() != null ? body.event_version() : 1L;
         String status = body.status() == null ? "COMPLETED" : body.status();
         String errorMessage = body.error_message();
-        Map<String, Object> result = featureStore.completeExtractionCallback(extractionId, status, errorMessage, eventVersion);
+        String audioUrl = body.audio_url() == null ? null : body.audio_url().trim();
+        Map<String, Object> result = featureStore.completeExtractionCallback(extractionId, status, errorMessage, eventVersion, audioUrl);
         if (result == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
         }
@@ -205,7 +209,31 @@ public class MediaController {
                     "오래된 callback 이벤트를 무시했습니다."
             ));
         }
-        return ResponseEntity.ok(ApiResponse.success(Map.of("extraction", result, "pipeline", featureStore.pipeline(String.valueOf(result.getOrDefault("lecture_id", "")))), "오디오 추출 callback이 반영되었습니다."));
+        String lectureId = String.valueOf(result.getOrDefault("lecture_id", "")).trim();
+        Map<String, Object> transcribeResult = null;
+        if ("COMPLETED".equalsIgnoreCase(String.valueOf(result.getOrDefault("status", ""))) && !lectureId.isBlank()) {
+            transcribeResult = featureStore.transcribe(
+                    lectureId,
+                    "ko",
+                    null,
+                    "cloudflare",
+                    "cf-whisper",
+                    audioUrl
+            );
+        }
+
+        if (transcribeResult == null) {
+            return ResponseEntity.ok(ApiResponse.success(Map.of("extraction", result, "pipeline", featureStore.pipeline(lectureId)), "오디오 추출 callback이 반영되었습니다."));
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of(
+                        "extraction", result,
+                        "pipeline", featureStore.pipeline(lectureId),
+                        "transcript", transcribeResult
+                ),
+                "오디오 추출 callback이 반영되어 STT가 자동 시작되었습니다."
+        ));
     }
 
     private String text(Map<String, Object> body, String key) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -389,11 +389,16 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> createExtraction(String lectureId) {
+        return createExtraction(lectureId, null);
+    }
+
+    public Map<String, Object> createExtraction(String lectureId, String audioUrl) {
         String id = UUID.randomUUID().toString();
         Map<String, Object> item = new HashMap<>();
         item.put("id", id);
         item.put("lecture_id", lectureId);
         item.put("status", "COMPLETED");
+        item.put("audio_url", audioUrl);
         item.put("last_event_version", 0L);
         item.put("created_at", Instant.now().toString());
 
@@ -416,7 +421,11 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> transcribe(String lectureId, String language, Integer durationMsInput, String sttProvider, String sttModel) {
-        Map<String, Object> extraction = createExtraction(lectureId);
+        return transcribe(lectureId, language, durationMsInput, sttProvider, sttModel, null);
+    }
+
+    public Map<String, Object> transcribe(String lectureId, String language, Integer durationMsInput, String sttProvider, String sttModel, String audioUrl) {
+        Map<String, Object> extraction = createExtraction(lectureId, audioUrl);
         LectureItem lecture = learningService.getLecture(lectureId);
         int lectureDurationMs = lecture == null
                 ? FALLBACK_TRANSCRIPT_DURATION_MS
@@ -425,8 +434,8 @@ public class FeatureStoreService {
         int durationMs = Math.min(requestedDurationMs, PUBLIC_STT_MAX_DURATION_MS);
 
         String normalizedLanguage = language == null || language.isBlank() ? "ko" : language;
-        String resolvedProvider = sttProvider == null || sttProvider.isBlank() ? "spring-stt" : sttProvider.trim();
-        String resolvedModel = sttModel == null || sttModel.isBlank() ? "spring-stt-v1" : sttModel.trim();
+        String resolvedProvider = sttProvider == null || sttProvider.isBlank() ? "demo" : sttProvider.trim();
+        String resolvedModel = sttModel == null || sttModel.isBlank() ? "demo-stt-v1" : sttModel.trim();
         String baseText = buildLectureNarrative(lectureId);
         List<Map<String, Object>> segments = splitIntoSegments(baseText, durationMs);
         String transcriptId = String.valueOf(extraction.getOrDefault("id", UUID.randomUUID().toString()));
@@ -467,19 +476,21 @@ public class FeatureStoreService {
         extractionPayload.put("language", normalizedLanguage);
         extractionPayload.put("requested_stt_provider", resolvedProvider);
         extractionPayload.put("requested_stt_model", resolvedModel);
+        extractionPayload.put("audio_url", audioUrl);
         store.upsertKv(EXTRACTION_SCOPE, transcriptId, extractionPayload);
 
-        return Map.of(
-                "transcript_id", transcriptId,
-                "lecture_id", lectureId,
-                "segment_count", segments.size(),
-                "duration_ms", durationMs,
-                "word_count", wordCount,
-                "stt_provider", resolvedProvider,
-                "stt_model", resolvedModel,
-                "pipeline", pipeline(lectureId),
-                "language", normalizedLanguage
-        );
+        Map<String, Object> response = new HashMap<>();
+        response.put("transcript_id", transcriptId);
+        response.put("lecture_id", lectureId);
+        response.put("segment_count", segments.size());
+        response.put("duration_ms", durationMs);
+        response.put("word_count", wordCount);
+        response.put("stt_provider", resolvedProvider);
+        response.put("stt_model", resolvedModel);
+        response.put("audio_url", audioUrl);
+        response.put("pipeline", pipeline(lectureId));
+        response.put("language", normalizedLanguage);
+        return response;
     }
 
     public List<Map<String, Object>> extractions(String lectureId) {
@@ -487,6 +498,10 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> completeExtractionCallback(String extractionId, String status, String errorMessage, long eventVersion) {
+        return completeExtractionCallback(extractionId, status, errorMessage, eventVersion, null);
+    }
+
+    public Map<String, Object> completeExtractionCallback(String extractionId, String status, String errorMessage, long eventVersion, String audioUrl) {
         Map<String, Object> extraction = store.getKv(EXTRACTION_SCOPE, extractionId);
         if (extraction != null) {
             extraction = new HashMap<>(extraction);
@@ -512,6 +527,9 @@ public class FeatureStoreService {
         extraction.put("last_event_version", eventVersion);
         extraction.put("status", status == null || status.isBlank() ? "COMPLETED" : status.toUpperCase());
         extraction.put("error_message", errorMessage);
+        if (audioUrl != null && !audioUrl.isBlank()) {
+            extraction.put("audio_url", audioUrl);
+        }
         extraction.put("updated_at", Instant.now().toString());
         store.upsertKv(EXTRACTION_SCOPE, extractionId, extraction);
         return extraction;

--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -94,7 +94,12 @@ function renderNoticeList(course: CourseDetail) {
   );
 }
 
-function renderMaterialList(course: CourseDetail) {
+function renderMaterialList(
+  course: CourseDetail,
+  canManageCurrent: boolean,
+  onOpenMaterial: (fileName: string) => void,
+  onNavigateStudio: () => void,
+) {
   const materials = Array.isArray(course.materials) ? course.materials : [];
   if (materials.length === 0) {
     return (
@@ -128,9 +133,24 @@ function renderMaterialList(course: CourseDetail) {
               <p className="mt-1 text-[11px] font-medium text-cyan-700">{material.file_name}</p>
               <p className="mt-2 text-[12px] leading-6 text-slate-500">{material.summary}</p>
               <div className="mt-3">
-                <button type="button" className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700">
-                  자료 보기
-                </button>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onOpenMaterial(material.file_name)}
+                    className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700"
+                  >
+                    파일명 복사
+                  </button>
+                  {canManageCurrent ? (
+                    <button
+                      type="button"
+                      onClick={onNavigateStudio}
+                      className="rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700 transition hover:border-cyan-300 hover:bg-cyan-100"
+                    >
+                      강의 스튜디오 이동
+                    </button>
+                  ) : null}
+                </div>
               </div>
             </div>
           </div>
@@ -157,6 +177,12 @@ export function CourseExploreDetailPanel({
   const isLocked = Boolean(course && !course.enrolled && !canManageCurrent);
   const protectedVideoUrl = buildProtectedVideoUrl(detailLecture?.video_url, sessionToken);
   const safeRating = Number.isFinite(course?.rating) ? course.rating : 0;
+
+  const handleOpenMaterial = (fileName: string) => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      void navigator.clipboard.writeText(fileName);
+    }
+  };
 
   return (
     <section className="overflow-hidden rounded-[30px] border border-[var(--app-border)] bg-white shadow-sm">
@@ -405,7 +431,7 @@ export function CourseExploreDetailPanel({
               ) : activeTab === '공지' ? (
                 renderNoticeList(course)
               ) : activeTab === '자료' ? (
-                renderMaterialList(course)
+                renderMaterialList(course, canManageCurrent, handleOpenMaterial, () => onNavigate('lecture-studio'))
               ) : (
                 <div className="space-y-3">
                   {isLocked ? (

--- a/frontend/src/features/lms/components/ShortformCommunityCard.tsx
+++ b/frontend/src/features/lms/components/ShortformCommunityCard.tsx
@@ -20,6 +20,7 @@ function formatDuration(ms: number): string {
 
 export function ShortformCommunityCard({ item, active, onOpen, onPreview }: ShortformCommunityCardProps) {
   const totalDuration = item.clips.reduce((sum, clip) => sum + (clip.end_time_ms - clip.start_time_ms), 0);
+  const primaryClip = item.clips[0];
 
   return (
     <article
@@ -57,6 +58,22 @@ export function ShortformCommunityCard({ item, active, onOpen, onPreview }: Shor
       <div className="px-5 py-4">
         <p className="line-clamp-2 text-[12px] leading-6 text-slate-500">{item.description || '설명이 아직 없습니다.'}</p>
 
+        <div className="mt-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-[11px] text-slate-600">
+          {primaryClip ? (
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate font-semibold text-slate-700">{primaryClip.lecture_title}</span>
+              <span className="flex-shrink-0 text-slate-500">
+                {Math.floor(primaryClip.start_time_ms / 1000)}s ~ {Math.floor(primaryClip.end_time_ms / 1000)}s
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-semibold text-slate-700">대표 클립 없음</span>
+              <span className="text-slate-500">준비 전</span>
+            </div>
+          )}
+        </div>
+
         <div className="space-y-1.5">
           {item.clips.slice(0, 3).map((clip, index) => (
             <div key={`${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`} className="flex items-center gap-2 rounded-xl bg-slate-50 px-3 py-2 text-[12px]">
@@ -70,7 +87,7 @@ export function ShortformCommunityCard({ item, active, onOpen, onPreview }: Shor
             </div>
           ))}
           {item.clips.length === 0 ? (
-            <div className="rounded-xl bg-slate-50 px-3 py-2 text-[12px] text-slate-500">클립 미리보기 준비 중입니다.</div>
+            <div className="rounded-xl bg-slate-50 px-3 py-2 text-[12px] text-slate-500">클립이 아직 생성되지 않았습니다.</div>
           ) : null}
         </div>
 

--- a/frontend/src/features/lms/components/ShortformPreviewModal.tsx
+++ b/frontend/src/features/lms/components/ShortformPreviewModal.tsx
@@ -53,7 +53,7 @@ export function ShortformPreviewModal({ item, onClose }: ShortformPreviewModalPr
         role="dialog"
         aria-modal="true"
         aria-label={item.title}
-        className="max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-[28px] bg-white shadow-[0_24px_80px_rgba(15,23,42,0.3)]"
+        className="max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-[22px] bg-white shadow-[0_24px_80px_rgba(15,23,42,0.3)] md:rounded-[28px]"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
@@ -70,9 +70,9 @@ export function ShortformPreviewModal({ item, onClose }: ShortformPreviewModalPr
           </button>
         </div>
 
-        <div className="grid gap-5 p-5 lg:grid-cols-[1.05fr_0.95fr]">
+        <div className="grid gap-4 p-4 md:gap-5 md:p-5 lg:grid-cols-[1.05fr_0.95fr]">
           <div className="space-y-4">
-            <div className="rounded-[24px] bg-slate-950 px-5 py-5 text-white">
+            <div className="rounded-[20px] bg-slate-950 px-4 py-4 text-white md:rounded-[24px] md:px-5 md:py-5">
               {playbackUrl ? (
                 <video className="aspect-video w-full rounded-2xl border border-white/10 bg-black" controls preload="metadata" src={playbackUrl} />
               ) : (
@@ -90,16 +90,16 @@ export function ShortformPreviewModal({ item, onClose }: ShortformPreviewModalPr
               </div>
             </div>
 
-            <div className="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-4">
+            <div className="rounded-[20px] border border-slate-200 bg-slate-50 px-4 py-3 md:rounded-[24px] md:px-5 md:py-4">
               <div className="text-[12px] font-semibold text-slate-900">상세 설명</div>
-              <p className="mt-2 text-[13px] leading-7 text-slate-600">{item.description || '설명 없음'}</p>
+              <p className="mt-2 line-clamp-3 text-[12px] leading-6 text-slate-600 md:line-clamp-none md:text-[13px] md:leading-7">{item.description || '설명 없음'}</p>
             </div>
           </div>
 
           <div className="space-y-3 overflow-y-auto pr-1">
             <div className="text-[12px] font-semibold text-slate-500">클립 구성</div>
             {item.clips.length > 0 ? (
-              item.clips.map((clip, index) => (
+              item.clips.slice(0, 4).map((clip, index) => (
                 <article key={`${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`} className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
                   <div className="flex items-start gap-3">
                     <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-[11px] font-bold text-cyan-700">
@@ -110,7 +110,7 @@ export function ShortformPreviewModal({ item, onClose }: ShortformPreviewModalPr
                       <p className="mt-1 text-[12px] leading-6 text-slate-500">
                         {clip.label || '구간'} · {formatDuration(clip.end_time_ms - clip.start_time_ms)}
                       </p>
-                      {clip.description ? <p className="mt-1 text-[12px] leading-6 text-slate-500">{clip.description}</p> : null}
+                      {clip.description ? <p className="mt-1 hidden text-[12px] leading-6 text-slate-500 md:block">{clip.description}</p> : null}
                     </div>
                     <div className="flex-shrink-0 text-[11px] text-slate-400">
                       {Math.floor(clip.start_time_ms / 1000)}s ~ {Math.floor(clip.end_time_ms / 1000)}s
@@ -138,6 +138,9 @@ export function ShortformPreviewModal({ item, onClose }: ShortformPreviewModalPr
                 <div className="text-[11px] text-slate-500">저장</div>
               </div>
             </div>
+            {item.clips.length > 4 ? (
+              <div className="text-center text-[11px] font-semibold text-slate-500">모바일에서는 상위 4개 클립만 표시됩니다.</div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/frontend/src/features/lms/pages/AdminAssignPage.tsx
+++ b/frontend/src/features/lms/pages/AdminAssignPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import type { AuthUser, CourseCard } from '@myway/shared';
 
 type AdminAssignPageProps = {
@@ -8,13 +9,30 @@ type AdminAssignPageProps = {
 export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
   const students = users.filter((user) => user.role === 'STUDENT');
   const instructors = users.filter((user) => user.role === 'INSTRUCTOR');
+  const [selectedCourseId, setSelectedCourseId] = useState<string>(courses[0]?.id ?? '');
+  const [query, setQuery] = useState('');
+
+  const selectedCourse = useMemo(
+    () => courses.find((course) => course.id === selectedCourseId) ?? courses[0] ?? null,
+    [courses, selectedCourseId],
+  );
+
+  const filteredStudents = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      return students;
+    }
+    return students.filter((student) => {
+      return [student.name, student.department, student.email].join(' ').toLowerCase().includes(normalized);
+    });
+  }, [query, students]);
 
   return (
     <div className="space-y-5">
       <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-5 shadow-sm">
         <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
           <i className="ri-links-line" />
-          Assignment Detail
+          배정 운영
         </div>
         <h2 className="mt-3 text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">강사/수강생 배정 상세</h2>
         <p className="mt-1 text-[13px] text-slate-600">강의별 담당 교강사와 수강생 그룹 분포를 한 번에 확인합니다.</p>
@@ -23,9 +41,23 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
       <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
         <h2 className="text-[15px] font-bold text-slate-900">강사 배정</h2>
         <p className="mt-1 text-[12px] text-slate-500">강의별 담당 교강사를 정리한 운영용 매핑 화면입니다.</p>
+        <div className="mt-3 rounded-2xl border border-cyan-100 bg-cyan-50 px-4 py-3">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-cyan-700">현재 선택 강의</div>
+          <div className="mt-1 text-[14px] font-bold text-slate-900">{selectedCourse?.title ?? '강의 없음'}</div>
+          <div className="mt-1 text-[12px] text-slate-600">{selectedCourse?.instructor_name ?? '담당 교강사 없음'}</div>
+        </div>
         <div className="mt-4 space-y-2">
           {courses.map((course) => (
-            <div key={course.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3">
+            <button
+              key={course.id}
+              type="button"
+              onClick={() => setSelectedCourseId(course.id)}
+              className={`flex w-full items-center gap-3 rounded-2xl border px-4 py-3 text-left transition ${
+                selectedCourse?.id === course.id
+                  ? 'border-cyan-300 bg-cyan-50/60'
+                  : 'border-slate-200 hover:border-cyan-200 hover:bg-cyan-50/30'
+              }`}
+            >
               <div className="flex h-[34px] w-[34px] items-center justify-center rounded-xl bg-cyan-50 text-cyan-700">
                 <i className="ri-book-open-line" />
               </div>
@@ -33,7 +65,8 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
                 <div className="text-[13px] font-semibold text-slate-900">{course.title}</div>
                 <div className="mt-0.5 text-[12px] text-slate-500">{course.instructor_name}</div>
               </div>
-            </div>
+              <i className="ri-arrow-right-s-line text-slate-400" />
+            </button>
           ))}
         </div>
       </section>
@@ -41,6 +74,15 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
       <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
         <h2 className="text-[15px] font-bold text-slate-900">수강생 그룹</h2>
         <p className="mt-1 text-[12px] text-slate-500">운영자가 역할별 분포와 수강생 배정 대상을 빠르게 확인할 수 있습니다.</p>
+        <label className="mt-4 block">
+          <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-400">수강생 검색</span>
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="이름, 부서, 이메일"
+            className="h-10 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 text-[12px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-300"
+          />
+        </label>
         <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
             <div className="text-[12px] font-semibold text-slate-500">교강사</div>
@@ -52,7 +94,7 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
           </div>
         </div>
         <div className="mt-4 space-y-2">
-          {students.slice(0, 6).map((student) => (
+          {filteredStudents.slice(0, 8).map((student) => (
             <div key={student.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3">
               <div className="flex h-[34px] w-[34px] items-center justify-center rounded-xl bg-emerald-50 text-emerald-600">
                 <i className="ri-user-line" />
@@ -61,8 +103,27 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
                 <div className="text-[13px] font-semibold text-slate-900">{student.name}</div>
                 <div className="mt-0.5 text-[12px] text-slate-500">{student.department}</div>
               </div>
+              <button
+                type="button"
+                className="rounded-full border border-slate-200 px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700"
+              >
+                배정 후보
+              </button>
             </div>
           ))}
+          {filteredStudents.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-slate-200 px-4 py-4 text-[12px] text-slate-500">
+              검색 조건에 맞는 수강생이 없습니다.
+            </div>
+          ) : null}
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button type="button" className="rounded-xl bg-cyan-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-cyan-500">
+            선택 인원 배정 시뮬레이션
+          </button>
+          <button type="button" className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-700">
+            배정 현황 내보내기
+          </button>
         </div>
       </section>
       </div>

--- a/frontend/src/features/lms/pages/AdminDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/AdminDashboardPage.tsx
@@ -64,6 +64,9 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
       },
     ];
   const activities = resolvedDashboard.recent_activities ?? [];
+  const lowProgressCourses = [...resolvedCourses]
+    .sort((left, right) => left.progress_percent - right.progress_percent)
+    .slice(0, 3);
 
   return (
     <div className="space-y-6">
@@ -171,24 +174,20 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
 
           <section className="rounded-2xl border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
             <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-pie-chart-2-line text-cyan-700" />
-              역할 비율
+              <i className="ri-alert-line text-cyan-700" />
+              집중 관리 코스
             </h3>
             <div className="mt-4 space-y-3">
-              {[
-                { label: '운영자', count: roleCounts.ADMIN, tone: 'bg-amber-500' },
-                { label: '교강사', count: roleCounts.INSTRUCTOR, tone: 'bg-emerald-500' },
-                { label: '수강생', count: roleCounts.STUDENT, tone: 'bg-cyan-500' },
-              ].map((item) => (
-                <div key={item.label}>
+              {lowProgressCourses.map((course) => (
+                <div key={course.id}>
                   <div className="mb-1 flex items-center justify-between text-[12px] text-slate-500">
-                    <span>{item.label}</span>
-                    <span>{item.count}명</span>
+                    <span className="truncate">{course.title}</span>
+                    <span>{course.progress_percent}%</span>
                   </div>
                   <div className="h-2 overflow-hidden rounded-full bg-slate-100">
                     <div
-                      className={`h-full rounded-full ${item.tone}`}
-                      style={{ width: `${Math.max((item.count / Math.max(resolvedUsers.length, 1)) * 100, item.count > 0 ? 12 : 0)}%` }}
+                      className="h-full rounded-full bg-cyan-500"
+                      style={{ width: `${Math.max(course.progress_percent, 6)}%` }}
                     />
                   </div>
                 </div>

--- a/frontend/src/features/lms/pages/AdminInstructorsPage.tsx
+++ b/frontend/src/features/lms/pages/AdminInstructorsPage.tsx
@@ -47,7 +47,7 @@ export function AdminInstructorsPage({ instructors, courses }: AdminInstructorsP
       <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-5 shadow-sm">
         <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
           <i className="ri-user-star-line" />
-          Instructor Detail
+          강사 운영
         </div>
         <h2 className="mt-3 text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">강사 운영 상세</h2>
         <p className="mt-1 text-[13px] text-slate-600">강사별 담당 과목과 소속을 빠르게 비교해 운영 우선순위를 조정합니다.</p>
@@ -77,6 +77,7 @@ export function AdminInstructorsPage({ instructors, courses }: AdminInstructorsP
         {filteredInstructors.length > 0 ? (
           filteredInstructors.map((instructor) => {
             const ownCourses = visibleCourses.filter((course) => course.instructor_name === instructor.name);
+            const averageProgress = ownCourses.length > 0 ? Math.round(ownCourses.reduce((sum, course) => sum + course.progress_percent, 0) / ownCourses.length) : 0;
             return (
               <article key={instructor.id} className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
                 <div className="flex items-start gap-3">
@@ -98,6 +99,16 @@ export function AdminInstructorsPage({ instructors, courses }: AdminInstructorsP
                       ) : (
                         <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-500">배정 과목 없음</span>
                       )}
+                    </div>
+                    <div className="mt-3 grid grid-cols-2 gap-2">
+                      <div className="rounded-xl bg-slate-50 px-3 py-2">
+                        <div className="text-[10px] font-semibold text-slate-400">담당 과목</div>
+                        <div className="mt-1 text-[13px] font-bold text-slate-900">{ownCourses.length}개</div>
+                      </div>
+                      <div className="rounded-xl bg-slate-50 px-3 py-2">
+                        <div className="text-[10px] font-semibold text-slate-400">평균 진도</div>
+                        <div className="mt-1 text-[13px] font-bold text-slate-900">{averageProgress}%</div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/features/lms/pages/AdminStatsPage.tsx
+++ b/frontend/src/features/lms/pages/AdminStatsPage.tsx
@@ -76,7 +76,7 @@ export function AdminStatsPage({ dashboard, courses, users, insights, aiLogs }: 
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
               <i className="ri-bar-chart-box-line" />
-              Admin Stats
+              운영 통계
             </div>
             <h2 className="mt-3 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900">운영 통계 상세</h2>
             <p className="mt-1 text-[13px] text-slate-600">사용자/강의/AI 로그를 비교해 운영 병목과 이상치를 빠르게 확인합니다.</p>

--- a/frontend/src/features/lms/pages/CommunityPage.tsx
+++ b/frontend/src/features/lms/pages/CommunityPage.tsx
@@ -15,41 +15,6 @@ type CommunityPageProps = {
 type FeedFilter = 'all' | 'popular' | 'saved' | 'recent';
 type DetailTab = 'video' | 'clips' | 'info';
 
-function buildFallbackItems(
-  courses: CourseCard[],
-): ShortformCommunityItem[] {
-  return courses.slice(0, 3).map((course) => ({
-      id: course.id,
-      shortform_id: `shortform-${course.id}`,
-      user_id: course.instructor_id,
-      title: course.title,
-      description: course.description,
-      duration_ms: 0,
-      total_segments: 0,
-      course_id: course.id,
-      source_lecture_ids: [],
-      status: 'PUBLIC' as const,
-      video_url: '',
-      export_status: 'COMPLETED' as const,
-      export_job_id: null,
-      export_result_url: null,
-      export_failure_reason: null,
-      export_error_message: null,
-      export_retry_count: 0,
-      updated_at: new Date().toISOString(),
-      share_count: 0,
-      like_count: 12,
-      save_count: 0,
-      view_count: 0,
-      created_at: new Date().toISOString(),
-      clips: [],
-      shared_by_name: course.instructor_name,
-      course_title: course.category,
-      is_saved: false,
-      is_liked: false,
-    }));
-}
-
 function rankItems(items: ShortformCommunityItem[], filter: FeedFilter, query: string): ShortformCommunityItem[] {
   const normalized = query.trim().toLowerCase();
 
@@ -145,9 +110,8 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
   }, [enrolledCourses]);
 
   const items = useMemo(() => {
-    const source = community.length > 0 ? community : buildFallbackItems(enrolledCourses);
-    return rankItems(source, filter, query);
-  }, [community, enrolledCourses, filter, query]);
+    return rankItems(community, filter, query);
+  }, [community, filter, query]);
 
   useEffect(() => {
     if (items.length === 0) {
@@ -169,6 +133,7 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
   const totalLikes = items.reduce((sum, item) => sum + item.like_count, 0);
   const selectedClipCount = selectedItem?.clips.length ?? 0;
   const hasEnrolledCourses = enrolledCourses.length > 0;
+  const hasRealFeed = items.length > 0;
 
   return (
     <div className="space-y-6">
@@ -236,7 +201,7 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
           </div>
 
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            {items.length > 0 ? (
+            {hasRealFeed ? (
               items.map((item) => (
                 <ShortformCommunityCard
                   key={item.id}
@@ -253,10 +218,14 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
               <div className="md:col-span-2">
                 <StatePanel
                   compact
-                  icon="ri-search-line"
+                  icon="ri-rss-line"
                   tone="slate"
-                  title="조건에 맞는 숏폼이 없습니다."
-                  description="검색어와 필터를 바꾸면 다른 숏폼을 다시 찾을 수 있습니다."
+                  title={query.trim() ? '조건에 맞는 숏폼이 없습니다.' : '공개된 숏폼 피드가 아직 없습니다.'}
+                  description={
+                    query.trim()
+                      ? '검색어와 필터를 바꾸면 다른 숏폼을 다시 찾을 수 있습니다.'
+                      : '강의의 숏폼이 공유되면 실데이터 피드가 이 영역에 표시됩니다.'
+                  }
                 />
               </div>
             ) : null}
@@ -396,19 +365,8 @@ export function CommunityPage({ courses, recommendations }: CommunityPageProps) 
                 ) : null}
               </div>
 
-              <div className="mt-4 grid grid-cols-3 gap-2 text-center">
-                <div className="rounded-2xl bg-slate-50 px-3 py-3">
-                  <div className="text-[18px] font-extrabold text-slate-900">{selectedItem?.view_count ?? 0}</div>
-                  <div className="text-[11px] text-slate-500">조회</div>
-                </div>
-                <div className="rounded-2xl bg-slate-50 px-3 py-3">
-                  <div className="text-[18px] font-extrabold text-slate-900">{selectedItem?.like_count ?? 0}</div>
-                  <div className="text-[11px] text-slate-500">좋아요</div>
-                </div>
-                <div className="rounded-2xl bg-slate-50 px-3 py-3">
-                  <div className="text-[18px] font-extrabold text-slate-900">{selectedItem?.save_count ?? 0}</div>
-                  <div className="text-[11px] text-slate-500">저장</div>
-                </div>
+              <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-[12px] text-slate-600">
+                <span className="font-semibold text-slate-700">요약:</span> {shortformSummary(selectedItem)}
               </div>
             </section>
 

--- a/frontend/src/features/lms/pages/CoursesPage.tsx
+++ b/frontend/src/features/lms/pages/CoursesPage.tsx
@@ -43,8 +43,8 @@ export function CoursesPage({
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <span className="inline-flex rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">강의 상세</span>
-            <h3 className="mt-3 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900 lg:text-[28px]">강의 정보와 차시를 레퍼런스 톤으로 집중해서 확인합니다.</h3>
-            <p className="mt-2 text-[13px] leading-6 text-slate-600">차시, 공지, 자료, 시청으로 이어지는 흐름은 유지하고 시각 밀도만 정리했습니다.</p>
+            <h3 className="mt-3 text-[24px] font-extrabold tracking-[-0.03em] text-slate-900 lg:text-[28px]">강의 핵심 정보와 차시를 빠르게 확인하세요.</h3>
+            <p className="mt-2 text-[13px] leading-6 text-slate-600">차시, 공지, 자료, 시청 흐름을 한 화면에서 이어봅니다.</p>
           </div>
           {selectedCourse ? (
             <div className="rounded-full border border-cyan-100 bg-white px-3 py-1 text-[11px] font-semibold text-cyan-700">

--- a/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
@@ -95,7 +95,7 @@ export function InstructorDashboardPage({ dashboard, courses, insights }: Instru
           <div>
             <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
               <i className="ri-presentation-line" />
-              Instructor Dashboard
+              강사 대시보드
             </div>
             <h2 className="mt-4 text-[24px] font-bold text-slate-900 lg:text-[28px]">강의 운영 대시보드</h2>
             <p className="mt-2 max-w-2xl text-[14px] leading-6 text-slate-500">{nextAction}</p>

--- a/frontend/src/features/lms/pages/StudentDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/StudentDashboardPage.tsx
@@ -83,6 +83,8 @@ export function StudentDashboardPage({
     ? courses.find((course) => course.id === highlightedLecture.course_id) ?? courses[0] ?? null
     : courses[0] ?? null;
   const progress = circularProgress(averageProgress);
+  const primaryQuickActions = quickActions.slice(0, 2);
+  const secondaryQuickActions = quickActions.slice(2);
 
   return (
     <div className="space-y-6">
@@ -148,8 +150,9 @@ export function StudentDashboardPage({
 
       <DashboardStatsGrid stats={stats} />
 
-      <section className="grid gap-4 lg:grid-cols-4">
-        {quickActions.map((action) => (
+      <section className="space-y-3">
+        <div className="grid gap-4 md:grid-cols-2">
+        {primaryQuickActions.map((action) => (
           <button
             key={action.page}
             type="button"
@@ -163,6 +166,19 @@ export function StudentDashboardPage({
             <div className="mt-1 text-[12px] leading-6 text-slate-500">{action.hint}</div>
           </button>
         ))}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {secondaryQuickActions.map((action) => (
+            <button
+              key={action.page}
+              type="button"
+              onClick={() => onNavigate(action.page)}
+              className="rounded-full border border-[#d6e6f5] bg-white px-4 py-2 text-[12px] font-semibold text-slate-600 transition hover:border-cyan-300 hover:text-cyan-700"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
       </section>
 
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">


### PR DESCRIPTION
﻿# 변경 요약
- 관리자 오케스트레이션 보드 기준으로 백엔드 RAG/STT P1과 프론트 LMS 상세 UX P1~P3를 반영했습니다.
- STT callback-전사 연계, 커뮤니티 실데이터 피드 UX, 관리자/강사/수강생 상세 페이지 밀도 개선을 완료했습니다.

## 배경
- 레퍼런스 대비 상세 페이지 완성도와 운영자 관점 가시성이 부족했습니다.
- Spring 마이그레이션 경로에서 media callback 이후 STT 연동 정합성이 필요했습니다.

## 변경 내용
- Backend
  - `backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java`
    - `audio_url` 입력/콜백 수신
    - extract callback 성공 시 STT 자동 연계
  - `backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java`
    - extraction/transcribe 오버로드 추가(`audio_url` 지원)
    - STT provider 기본값을 provider catalog와 정합화 (`demo`)
- Frontend
  - `frontend/src/features/lms/pages/CommunityPage.tsx`
    - 가짜 fallback 피드 제거, 실데이터 없는 경우 빈 상태 UX
    - 우측 상세 중복 통계 제거
  - `frontend/src/features/lms/components/ShortformCommunityCard.tsx`
    - 대표 클립 요약/타임라인 정보 강화
  - `frontend/src/features/lms/components/CourseExploreDetailPanel.tsx`
    - 자료 탭 액션 실동작(파일명 복사/강의 스튜디오 이동)
  - `frontend/src/features/lms/pages/AdminAssignPage.tsx`
    - 강의 선택/수강생 검색/배정 시뮬레이션 액션
  - `frontend/src/features/lms/pages/StudentDashboardPage.tsx`
    - 핵심 CTA 2개 중심으로 정보 밀도 축약
  - `frontend/src/features/lms/pages/AdminDashboardPage.tsx`
    - 중복 역할비율 영역을 집중관리 코스 인사이트로 전환
  - `frontend/src/features/lms/pages/AdminInstructorsPage.tsx`
    - 강사별 담당 과목 수/평균 진도 지표 추가
  - `frontend/src/features/lms/pages/AdminStatsPage.tsx`
  - `frontend/src/features/lms/pages/InstructorDashboardPage.tsx`
  - `frontend/src/features/lms/pages/CoursesPage.tsx`
    - 라벨/카피 톤 정리
  - `frontend/src/features/lms/components/ShortformPreviewModal.tsx`
    - 모바일 밀도 최적화(상위 4개 클립, 설명 축약)

## 연결 이슈
- Closes #224

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [x] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] 기능 PR이면 ADR 링크를 본문에 포함했다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- `docs/decisions/ADR-0001-rag-retrieval-architecture.md`
- `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
- `docs/decisions/ADR-0003-embedding-provider-index.md`
