### PR TITLE
chore: add unified verify command for frontend and spring backend

### DIFF
--- a/docs/project/20-status-and-next-steps.md
+++ b/docs/project/20-status-and-next-steps.md
@@ -66,7 +66,7 @@
 - 검증 / 배포 안정화
   - backend workspace 의존성 점검을 자동화한다.
   - frontend build 환경 오류 같은 실행 이슈를 별도로 정리한다.
-  - `npm run verify`로 의존성과 빌드를 한 번에 점검한다.
+  - `npm run verify`(frontend build + backend spring test)로 핵심 검증을 한 번에 점검한다.
 - 미디어 업로드 / 오디오 추출
   - 강의 영상 업로드, R2 asset 조회, 외부 media processor dispatch, callback 기반 STT 연결까지 붙었다.
   - 다음 단계는 실제 FFmpeg 실행 환경을 운영에 배포하고, 추출 job 상태를 UI에서 더 세밀하게 보여주는 일이다.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:frontend": "npm --workspace @myway/frontend run build",
     "build:backend": "cd backend-spring && mvnw.cmd -DskipTests package",
     "test:backend": "cd backend-spring && mvnw.cmd test",
+    "verify": "npm run build:frontend && npm run test:backend",
     "build:backend:legacy": "npm --workspace @myway/backend run build",
     "build": "npm run build:frontend && npm run build:backend"
   }


### PR DESCRIPTION
﻿## 변경 요약
루트에서 `npm run verify` 한 번으로 프론트 빌드와 스프링 백엔드 테스트를 연속 실행하도록 검증 명령을 추가했습니다.

## 배경
다음 단계 작업을 자동화할 때 검증 명령이 분산되어 있으면 실패 지점 추적이 늦어집니다. 공통 verify 엔트리포인트가 필요했습니다.

## 변경 내용
- `package.json`
  - `verify` 스크립트 추가
  - 실행 순서: `build:frontend` -> `test:backend`
- `docs/project/20-status-and-next-steps.md`
  - 검증 항목을 실제 명령 기준으로 명확화

## 연결 이슈
- 없음

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료

## ADR 링크
- ADR: N/A (설계 변경 아님)
