### PR TITLE
feat: 관리자 배정 기능 API 연동 및 저장/조회 실동작 구현

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AdminAssignmentsController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AdminAssignmentsController.java
@@ -1,0 +1,76 @@
+package com.myway.backendspring.api;
+
+import com.myway.backendspring.auth.SessionService;
+import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.feature.FeatureStoreService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/admin/assignments")
+public class AdminAssignmentsController {
+    private final SessionService sessionService;
+    private final FeatureStoreService featureStore;
+
+    public AdminAssignmentsController(SessionService sessionService, FeatureStoreService featureStore) {
+        this.sessionService = sessionService;
+        this.featureStore = featureStore;
+    }
+
+    private SessionView require(String auth) {
+        return sessionService.me(auth);
+    }
+
+    private boolean isAdmin(SessionView session) {
+        return session != null && "admin".equals(session.user().role());
+    }
+
+    @GetMapping("/{courseId}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getAssignment(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String courseId
+    ) {
+        SessionView session = require(auth);
+        if (session == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
+        if (!isAdmin(session)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "관리자 권한이 필요합니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.success(featureStore.getAdminAssignment(courseId)));
+    }
+
+    @PutMapping("/{courseId}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> saveAssignment(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String courseId,
+            @RequestBody Map<String, Object> body
+    ) {
+        SessionView session = require(auth);
+        if (session == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
+        if (!isAdmin(session)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "관리자 권한이 필요합니다."));
+        }
+
+        List<String> studentIds = new ArrayList<>();
+        Object rawStudentIds = body == null ? null : body.get("student_ids");
+        if (rawStudentIds instanceof List<?> list) {
+            for (Object item : list) {
+                if (item != null) {
+                    studentIds.add(String.valueOf(item));
+                }
+            }
+        }
+
+        Map<String, Object> saved = featureStore.saveAdminAssignment(session.user().id(), courseId, studentIds);
+        return ResponseEntity.ok(ApiResponse.success(saved, "배정이 저장되었습니다."));
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -33,6 +33,7 @@ public class FeatureStoreService {
     private static final String SHORTFORM_SHARE_SCOPE = "shortform_share";
     private static final String SHORTFORM_LIKE_SCOPE = "shortform_like";
     private static final String CUSTOM_COURSE_SCOPE = "custom_course";
+    private static final String ADMIN_ASSIGNMENT_SCOPE = "admin_assignment";
     private static final String AI_USAGE_SCOPE = "ai_usage_daily";
     private static final String AI_LOG_SCOPE = "ai_log";
     private static final int PUBLIC_STT_MAX_DURATION_MS = 180_000;
@@ -795,6 +796,39 @@ public class FeatureStoreService {
 
     public List<Map<String, Object>> communityCustomCourses(String courseId) {
         return store.listEventsByScope(CUSTOM_COURSE_SCOPE + "_community");
+    }
+
+    public Map<String, Object> getAdminAssignment(String courseId) {
+        Map<String, Object> current = store.getKv(ADMIN_ASSIGNMENT_SCOPE, courseId);
+        if (current != null) {
+            return current;
+        }
+        Map<String, Object> empty = new HashMap<>();
+        empty.put("course_id", courseId);
+        empty.put("student_ids", List.of());
+        empty.put("updated_at", Instant.now().toString());
+        return empty;
+    }
+
+    public Map<String, Object> saveAdminAssignment(String actorUserId, String courseId, List<String> studentIds) {
+        LinkedHashSet<String> deduped = new LinkedHashSet<>();
+        if (studentIds != null) {
+            for (String studentId : studentIds) {
+                if (studentId != null) {
+                    String normalized = studentId.trim();
+                    if (!normalized.isBlank()) {
+                        deduped.add(normalized);
+                    }
+                }
+            }
+        }
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("course_id", courseId);
+        payload.put("student_ids", List.copyOf(deduped));
+        payload.put("updated_by", actorUserId);
+        payload.put("updated_at", Instant.now().toString());
+        store.upsertKv(ADMIN_ASSIGNMENT_SCOPE, courseId, payload);
+        return payload;
     }
 
     private int asInt(Object value) {

--- a/frontend/src/features/lms/pages/AdminAssignPage.tsx
+++ b/frontend/src/features/lms/pages/AdminAssignPage.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { AuthUser, CourseCard } from '@myway/shared';
+import { loadAdminAssignment, saveAdminAssignment } from '../../../lib/api';
 
 type AdminAssignPageProps = {
   users: AuthUser[];
@@ -11,6 +12,8 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
   const instructors = users.filter((user) => user.role === 'INSTRUCTOR');
   const [selectedCourseId, setSelectedCourseId] = useState<string>(courses[0]?.id ?? '');
   const [query, setQuery] = useState('');
+  const [assignedStudentIds, setAssignedStudentIds] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
 
   const selectedCourse = useMemo(
     () => courses.find((course) => course.id === selectedCourseId) ?? courses[0] ?? null,
@@ -26,6 +29,51 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
       return [student.name, student.department, student.email].join(' ').toLowerCase().includes(normalized);
     });
   }, [query, students]);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!selectedCourse?.id) {
+      setAssignedStudentIds([]);
+      return () => {
+        mounted = false;
+      };
+    }
+
+    void loadAdminAssignment(selectedCourse.id).then((record) => {
+      if (!mounted) {
+        return;
+      }
+      setAssignedStudentIds(Array.isArray(record.student_ids) ? record.student_ids : []);
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, [selectedCourse?.id]);
+
+  const assignedSet = useMemo(() => new Set(assignedStudentIds), [assignedStudentIds]);
+
+  const toggleStudent = (studentId: string) => {
+    setAssignedStudentIds((current) => {
+      if (current.includes(studentId)) {
+        return current.filter((id) => id !== studentId);
+      }
+      return [...current, studentId];
+    });
+  };
+
+  const persistAssignment = async () => {
+    if (!selectedCourse?.id || saving) {
+      return;
+    }
+    setSaving(true);
+    try {
+      const saved = await saveAdminAssignment(selectedCourse.id, assignedStudentIds);
+      setAssignedStudentIds(saved.student_ids ?? []);
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <div className="space-y-5">
@@ -105,9 +153,10 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
               </div>
               <button
                 type="button"
+                onClick={() => toggleStudent(student.id)}
                 className="rounded-full border border-slate-200 px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700"
               >
-                배정 후보
+                {assignedSet.has(student.id) ? '배정됨' : '배정 후보'}
               </button>
             </div>
           ))}
@@ -118,11 +167,20 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
           ) : null}
         </div>
         <div className="mt-4 flex flex-wrap gap-2">
-          <button type="button" className="rounded-xl bg-cyan-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-cyan-500">
-            선택 인원 배정 시뮬레이션
+          <button
+            type="button"
+            onClick={persistAssignment}
+            disabled={!selectedCourse?.id || saving}
+            className="rounded-xl bg-cyan-600 px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-cyan-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {saving ? '배정 저장 중...' : `선택 인원 배정 저장 (${assignedStudentIds.length})`}
           </button>
-          <button type="button" className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-700">
-            배정 현황 내보내기
+          <button
+            type="button"
+            onClick={() => setAssignedStudentIds([])}
+            className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-700"
+          >
+            선택 초기화
           </button>
         </div>
       </section>

--- a/frontend/src/lib/api-admin-assignments.ts
+++ b/frontend/src/lib/api-admin-assignments.ts
@@ -1,0 +1,32 @@
+import { request, unwrap } from './api-core';
+
+export type AdminAssignmentRecord = {
+  course_id: string;
+  student_ids: string[];
+  updated_by?: string;
+  updated_at?: string;
+};
+
+function fallbackRecord(courseId: string): AdminAssignmentRecord {
+  return {
+    course_id: courseId,
+    student_ids: [],
+  };
+}
+
+export async function loadAdminAssignment(courseId: string): Promise<AdminAssignmentRecord> {
+  const response = await request<AdminAssignmentRecord>(`/api/v1/admin/assignments/${courseId}`, {
+    method: 'GET',
+  });
+  return unwrap(response, () => fallbackRecord(courseId));
+}
+
+export async function saveAdminAssignment(courseId: string, studentIds: string[]): Promise<AdminAssignmentRecord> {
+  const response = await request<AdminAssignmentRecord>(`/api/v1/admin/assignments/${courseId}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      student_ids: studentIds,
+    }),
+  });
+  return unwrap(response, () => fallbackRecord(courseId));
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -50,6 +50,7 @@ export {
   canCurrentUserEnroll,
   getCurrentRoleLabel,
 } from './api-courses';
+export { loadAdminAssignment, saveAdminAssignment } from './api-admin-assignments';
 export {
   uploadLectureVideo,
   uploadLectureVideoDetailed,


### PR DESCRIPTION
﻿# 변경 요약
- 관리자 배정 화면을 실제 저장/조회 동작으로 전환했습니다.
- Spring 백엔드에 관리자 배정 API를 추가했습니다.

## 변경 내용
- Backend
  - `backend-spring/src/main/java/com/myway/backendspring/api/AdminAssignmentsController.java`
    - `GET /api/v1/admin/assignments/{courseId}`
    - `PUT /api/v1/admin/assignments/{courseId}`
    - 관리자 권한 검사 포함
  - `backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java`
    - `getAdminAssignment`, `saveAdminAssignment` 추가
- Frontend
  - `frontend/src/lib/api-admin-assignments.ts` 추가
  - `frontend/src/lib/api.ts` export 추가
  - `frontend/src/features/lms/pages/AdminAssignPage.tsx`
    - 코스 선택 시 배정 데이터 로드
    - 학생 토글 선택
    - 배정 저장 API 연동

## 검증
- [x] `backend-spring`: `.\\mvnw.cmd test` 통과 (23/23)
- [x] `frontend`: `npm run build:frontend` 통과

## 연결 이슈
- Closes #224
