### PR TITLE
docs: automate ADR governance and PR linkage rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,10 +29,10 @@
 ## 체크 사항
 - [ ] 범위가 MoSCoW 기준에 맞는다
 - [ ] 관련 문서가 함께 갱신됐다
-- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다
+- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
 - [ ] `docs/dev-logs/`에 변경 요약을 남겼다
 - [ ] 불필요한 리팩터링이 없다
 
 ## ADR 링크
-- ADR:
-  - 
+- ADR: `docs/decisions/ADR-xxxx-*.md`
+- 상태 변경: `Proposed -> Accepted` 또는 `Accepted -> Superseded` (해당 시 기입)

--- a/docs/decisions/ADR-0001-rag-retrieval-architecture.md
+++ b/docs/decisions/ADR-0001-rag-retrieval-architecture.md
@@ -3,6 +3,8 @@
 - Status: Accepted
 - Date: 2026-05-07
 - Owners: Backend / AI Layer
+- Supersedes: N/A
+- Superseded by: N/A
 
 ## 배경(Context)
 현재 LMS AI 질의응답은 강의 STT/노트 기반 검색이 필요하며, 응답 groundedness와 운영비를 동시에 맞춰야 한다.

--- a/docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md
+++ b/docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md
@@ -3,6 +3,8 @@
 - Status: Accepted
 - Date: 2026-05-07
 - Owners: Backend / Media Pipeline
+- Supersedes: N/A
+- Superseded by: N/A
 
 ## 배경(Context)
 강의 전사(STT) 결과를 RAG/숏폼/학습 UI에서 공통 재사용하려면, 세그먼트 청킹과 타임스탬프 보존 전략이 필요하다.

--- a/docs/decisions/ADR-0003-embedding-provider-index.md
+++ b/docs/decisions/ADR-0003-embedding-provider-index.md
@@ -3,6 +3,8 @@
 - Status: Proposed
 - Date: 2026-05-07
 - Owners: Backend / Infra
+- Supersedes: N/A
+- Superseded by: N/A
 
 ## 배경(Context)
 RAG 품질 고도화를 위해 임베딩 모델과 벡터 인덱스 저장소 조합을 표준화해야 한다.

--- a/docs/decisions/ADR-TEMPLATE.md
+++ b/docs/decisions/ADR-TEMPLATE.md
@@ -1,0 +1,43 @@
+# ADR-XXXX: <Decision Title>
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Owners: <Team or Owners>
+- Supersedes: <ADR-XXXX or N/A>
+- Superseded by: <ADR-XXXX or N/A>
+
+## 배경(Context)
+이 의사결정이 필요한 배경과 현재 제약을 작성한다.
+
+## 목표(Decision Drivers)
+- 목표 1
+- 목표 2
+- 목표 3
+
+## 고려한 대안(Options)
+1. 대안 A
+2. 대안 B
+3. 대안 C
+
+## 최종 선택(Decision)
+채택한 대안을 한 문단으로 명확히 작성한다.
+
+## 선택 이유(Rationale)
+채택한 대안이 목표를 어떻게 충족하는지 근거를 작성한다.
+
+## 포기한 대안의 이유(Why not)
+채택하지 않은 대안별로 기각 이유를 작성한다.
+
+## 결과/영향(Consequences)
+- 긍정적 영향
+- 부정적 영향
+- 운영/개발 영향
+
+## 검증 계획(How we will verify)
+- 측정 지표
+- 검증 방법
+- 기준선 및 목표치
+
+## 롤백 조건(Rollback Trigger)
+- 어떤 조건에서 롤백할지
+- 롤백 시 대체 경로

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records (ADR)
+
+## 목적
+- 설계 변경 사항의 배경, 선택 근거, 트레이드오프, 검증/롤백 기준을 추적한다.
+- 기능 구현 완료 기준에 문서 업데이트를 포함해 지식 누락을 방지한다.
+
+## 상태 관리
+- `Proposed`: 검토 중인 설계
+- `Accepted`: 채택되어 구현/운영 기준으로 사용하는 설계
+- `Superseded`: 더 최신 ADR로 대체된 설계
+
+각 ADR 헤더에 다음 메타를 반드시 포함한다.
+- `Status`
+- `Date`
+- `Owners`
+- `Supersedes` (선택)
+- `Superseded by` (선택)
+
+## 필수 템플릿
+`docs/decisions/ADR-TEMPLATE.md`를 기본으로 작성한다.
+
+필수 섹션:
+- 배경(Context)
+- 목표(Decision Drivers)
+- 고려한 대안(Options)
+- 최종 선택(Decision)
+- 선택 이유(Rationale)
+- 포기한 대안의 이유(Why not)
+- 결과/영향(Consequences)
+- 검증 계획(How we will verify)
+- 롤백 조건(Rollback Trigger)
+
+## 운영 원칙
+- 기능 PR에는 ADR 링크를 본문에 포함한다.
+- "구현 완료" 조건에 "문서 업데이트 완료"를 포함한다.
+- 설계 변경 시 ADR 상태를 `Proposed/Accepted/Superseded`로 갱신한다.
+- 기존 설계를 대체하는 경우, 이전 ADR에 `Superseded by`를 명시한다.

