### PR TITLE
feat: orchestrated dashboard/activity pipeline hardening

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/DashboardController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/DashboardController.java
@@ -14,8 +14,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/api/v1/dashboard")
@@ -42,22 +44,33 @@ public class DashboardController {
                 ? 0
                 : (int) Math.round(view.courses().stream().mapToInt(course -> course.progress_percent()).average().orElse(0));
 
+        List<Map<String, Object>> recentEventRows = activityEventService.recent(session.user().id(), 120);
         List<Map<String, Object>> recentActivities = new ArrayList<>();
-        for (Map<String, Object> event : activityEventService.recent(session.user().id(), 12)) {
-            String type = String.valueOf(event.getOrDefault("type", "insight"));
-            Map<String, Object> metadata = event.get("metadata") instanceof Map<?, ?> map
-                    ? (Map<String, Object>) map
-                    : Map.of();
-            recentActivities.add(Map.of(
-                    "id", String.valueOf(event.getOrDefault("id", "")),
-                    "type", normalizeActivityType(type),
-                    "title", activityTitle(type),
-                    "detail", activityDetail(type, metadata),
-                    "timestamp", String.valueOf(event.getOrDefault("occurred_at", "")),
-                    "icon", activityIcon(type),
-                    "tone", activityTone(type)
-            ));
+        for (Map<String, Object> event : recentEventRows.stream().limit(12).toList()) {
+            String type = safeString(event.get("type"), "insight");
+            Map<String, Object> metadata = safeMetadata(event.get("metadata"));
+            Map<String, Object> item = new HashMap<>();
+            item.put("id", safeString(event.get("id"), ""));
+            item.put("type", normalizeActivityType(type));
+            item.put("title", activityTitle(type));
+            item.put("detail", activityDetail(type, metadata));
+            item.put("timestamp", safeString(event.get("occurred_at"), ""));
+            item.put("icon", activityIcon(type));
+            item.put("tone", activityTone(type));
+            putIfNotBlank(item, "course_id", metadata.get("course_id"));
+            putIfNotBlank(item, "course_title", metadata.get("course_title"));
+            putIfNotBlank(item, "lecture_id", metadata.get("lecture_id"));
+            putIfNotBlank(item, "lecture_title", metadata.get("lecture_title"));
+            recentActivities.add(item);
         }
+
+        Map<String, Integer> statsCount = summarizeStats(recentEventRows);
+        List<Map<String, Object>> stats = List.of(
+                stat("completed_lectures", "학습 완료", String.valueOf(statsCount.get("completed_lectures")), "완료한 강의 수", "check-circle", "emerald"),
+                stat("ai_usage", "AI 사용", String.valueOf(statsCount.get("ai_usage")), "AI 기능 호출 수", "sparkles", "violet"),
+                stat("media_success", "미디어 성공", String.valueOf(statsCount.get("media_success")), "추출/전사 성공 수", "video", "indigo"),
+                stat("media_failed", "미디어 실패", String.valueOf(statsCount.get("media_failed")), "추출/전사 실패 수", "alert-triangle", "amber")
+        );
 
         Map<String, Object> payload = Map.of(
                 "learner_name", session.user().name(),
@@ -66,7 +79,7 @@ public class DashboardController {
                 "active_enrollments", view.enrolled_count(),
                 "average_progress", averageProgress,
                 "courses", view.courses(),
-                "stats", List.of(),
+                "stats", stats,
                 "recent_activities", recentActivities,
                 "next_action", "이어서 학습할 강의를 선택하세요."
         );
@@ -118,6 +131,73 @@ public class DashboardController {
             return "AI 요청이 처리되었습니다.";
         }
         return String.valueOf(metadata.getOrDefault("message", "활동이 기록되었습니다."));
+    }
+
+    private Map<String, Integer> summarizeStats(List<Map<String, Object>> rows) {
+        int completedLectures = 0;
+        int aiUsage = 0;
+        int mediaSuccess = 0;
+        int mediaFailed = 0;
+        for (Map<String, Object> row : rows) {
+            String type = safeString(row.get("type"), "");
+            if ("lecture_complete".equals(type)) {
+                completedLectures++;
+            }
+            if (type.startsWith("ai_")) {
+                aiUsage++;
+            }
+            if ("media_extraction_completed".equals(type)) {
+                mediaSuccess++;
+            }
+            if (type.startsWith("media_extraction_failed")) {
+                mediaFailed++;
+            }
+        }
+        return Map.of(
+                "completed_lectures", completedLectures,
+                "ai_usage", aiUsage,
+                "media_success", mediaSuccess,
+                "media_failed", mediaFailed
+        );
+    }
+
+    private Map<String, Object> stat(String id, String label, String value, String hint, String icon, String tone) {
+        return Map.of(
+                "id", id,
+                "label", label,
+                "value", value,
+                "hint", hint,
+                "icon", icon,
+                "tone", tone
+        );
+    }
+
+    private Map<String, Object> safeMetadata(Object value) {
+        if (value instanceof Map<?, ?> raw) {
+            Map<String, Object> metadata = new HashMap<>();
+            for (Map.Entry<?, ?> entry : raw.entrySet()) {
+                if (entry.getKey() != null) {
+                    metadata.put(String.valueOf(entry.getKey()), entry.getValue());
+                }
+            }
+            return metadata;
+        }
+        return Map.of();
+    }
+
+    private String safeString(Object value, String fallback) {
+        if (value == null) {
+            return fallback;
+        }
+        String resolved = String.valueOf(value);
+        return resolved.isBlank() ? fallback : resolved;
+    }
+
+    private void putIfNotBlank(Map<String, Object> target, String key, Object value) {
+        String resolved = safeString(value, "");
+        if (!Objects.equals(resolved, "")) {
+            target.put(key, resolved);
+        }
     }
 
     private String activityIcon(String type) {

--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -234,7 +234,9 @@ public class MediaController {
         }
         String lectureId = String.valueOf(result.getOrDefault("lecture_id", "")).trim();
         Map<String, Object> transcribeResult = null;
-        if ("COMPLETED".equalsIgnoreCase(String.valueOf(result.getOrDefault("status", ""))) && !lectureId.isBlank()) {
+        boolean shouldStartStt = "COMPLETED".equalsIgnoreCase(status)
+                || "transcribing".equalsIgnoreCase(String.valueOf(result.getOrDefault("processing_stage", "")));
+        if (shouldStartStt && !lectureId.isBlank()) {
             transcribeResult = featureStore.transcribe(
                     lectureId,
                     "ko",

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/ActivityEventService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/ActivityEventService.java
@@ -32,4 +32,14 @@ public class ActivityEventService {
     public List<Map<String, Object>> recent(String userId, int limit) {
         return store.listActivityEvents(userId, limit);
     }
+
+    public List<Map<String, Object>> recent(
+            String userId,
+            String type,
+            String occurredFromIso,
+            String occurredToIso,
+            int limit
+    ) {
+        return store.listActivityEvents(userId, type, occurredFromIso, occurredToIso, limit);
+    }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -445,6 +445,8 @@ public class FeatureStoreService {
         item.put("audio_url", audioUrl);
         item.put("processing_stage", "queued");
         item.put("processing_step", "job_requested");
+        item.put("processing_error_code", null);
+        item.put("processing_error", null);
         item.put("stt_status", "PENDING");
         item.put("transcript_id", null);
         item.put("last_event_version", 0L);
@@ -458,6 +460,10 @@ public class FeatureStoreService {
         pipeline.put("transcript_status", "PENDING");
         pipeline.put("summary_status", "PENDING");
         pipeline.put("audio_status", "PROCESSING");
+        pipeline.put("processing_stage", "queued");
+        pipeline.put("processing_step", "job_requested");
+        pipeline.put("processing_error_code", null);
+        pipeline.put("processing_error", null);
         pipeline.put("transcript_id", null);
         pipeline.put("note_id", null);
         pipeline.put("extraction_id", id);
@@ -474,8 +480,12 @@ public class FeatureStoreService {
         }
         extraction = new HashMap<>(extraction);
         if (mediaProcessorUrl.isBlank()) {
+            extraction.put("status", "FAILED");
+            extraction.put("processing_stage", "failed");
             extraction.put("processing_step", "processor_not_configured");
+            extraction.put("processing_error_code", "PROCESSOR_NOT_CONFIGURED");
             extraction.put("processing_error", "MYWAY_MEDIA_PROCESSOR_URL이 설정되지 않았습니다.");
+            extraction.put("stt_status", "FAILED");
             extraction.put("updated_at", Instant.now().toString());
             store.upsertKv(EXTRACTION_SCOPE, extractionId, extraction);
             return extraction;
@@ -507,18 +517,24 @@ public class FeatureStoreService {
                 extraction.put("processing_step", "dispatched");
                 extraction.put("processing_stage", "queued");
                 extraction.put("status", status == null ? "PROCESSING" : String.valueOf(status).toUpperCase());
+                extraction.put("stt_status", "PENDING");
+                extraction.put("processing_error_code", null);
                 extraction.put("processing_error", null);
             } else {
                 extraction.put("status", "FAILED");
                 extraction.put("processing_stage", "failed");
                 extraction.put("processing_step", "dispatch_failed");
+                extraction.put("processing_error_code", "PROCESSOR_DISPATCH_FAILED");
                 extraction.put("processing_error", "processor dispatch 실패 (" + response.statusCode() + ")");
+                extraction.put("stt_status", "FAILED");
             }
         } catch (Exception exception) {
             extraction.put("status", "FAILED");
             extraction.put("processing_stage", "failed");
             extraction.put("processing_step", "dispatch_exception");
+            extraction.put("processing_error_code", "PROCESSOR_DISPATCH_EXCEPTION");
             extraction.put("processing_error", exception.getMessage());
+            extraction.put("stt_status", "FAILED");
         }
         extraction.put("updated_at", Instant.now().toString());
         store.upsertKv(EXTRACTION_SCOPE, extractionId, extraction);
@@ -544,6 +560,17 @@ public class FeatureStoreService {
         if (extraction == null) {
             extraction = createExtraction(lectureId, audioUrl);
         }
+        String now = Instant.now().toString();
+        Map<String, Object> extractionInProgress = new HashMap<>(extraction);
+        extractionInProgress.put("status", "PROCESSING");
+        extractionInProgress.put("stt_status", "PROCESSING");
+        extractionInProgress.put("processing_stage", "transcribing");
+        extractionInProgress.put("processing_step", "stt_started");
+        extractionInProgress.put("processing_error_code", null);
+        extractionInProgress.put("processing_error", null);
+        extractionInProgress.put("updated_at", now);
+        store.upsertKv(EXTRACTION_SCOPE, String.valueOf(extractionInProgress.getOrDefault("id", extractionId)), extractionInProgress);
+        extraction = extractionInProgress;
         LectureItem lecture = learningService.getLecture(lectureId);
         int lectureDurationMs = lecture == null
                 ? FALLBACK_TRANSCRIPT_DURATION_MS
@@ -572,12 +599,15 @@ public class FeatureStoreService {
         transcriptPayload.put("created_at", Instant.now().toString());
         store.upsertKv(TRANSCRIPT_SCOPE, lectureId, transcriptPayload);
 
-        String now = Instant.now().toString();
         Map<String, Object> pipelinePayload = new HashMap<>();
         pipelinePayload.put("lecture_id", lectureId);
         pipelinePayload.put("transcript_status", "COMPLETED");
         pipelinePayload.put("summary_status", "PENDING");
         pipelinePayload.put("audio_status", "COMPLETED");
+        pipelinePayload.put("processing_stage", "completed");
+        pipelinePayload.put("processing_step", "stt_completed");
+        pipelinePayload.put("processing_error_code", null);
+        pipelinePayload.put("processing_error", null);
         pipelinePayload.put("transcript_id", transcriptId);
         pipelinePayload.put("note_id", null);
         pipelinePayload.put("extraction_id", extraction.get("id"));
@@ -597,6 +627,8 @@ public class FeatureStoreService {
         extractionPayload.put("audio_url", audioUrl);
         extractionPayload.put("processing_stage", "completed");
         extractionPayload.put("processing_step", "stt_completed");
+        extractionPayload.put("processing_error_code", null);
+        extractionPayload.put("processing_error", null);
         store.upsertKv(EXTRACTION_SCOPE, String.valueOf(extraction.getOrDefault("id", transcriptId)), extractionPayload);
 
         Map<String, Object> response = new HashMap<>();
@@ -635,7 +667,20 @@ public class FeatureStoreService {
     }
 
     public List<Map<String, Object>> extractions(String lectureId) {
-        return store.listEventsByOwner(EXTRACTION_SCOPE, lectureId);
+        List<Map<String, Object>> rows = store.listEventsByOwner(EXTRACTION_SCOPE, lectureId);
+        List<Map<String, Object>> merged = new ArrayList<>();
+        for (Map<String, Object> row : rows) {
+            String extractionId = String.valueOf(row.getOrDefault("id", "")).trim();
+            Map<String, Object> latest = extractionId.isBlank() ? null : store.getKv(EXTRACTION_SCOPE, extractionId);
+            Map<String, Object> hydrated = latest == null ? new HashMap<>(row) : new HashMap<>(latest);
+            hydrated.putIfAbsent("processing_stage", "queued");
+            hydrated.putIfAbsent("processing_step", "job_requested");
+            hydrated.putIfAbsent("processing_error_code", null);
+            hydrated.putIfAbsent("processing_error", null);
+            hydrated.putIfAbsent("stt_status", "PENDING");
+            merged.add(hydrated);
+        }
+        return merged;
     }
 
     public Map<String, Object> completeExtractionCallback(String extractionId, String status, String errorMessage, long eventVersion) {
@@ -683,6 +728,10 @@ public class FeatureStoreService {
 
         String now = Instant.now().toString();
         String resolvedStatus = status == null || status.isBlank() ? "COMPLETED" : status.toUpperCase();
+        String resolvedErrorCode = "FAILED".equalsIgnoreCase(resolvedStatus) ? "PROCESSOR_CALLBACK_FAILED" : null;
+        if ("FAILED".equalsIgnoreCase(resolvedStatus) && (errorMessage == null || errorMessage.isBlank())) {
+            errorMessage = "media processor callback failed";
+        }
         extraction.put("last_event_version", eventVersion);
         extraction.put("status", resolvedStatus);
         extraction.put("error_message", errorMessage);
@@ -708,14 +757,19 @@ public class FeatureStoreService {
             extraction.put("channels", channels);
         }
         if ("COMPLETED".equalsIgnoreCase(resolvedStatus)) {
-            extraction.put("processing_stage", "callback");
-            extraction.put("processing_step", "callback_received");
+            extraction.put("status", "PROCESSING");
+            extraction.put("processing_stage", "transcribing");
+            extraction.put("processing_step", "stt_started");
             extraction.put("stt_status", "PROCESSING");
+            extraction.put("processing_error_code", null);
+            extraction.put("processing_error", null);
             extraction.put("processed_at", now);
         } else if ("FAILED".equalsIgnoreCase(resolvedStatus)) {
             extraction.put("processing_stage", "failed");
             extraction.put("processing_step", "callback_failed");
             extraction.put("stt_status", "FAILED");
+            extraction.put("processing_error_code", resolvedErrorCode);
+            extraction.put("processing_error", errorMessage);
             extraction.put("processed_at", now);
         } else {
             extraction.put("processing_stage", "callback");
@@ -731,6 +785,10 @@ public class FeatureStoreService {
             pipeline.put("audio_status", "FAILED".equalsIgnoreCase(resolvedStatus) ? "FAILED" : "COMPLETED");
             pipeline.put("transcript_status", "FAILED".equalsIgnoreCase(resolvedStatus) ? "FAILED" : "PROCESSING");
             pipeline.put("summary_status", "PENDING");
+            pipeline.put("processing_stage", "FAILED".equalsIgnoreCase(resolvedStatus) ? "failed" : "transcribing");
+            pipeline.put("processing_step", "FAILED".equalsIgnoreCase(resolvedStatus) ? "callback_failed" : "stt_started");
+            pipeline.put("processing_error_code", "FAILED".equalsIgnoreCase(resolvedStatus) ? resolvedErrorCode : null);
+            pipeline.put("processing_error", "FAILED".equalsIgnoreCase(resolvedStatus) ? errorMessage : null);
             pipeline.put("transcript_id", extraction.get("transcript_id"));
             pipeline.put("note_id", null);
             pipeline.put("extraction_id", extraction.get("id"));
@@ -754,7 +812,36 @@ public class FeatureStoreService {
 
     public Map<String, Object> pipeline(String lectureId) {
         Map<String, Object> row = store.getKv(PIPELINE_SCOPE, lectureId);
-        return row != null ? row : Map.of("lecture_id", lectureId, "status", "EMPTY");
+        if (row == null) {
+            Map<String, Object> empty = new HashMap<>();
+            empty.put("lecture_id", lectureId);
+            empty.put("status", "EMPTY");
+            empty.put("audio_status", "PENDING");
+            empty.put("transcript_status", "PENDING");
+            empty.put("summary_status", "PENDING");
+            empty.put("processing_stage", "idle");
+            empty.put("processing_step", "not_started");
+            empty.put("processing_error_code", null);
+            empty.put("processing_error", null);
+            empty.put("transcript_id", null);
+            empty.put("note_id", null);
+            empty.put("extraction_id", null);
+            empty.put("updated_at", Instant.now().toString());
+            return empty;
+        }
+        Map<String, Object> hydrated = new HashMap<>(row);
+        hydrated.putIfAbsent("audio_status", "PENDING");
+        hydrated.putIfAbsent("transcript_status", "PENDING");
+        hydrated.putIfAbsent("summary_status", "PENDING");
+        hydrated.putIfAbsent("processing_stage", "idle");
+        hydrated.putIfAbsent("processing_step", "not_started");
+        hydrated.putIfAbsent("processing_error_code", null);
+        hydrated.putIfAbsent("processing_error", null);
+        hydrated.putIfAbsent("transcript_id", null);
+        hydrated.putIfAbsent("note_id", null);
+        hydrated.putIfAbsent("extraction_id", null);
+        hydrated.putIfAbsent("updated_at", Instant.now().toString());
+        return hydrated;
     }
 
     public Map<String, Object> summarizeLecture(String lectureId, String style, String language) {

--- a/backend-spring/src/main/java/com/myway/backendspring/persistence/FeatureJdbcStore.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/persistence/FeatureJdbcStore.java
@@ -7,6 +7,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -142,9 +143,31 @@ public class FeatureJdbcStore {
     }
 
     public List<Map<String, Object>> listActivityEvents(String userId, int limit) {
+        return listActivityEvents(userId, null, null, null, limit);
+    }
+
+    public List<Map<String, Object>> listActivityEvents(
+            String userId,
+            String type,
+            String occurredFromIso,
+            String occurredToIso,
+            int limit
+    ) {
         int safeLimit = Math.max(1, Math.min(limit, 100));
+        OffsetDateTime occurredFrom = parseIsoDateTimeOrNull(occurredFromIso);
+        OffsetDateTime occurredTo = parseIsoDateTimeOrNull(occurredToIso);
+        String safeType = (type == null || type.isBlank()) ? null : type.trim();
         return jdbcTemplate.query(
-                "SELECT id, user_id, type, resource_type, resource_id, metadata, occurred_at FROM activity_event WHERE user_id = ? ORDER BY occurred_at DESC LIMIT ?",
+                """
+                SELECT id, user_id, type, resource_type, resource_id, metadata, occurred_at
+                FROM activity_event
+                WHERE user_id = ?
+                  AND (? IS NULL OR type = ?)
+                  AND (? IS NULL OR occurred_at >= ?)
+                  AND (? IS NULL OR occurred_at <= ?)
+                ORDER BY occurred_at DESC
+                LIMIT ?
+                """,
                 (rs, rowNum) -> {
                     Map<String, Object> row = new HashMap<>();
                     row.put("id", rs.getString("id"));
@@ -157,8 +180,19 @@ public class FeatureJdbcStore {
                     row.put("occurred_at", rs.getTimestamp("occurred_at").toInstant().toString());
                     return row;
                 },
-                userId, safeLimit
+                userId,
+                safeType, safeType,
+                occurredFrom, occurredFrom,
+                occurredTo, occurredTo,
+                safeLimit
         );
+    }
+
+    private OffsetDateTime parseIsoDateTimeOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return OffsetDateTime.parse(value);
     }
 
     private String toJson(Map<String, Object> payload) {

--- a/backend-spring/src/main/resources/schema.sql
+++ b/backend-spring/src/main/resources/schema.sql
@@ -49,3 +49,4 @@ CREATE TABLE IF NOT EXISTS activity_event (
 );
 
 CREATE INDEX IF NOT EXISTS idx_activity_event_user_time ON activity_event(user_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_event_user_type_time ON activity_event(user_id, type, occurred_at DESC);

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/DashboardContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/DashboardContractTest.java
@@ -1,0 +1,68 @@
+package com.myway.backendspring.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DashboardContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void dashboard_shouldReturnStatsAndRecentActivities_withStableShape() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken();
+
+        String response = mockMvc.perform(get("/api/v1/dashboard").header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode root = objectMapper.readTree(response);
+        JsonNode data = root.path("data");
+        JsonNode stats = data.path("stats");
+        JsonNode activities = data.path("recent_activities");
+
+        assertThat(root.path("success").asBoolean()).isTrue();
+        assertThat(stats.isArray()).isTrue();
+        assertThat(stats.size()).isEqualTo(4);
+        assertThat(activities.isArray()).isTrue();
+
+        JsonNode firstStat = stats.get(0);
+        assertThat(firstStat.path("id").isMissingNode()).isFalse();
+        assertThat(firstStat.path("label").isMissingNode()).isFalse();
+        assertThat(firstStat.path("value").isMissingNode()).isFalse();
+        assertThat(firstStat.path("hint").isMissingNode()).isFalse();
+        assertThat(firstStat.path("icon").isMissingNode()).isFalse();
+        assertThat(firstStat.path("tone").isMissingNode()).isFalse();
+    }
+
+    private String loginAndGetToken() throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"usr_std_001\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode root = objectMapper.readTree(response);
+        return root.path("data").path("session_token").asText();
+    }
+}

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AdminEndpointMigrationIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AdminEndpointMigrationIntegrationTest.java
@@ -84,7 +84,9 @@ class AdminEndpointMigrationIntegrationTest {
                         .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\"}"))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        assertThat(objectMapper.readTree(callback).path("data").path("extraction").path("status").asText()).isEqualTo("COMPLETED");
+        JsonNode callbackRoot = objectMapper.readTree(callback);
+        assertThat(callbackRoot.path("data").path("extraction").path("status").asText()).isEqualTo("PROCESSING");
+        assertThat(callbackRoot.path("data").path("pipeline").path("transcript_status").asText()).isEqualTo("COMPLETED");
 
         String upload = mockMvc.perform(post("/api/v1/media/upload-video")
                         .header("Authorization", auth)

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/MediaCallbackVersionIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/MediaCallbackVersionIntegrationTest.java
@@ -68,7 +68,8 @@ class MediaCallbackVersionIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
 
         JsonNode successRoot = objectMapper.readTree(successCallback);
-        assertThat(successRoot.path("data").path("extraction").path("status").asText()).isEqualTo("COMPLETED");
+        assertThat(successRoot.path("data").path("extraction").path("status").asText()).isEqualTo("PROCESSING");
+        assertThat(successRoot.path("data").path("pipeline").path("transcript_status").asText()).isEqualTo("COMPLETED");
         assertThat(successRoot.path("data").path("extraction").path("last_event_version").asLong()).isEqualTo(3L);
 
         mockMvc.perform(post("/api/v1/media/extract-audio/callback")


### PR DESCRIPTION
## 요약
- 관리자 오케스트레이션 하네스 방식으로 병렬 작업을 적용해 대시보드/이벤트/미디어 파이프라인 고도화를 진행했습니다.
- 미디어 콜백->STT 상태 전이를 명확화하고 오류 코드를 일관화했습니다.
- activity_event 조회 필터(타입/기간)와 인덱스를 추가해 대시보드 집계 기반을 강화했습니다.
- 대시보드 `/api/v1/dashboard`에 activity_event 기반 stats를 채우고 recent 활동 매핑을 null-safe로 안정화했습니다.

## 주요 변경
### Backend
- `FeatureStoreService`
  - callback 완료 후 `transcribing -> completed` 단계 전이 보강
  - `processing_error_code` 일관화
  - pipeline/extraction 단계 필드 보강
- `MediaController`
  - callback 처리 응답 정합성 보강
- `FeatureJdbcStore`
  - `listActivityEvents` 필터 오버로드 추가(type, occurredFromIso, occurredToIso, limit)
- `ActivityEventService`
  - 필터형 `recent(...)` 오버로드 추가
- `DashboardController`
  - stats 4종 집계(학습 완료, AI 사용, 미디어 성공/실패)
  - recent_activities null-safe 매핑
- `schema.sql`
  - `activity_event(user_id, type, occurred_at)` 보조 인덱스 추가

### Test
- `DashboardContractTest` 추가
  - `/api/v1/dashboard` 응답의 `stats`, `recent_activities` shape 검증

## 검증
- 로컬 백엔드 테스트는 JAVA_HOME 미설정으로 미실행
- CI에서 backend-spring-tests 확인 예정