### PR TITLE
feat: automated admin orchestration hardening for dashboard and media callback

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/DashboardController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/DashboardController.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/v1/dashboard")
@@ -43,18 +44,19 @@ public class DashboardController {
         int averageProgress = totalCourses == 0
                 ? 0
                 : (int) Math.round(view.courses().stream().mapToInt(course -> course.progress_percent()).average().orElse(0));
+        String role = normalizeRole(session.user().role());
 
         List<Map<String, Object>> recentEventRows = activityEventService.recent(session.user().id(), 120);
         List<Map<String, Object>> recentActivities = new ArrayList<>();
         for (Map<String, Object> event : recentEventRows.stream().limit(12).toList()) {
-            String type = safeString(event.get("type"), "insight");
             Map<String, Object> metadata = safeMetadata(event.get("metadata"));
+            String type = resolveActivityType(event, metadata);
             Map<String, Object> item = new HashMap<>();
             item.put("id", safeString(event.get("id"), ""));
             item.put("type", normalizeActivityType(type));
             item.put("title", activityTitle(type));
             item.put("detail", activityDetail(type, metadata));
-            item.put("timestamp", safeString(event.get("occurred_at"), ""));
+            item.put("timestamp", resolveActivityTimestamp(event, metadata));
             item.put("icon", activityIcon(type));
             item.put("tone", activityTone(type));
             putIfNotBlank(item, "course_id", metadata.get("course_id"));
@@ -64,9 +66,9 @@ public class DashboardController {
             recentActivities.add(item);
         }
 
-        Map<String, Integer> statsCount = summarizeStats(recentEventRows);
+        Map<String, Integer> statsCount = summarizeStats(recentEventRows, role);
         List<Map<String, Object>> stats = List.of(
-                stat("completed_lectures", "학습 완료", String.valueOf(statsCount.get("completed_lectures")), "완료한 강의 수", "check-circle", "emerald"),
+                stat("completed_lectures", "학습 완료", String.valueOf(statsCount.get("completed_lectures")), roleStatsHint(role), "check-circle", "emerald"),
                 stat("ai_usage", "AI 사용", String.valueOf(statsCount.get("ai_usage")), "AI 기능 호출 수", "sparkles", "violet"),
                 stat("media_success", "미디어 성공", String.valueOf(statsCount.get("media_success")), "추출/전사 성공 수", "video", "indigo"),
                 stat("media_failed", "미디어 실패", String.valueOf(statsCount.get("media_failed")), "추출/전사 실패 수", "alert-triangle", "amber")
@@ -74,7 +76,7 @@ public class DashboardController {
 
         Map<String, Object> payload = Map.of(
                 "learner_name", session.user().name(),
-                "role", normalizeRole(session.user().role()),
+                "role", role,
                 "total_courses", totalCourses,
                 "active_enrollments", view.enrolled_count(),
                 "average_progress", averageProgress,
@@ -133,14 +135,15 @@ public class DashboardController {
         return String.valueOf(metadata.getOrDefault("message", "활동이 기록되었습니다."));
     }
 
-    private Map<String, Integer> summarizeStats(List<Map<String, Object>> rows) {
+    private Map<String, Integer> summarizeStats(List<Map<String, Object>> rows, String role) {
         int completedLectures = 0;
         int aiUsage = 0;
         int mediaSuccess = 0;
         int mediaFailed = 0;
+        Set<String> completionTypes = completionTypesByRole(role);
         for (Map<String, Object> row : rows) {
             String type = safeString(row.get("type"), "");
-            if ("lecture_complete".equals(type)) {
+            if (completionTypes.contains(type)) {
                 completedLectures++;
             }
             if (type.startsWith("ai_")) {
@@ -159,6 +162,22 @@ public class DashboardController {
                 "media_success", mediaSuccess,
                 "media_failed", mediaFailed
         );
+    }
+
+    private Set<String> completionTypesByRole(String role) {
+        return switch (role) {
+            case "admin" -> Set.of("lecture_complete", "enrollment", "media_extraction_completed");
+            case "instructor" -> Set.of("lecture_complete", "custom_course_created", "shortform_created");
+            default -> Set.of("lecture_complete");
+        };
+    }
+
+    private String roleStatsHint(String role) {
+        return switch (role) {
+            case "admin" -> "운영 기준 완료 이벤트 수";
+            case "instructor" -> "강의/콘텐츠 완료 이벤트 수";
+            default -> "완료한 강의 수";
+        };
     }
 
     private Map<String, Object> stat(String id, String label, String value, String hint, String icon, String tone) {
@@ -191,6 +210,38 @@ public class DashboardController {
         }
         String resolved = String.valueOf(value);
         return resolved.isBlank() ? fallback : resolved;
+    }
+
+    private String resolveActivityType(Map<String, Object> event, Map<String, Object> metadata) {
+        String baseType = safeString(event.get("type"), "");
+        if (!baseType.isBlank()) {
+            return baseType;
+        }
+        String metadataType = safeString(metadata.get("type"), "");
+        if (!metadataType.isBlank()) {
+            return metadataType;
+        }
+        String actionType = safeString(metadata.get("action"), "");
+        if (!actionType.isBlank()) {
+            return actionType;
+        }
+        return "insight";
+    }
+
+    private String resolveActivityTimestamp(Map<String, Object> event, Map<String, Object> metadata) {
+        String occurredAt = safeString(event.get("occurred_at"), "");
+        if (!occurredAt.isBlank()) {
+            return occurredAt;
+        }
+        String metadataOccurredAt = safeString(metadata.get("occurred_at"), "");
+        if (!metadataOccurredAt.isBlank()) {
+            return metadataOccurredAt;
+        }
+        String metadataTimestamp = safeString(metadata.get("timestamp"), "");
+        if (!metadataTimestamp.isBlank()) {
+            return metadataTimestamp;
+        }
+        return "1970-01-01T00:00:00Z";
     }
 
     private void putIfNotBlank(Map<String, Object> target, String key, Object value) {

--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -197,14 +197,14 @@ public class MediaController {
     ) {
         String resolvedToken = (token != null && !token.isBlank()) ? token : callbackSecret;
         if (resolvedToken == null || resolvedToken.isBlank() || !resolvedToken.equals(callbackToken)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "유효한 callback token이 필요합니다."));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("CALLBACK_UNAUTHORIZED", "유효한 callback token이 필요합니다."));
         }
         if (body == null) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID", "callback payload가 올바르지 않습니다."));
+            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID_PAYLOAD", "callback payload가 올바르지 않습니다."));
         }
         String extractionId = body.extraction_id() == null ? "" : body.extraction_id().trim();
         if (extractionId.isEmpty()) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID", "callback payload가 올바르지 않습니다."));
+            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID_PAYLOAD", "callback payload가 올바르지 않습니다."));
         }
         long eventVersion = body.event_version() != null ? body.event_version() : 1L;
         String status = body.status() == null ? "COMPLETED" : body.status();
@@ -224,7 +224,7 @@ public class MediaController {
                 body.channels()
         );
         if (result == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("CALLBACK_EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
         }
         if (Boolean.TRUE.equals(result.get("callback_ignored"))) {
             return ResponseEntity.ok(ApiResponse.success(

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -721,7 +721,8 @@ public class FeatureStoreService {
         long currentVersion = asLong(extraction.get("last_event_version"));
         if (eventVersion <= currentVersion) {
             extraction.put("callback_ignored", true);
-            return extraction;
+            extraction.put("callback_status", "IGNORED_STALE");
+            return normalizeExtractionForResponse(extraction);
         }
 
         String now = Instant.now().toString();
@@ -773,6 +774,8 @@ public class FeatureStoreService {
             extraction.put("processing_stage", "callback");
             extraction.put("processing_step", "callback_received");
         }
+        extraction.put("callback_ignored", false);
+        extraction.put("callback_status", "APPLIED");
         extraction.put("updated_at", now);
         store.upsertKv(EXTRACTION_SCOPE, extractionId, extraction);
 
@@ -805,7 +808,21 @@ public class FeatureStoreService {
                 );
             }
         }
-        return extraction;
+        return normalizeExtractionForResponse(extraction);
+    }
+
+    private Map<String, Object> normalizeExtractionForResponse(Map<String, Object> extraction) {
+        Map<String, Object> hydrated = new HashMap<>(extraction);
+        hydrated.putIfAbsent("processing_stage", "queued");
+        hydrated.putIfAbsent("processing_step", "job_requested");
+        hydrated.putIfAbsent("processing_error_code", null);
+        hydrated.putIfAbsent("processing_error", null);
+        hydrated.putIfAbsent("stt_status", "PENDING");
+        hydrated.putIfAbsent("error_message", null);
+        hydrated.putIfAbsent("callback_ignored", false);
+        hydrated.putIfAbsent("callback_status", "APPLIED");
+        hydrated.putIfAbsent("last_event_version", 0L);
+        return hydrated;
     }
 
     public Map<String, Object> pipeline(String lectureId) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -41,7 +41,6 @@ public class FeatureStoreService {
     private static final String CUSTOM_COURSE_SCOPE = "custom_course";
     private static final String ADMIN_ASSIGNMENT_SCOPE = "admin_assignment";
     private static final String AI_USAGE_SCOPE = "ai_usage_daily";
-    private static final String AI_LOG_SCOPE = "ai_log";
     private static final int PUBLIC_STT_MAX_DURATION_MS = 180_000;
     private static final int FALLBACK_TRANSCRIPT_DURATION_MS = 120_000;
     private static final int FALLBACK_SEGMENT_MIN_MS = 1_000;
@@ -124,10 +123,18 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> aiLogs(String userId) {
-        List<Map<String, Object>> rows = store.listAiUsageLogs(userId);
-        if (rows.isEmpty()) {
-            rows = store.listEventsByOwner(AI_LOG_SCOPE, userId);
-        }
+        List<Map<String, Object>> rows = store.listAiUsageLogs(userId).stream()
+                .map(item -> {
+                    Map<String, Object> mapped = new HashMap<>();
+                    mapped.put("id", String.valueOf(item.getOrDefault("id", "")));
+                    mapped.put("user_id", String.valueOf(item.getOrDefault("user_id", userId)));
+                    mapped.put("feature", String.valueOf(item.getOrDefault("feature", "request")));
+                    mapped.put("success", asBoolean(item.get("success"), false));
+                    mapped.put("input_text", String.valueOf(item.getOrDefault("input_text", "")));
+                    mapped.put("created_at", String.valueOf(item.getOrDefault("created_at", Instant.now().toString())));
+                    return mapped;
+                })
+                .toList();
         return Map.of("user_id", userId, "items", rows, "count", rows.size());
     }
 
@@ -295,12 +302,10 @@ public class FeatureStoreService {
                 })
                 .count();
         } else if (usedByLogs == 0) {
-            usedByLogs = (int) store.listEventsByOwner(AI_LOG_SCOPE, userId).stream()
-                .filter(item -> {
-                    Instant createdAt = parseInstantOrNull(item.get("created_at"));
-                    return createdAt != null;
-                })
-                .count();
+            usedByLogs = (int) store.listActivityEvents(userId, 100).stream()
+                    .map(item -> String.valueOf(item.getOrDefault("type", "")))
+                    .filter(type -> type.startsWith("ai_"))
+                    .count();
         }
         int used = Math.max(usedToday, usedByLogs);
         return used < limit;
@@ -321,13 +326,6 @@ public class FeatureStoreService {
 
         String logId = UUID.randomUUID().toString();
         store.insertAiUsageLog(logId, userId, feature, success, inputText);
-        Map<String, Object> log = new HashMap<>();
-        log.put("id", logId);
-        log.put("feature", feature);
-        log.put("success", success);
-        log.put("input_text", inputText);
-        log.put("created_at", Instant.now().toString());
-        store.insertEvent(AI_LOG_SCOPE, userId, String.valueOf(log.get("id")), log);
         if (activityEventService != null) {
             activityEventService.append(
                     userId,

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -1208,6 +1208,26 @@ public class FeatureStoreService {
         }
     }
 
+    private boolean asBoolean(Object value, boolean defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        String normalized = String.valueOf(value).trim().toLowerCase();
+        if (normalized.isEmpty()) {
+            return defaultValue;
+        }
+        if ("true".equals(normalized) || "1".equals(normalized) || "y".equals(normalized) || "yes".equals(normalized)) {
+            return true;
+        }
+        if ("false".equals(normalized) || "0".equals(normalized) || "n".equals(normalized) || "no".equals(normalized)) {
+            return false;
+        }
+        return defaultValue;
+    }
+
     private long asLong(Object value) {
         if (value == null) {
             return 0L;

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/DashboardContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/DashboardContractTest.java
@@ -26,20 +26,25 @@ class DashboardContractTest {
 
     @Test
     void dashboard_shouldReturnStatsAndRecentActivities_withStableShape() throws Exception {
-        String authHeader = "Bearer " + loginAndGetToken();
+        assertDashboardShapeForUser("usr_std_001");
+        assertDashboardShapeForUser("usr_ins_001");
+        assertDashboardShapeForUser("usr_admin_001");
+    }
 
+    private void assertDashboardShapeForUser(String userId) throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken(userId);
         String response = mockMvc.perform(get("/api/v1/dashboard").header("Authorization", authHeader))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
-
         JsonNode root = objectMapper.readTree(response);
         JsonNode data = root.path("data");
         JsonNode stats = data.path("stats");
         JsonNode activities = data.path("recent_activities");
 
         assertThat(root.path("success").asBoolean()).isTrue();
+        assertThat(data.path("role").asText()).isIn("student", "instructor", "admin");
         assertThat(stats.isArray()).isTrue();
         assertThat(stats.size()).isEqualTo(4);
         assertThat(activities.isArray()).isTrue();
@@ -48,15 +53,22 @@ class DashboardContractTest {
         assertThat(firstStat.path("id").isMissingNode()).isFalse();
         assertThat(firstStat.path("label").isMissingNode()).isFalse();
         assertThat(firstStat.path("value").isMissingNode()).isFalse();
+        assertThat(firstStat.path("value").asText()).matches("\\d+");
         assertThat(firstStat.path("hint").isMissingNode()).isFalse();
         assertThat(firstStat.path("icon").isMissingNode()).isFalse();
         assertThat(firstStat.path("tone").isMissingNode()).isFalse();
+
+        if (activities.size() > 0) {
+            JsonNode firstActivity = activities.get(0);
+            assertThat(firstActivity.path("type").asText()).isNotBlank();
+            assertThat(firstActivity.path("timestamp").asText()).isNotBlank();
+        }
     }
 
-    private String loginAndGetToken() throws Exception {
+    private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"userId\":\"usr_std_001\"}"))
+                        .content("{\"userId\":\"" + userId + "\"}"))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -56,7 +56,7 @@ class MediaContractTest {
                         .content("{\"extraction_id\":\"abc\",\"status\":\"COMPLETED\"}"))
                 .andExpect(status().isForbidden())
                 .andReturn(),
-                "FORBIDDEN");
+                "CALLBACK_UNAUTHORIZED");
     }
 
     private String loginAndGetToken(String userId) throws Exception {

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/MediaCallbackVersionIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/MediaCallbackVersionIntegrationTest.java
@@ -46,6 +46,8 @@ class MediaCallbackVersionIntegrationTest {
 
         JsonNode failedRoot = objectMapper.readTree(failedCallback);
         assertThat(failedRoot.path("data").path("extraction").path("status").asText()).isEqualTo("FAILED");
+        assertThat(failedRoot.path("data").path("extraction").path("processing_error_code").asText()).isEqualTo("PROCESSOR_CALLBACK_FAILED");
+        assertThat(failedRoot.path("data").path("extraction").path("callback_status").asText()).isEqualTo("APPLIED");
         assertThat(failedRoot.path("data").path("extraction").path("last_event_version").asLong()).isEqualTo(2L);
 
         String staleCallback = mockMvc.perform(post("/api/v1/media/extract-audio/callback")
@@ -57,8 +59,11 @@ class MediaCallbackVersionIntegrationTest {
 
         JsonNode staleRoot = objectMapper.readTree(staleCallback);
         assertThat(staleRoot.path("data").path("extraction").path("callback_ignored").asBoolean()).isTrue();
+        assertThat(staleRoot.path("data").path("extraction").path("callback_status").asText()).isEqualTo("IGNORED_STALE");
         assertThat(staleRoot.path("data").path("extraction").path("status").asText()).isEqualTo("FAILED");
         assertThat(staleRoot.path("data").path("extraction").path("last_event_version").asLong()).isEqualTo(2L);
+        assertThat(staleRoot.path("data").path("pipeline").path("audio_status").asText()).isEqualTo("FAILED");
+        assertThat(staleRoot.path("data").path("pipeline").path("processing_error_code").asText()).isEqualTo("PROCESSOR_CALLBACK_FAILED");
 
         String successCallback = mockMvc.perform(post("/api/v1/media/extract-audio/callback")
                         .header("X-Callback-Token", "dev-media-callback-token")
@@ -69,8 +74,23 @@ class MediaCallbackVersionIntegrationTest {
 
         JsonNode successRoot = objectMapper.readTree(successCallback);
         assertThat(successRoot.path("data").path("extraction").path("status").asText()).isEqualTo("PROCESSING");
+        assertThat(successRoot.path("data").path("extraction").path("callback_ignored").asBoolean()).isFalse();
+        assertThat(successRoot.path("data").path("extraction").path("callback_status").asText()).isEqualTo("APPLIED");
         assertThat(successRoot.path("data").path("pipeline").path("transcript_status").asText()).isEqualTo("COMPLETED");
         assertThat(successRoot.path("data").path("extraction").path("last_event_version").asLong()).isEqualTo(3L);
+
+        String staleAfterSuccess = mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("X-Callback-Token", "dev-media-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"FAILED\",\"error_message\":\"late-error\",\"event_version\":2}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode staleAfterSuccessRoot = objectMapper.readTree(staleAfterSuccess);
+        assertThat(staleAfterSuccessRoot.path("data").path("extraction").path("callback_ignored").asBoolean()).isTrue();
+        assertThat(staleAfterSuccessRoot.path("data").path("extraction").path("callback_status").asText()).isEqualTo("IGNORED_STALE");
+        assertThat(staleAfterSuccessRoot.path("data").path("extraction").path("last_event_version").asLong()).isEqualTo(3L);
+        assertThat(staleAfterSuccessRoot.path("data").path("pipeline").path("transcript_status").asText()).isEqualTo("COMPLETED");
 
         mockMvc.perform(post("/api/v1/media/extract-audio/callback")
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
﻿## 요약
- 관리자 오케스트레이션 기반으로 백엔드 안정화 항목을 정리/적용했습니다.
- AI 로그 집계 경로를 typed 저장소 중심으로 정리했습니다.
- 미디어 콜백 실패 코드와 stale 이벤트 응답 포맷을 표준화했습니다.
- 대시보드 통계를 role-safe 방식으로 보강했습니다.
- CI 컴파일 실패 원인이었던 `FeatureStoreService`의 `asBoolean(...)` 누락 메서드를 복구했습니다.

## 주요 변경
### 1) AI 로그/집계 정리
- `FeatureStoreService`에서 구 fallback 경로 의존 제거
- `ai_usage_log + activity_event` 중심으로 일관 집계
- 기존 응답 스키마(`user_id/items/count`) 유지

### 2) 미디어 콜백 표준화
- 실패 코드 통일
  - `CALLBACK_UNAUTHORIZED`
  - `CALLBACK_INVALID_PAYLOAD`
  - `CALLBACK_EXTRACTION_NOT_FOUND`
- stale 콜백 무시 시 응답 필드 일관화
  - `callback_status`, `processing_stage`, `processing_step`, `processing_error_code`, `processing_error`, `stt_status`, `last_event_version`

### 3) 대시보드 안정성 강화
- 학생/강사/관리자 role-safe 통계 집계
- `recent_activities`의 type/timestamp fallback 보강
- 관련 계약 테스트 보강

### 4) CI 컴파일 이슈 수정
- `FeatureStoreService`에 `asBoolean(Object, boolean)` 헬퍼 재추가
- 로그 매핑 구문 컴파일 에러 해소

## 검증 상태
- 로컬: `JAVA_HOME` 미설정으로 `./mvnw test` 미실행
- 원격: PR CI(`test-backend-spring`) 결과로 최종 확인 예정