--- a/docs/dev-logs/2026-05-08-adr-governance-automation.md
+++ b/docs/dev-logs/2026-05-08-adr-governance-automation.md
@@ -1,0 +1,12 @@
+# 2026-05-08 ADR 거버넌스 자동화
+
+## 요약
+- ADR 운영 원칙을 `docs/decisions/README.md`로 문서화했다.
+- ADR 작성 템플릿(`docs/decisions/ADR-TEMPLATE.md`)을 추가했다.
+- 기존 ADR 3건에 `Supersedes`, `Superseded by` 메타 필드를 정렬했다.
+- PR 템플릿에 기능 PR ADR 링크 필수 규칙을 강화했다.
+
+## 의도
+- 설계 변경의 추적성 누락 방지
+- 기능 구현 완료 조건에 문서 업데이트를 실무적으로 고정
+- ADR 상태(`Proposed/Accepted/Superseded`) 관리 일관성 확보


### PR DESCRIPTION
﻿## 변경 요약
ADR 운영 원칙을 문서/템플릿/PR 템플릿에 반영해 설계 변경 추적과 문서 동기화를 자동화했습니다.

## 배경
RAG/STT/임베딩 설계 변경이 잦은데 ADR 상태/링크 관리가 느슨하면 구현과 문서가 쉽게 분리됩니다. PR 단계에서 ADR 연결을 강제할 공통 규칙이 필요했습니다.

## 변경 내용
- `docs/decisions/README.md` 추가: ADR 상태(`Proposed/Accepted/Superseded`)와 운영 원칙 정의
- `docs/decisions/ADR-TEMPLATE.md` 추가: 필수 섹션/메타 템플릿 표준화
- 기존 ADR 메타 보강:
  - `docs/decisions/ADR-0001-rag-retrieval-architecture.md`
  - `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
  - `docs/decisions/ADR-0003-embedding-provider-index.md`
  - `Supersedes`, `Superseded by` 필드 정렬
- `.github/pull_request_template.md` 업데이트:
  - 기능 PR ADR 링크 필수 규칙 강화
  - ADR 상태 전이 기입 가이드 추가
- `docs/dev-logs/2026-05-08-adr-governance-automation.md` 기록 추가

## 연결 이슈
- 없음

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [x] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## ADR 링크
- ADR: `docs/decisions/ADR-0001-rag-retrieval-architecture.md`
- ADR: `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
- ADR: `docs/decisions/ADR-0003-embedding-provider-index.md`
- ADR 가이드: `docs/decisions/README.md`
- ADR 템플릿: `docs/decisions/ADR-TEMPLATE.md`
