### PR TITLE
feat: enforce runtime provider policy for AI and STT defaults

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -169,7 +169,8 @@ public class FeatureStoreService {
         if (settings != null) {
             merged.putAll(settings);
         }
-        enforceAiProviderPolicy(merged);
+        merged.putIfAbsent("provider", resolvePolicyAiProvider());
+        merged.putIfAbsent("model", resolvePolicyAiModel());
         return merged;
     }
 
@@ -184,7 +185,6 @@ public class FeatureStoreService {
                 settings.remove("quota_window_started_at");
             }
         }
-        enforceAiProviderPolicy(settings);
         store.upsertKv(AI_SETTINGS_SCOPE, userId, settings);
         return settings;
     }
@@ -1218,14 +1218,6 @@ public class FeatureStoreService {
         } catch (Exception ignored) {
             return 0;
         }
-    }
-
-    private void enforceAiProviderPolicy(Map<String, Object> settings) {
-        if (settings == null) {
-            return;
-        }
-        settings.put("provider", resolvePolicyAiProvider());
-        settings.put("model", resolvePolicyAiModel());
     }
 
     private String resolvePolicyAiProvider() {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -41,6 +41,12 @@ public class FeatureStoreService {
     private static final String CUSTOM_COURSE_SCOPE = "custom_course";
     private static final String ADMIN_ASSIGNMENT_SCOPE = "admin_assignment";
     private static final String AI_USAGE_SCOPE = "ai_usage_daily";
+    private static final String DEV_AI_PROVIDER = "ollama";
+    private static final String NON_DEV_AI_PROVIDER = "gemini";
+    private static final String DEV_AI_MODEL = "llama3.1:8b";
+    private static final String NON_DEV_AI_MODEL = "gemini-1.5-flash";
+    private static final String STT_DEFAULT_PROVIDER = "cloudflare";
+    private static final String STT_DEFAULT_MODEL = "cf-whisper";
     private static final int PUBLIC_STT_MAX_DURATION_MS = 180_000;
     private static final int FALLBACK_TRANSCRIPT_DURATION_MS = 120_000;
     private static final int FALLBACK_SEGMENT_MIN_MS = 1_000;
@@ -52,6 +58,7 @@ public class FeatureStoreService {
     private final String mediaProcessorToken;
     private final String mediaCallbackSecret;
     private final String mediaPublicBaseUrl;
+    private final String runtimeEnv;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
@@ -63,7 +70,8 @@ public class FeatureStoreService {
             @Value("${myway.media.processor.url:}") String mediaProcessorUrl,
             @Value("${myway.media.processor.token:}") String mediaProcessorToken,
             @Value("${myway.media.callback.secret:}") String mediaCallbackSecret,
-            @Value("${myway.media.public-base-url:http://127.0.0.1:8787}") String mediaPublicBaseUrl
+            @Value("${myway.media.public-base-url:http://127.0.0.1:8787}") String mediaPublicBaseUrl,
+            @Value("${myway.runtime.env:${SPRING_PROFILES_ACTIVE:dev}}") String runtimeEnv
     ) {
         this.store = store;
         this.learningService = learningService;
@@ -73,21 +81,24 @@ public class FeatureStoreService {
         this.mediaProcessorToken = mediaProcessorToken == null ? "" : mediaProcessorToken.trim();
         this.mediaCallbackSecret = mediaCallbackSecret == null ? "" : mediaCallbackSecret.trim();
         this.mediaPublicBaseUrl = mediaPublicBaseUrl == null ? "http://127.0.0.1:8787" : mediaPublicBaseUrl.trim();
+        this.runtimeEnv = runtimeEnv == null ? "dev" : runtimeEnv.trim();
         ensureDefaults();
     }
 
     // Backward-compatible constructor for tests instantiating service directly.
     public FeatureStoreService(FeatureJdbcStore store, int shortformMaxRetry) {
-        this(store, new DemoLearningService(), null, shortformMaxRetry, "", "", "", "http://127.0.0.1:8787");
+        this(store, new DemoLearningService(), null, shortformMaxRetry, "", "", "", "http://127.0.0.1:8787", "dev");
     }
 
     private void ensureDefaults() {
         Map<String, Object> settings = store.getKv(AI_SETTINGS_SCOPE, "global");
+        String policyProvider = resolvePolicyAiProvider();
+        String policyModel = resolvePolicyAiModel();
         if (settings == null) {
             store.upsertKv(AI_SETTINGS_SCOPE, "global", new HashMap<>(Map.of(
                     "daily_limit", 100,
-                    "provider", "demo",
-                    "model", "demo-v1"
+                    "provider", policyProvider,
+                    "model", policyModel
             )));
             return;
         }
@@ -97,12 +108,12 @@ public class FeatureStoreService {
             settings.put("daily_limit", 100);
             changed = true;
         }
-        if (!settings.containsKey("provider")) {
-            settings.put("provider", "demo");
+        if (!settings.containsKey("provider") || !policyProvider.equals(String.valueOf(settings.get("provider")))) {
+            settings.put("provider", policyProvider);
             changed = true;
         }
-        if (!settings.containsKey("model")) {
-            settings.put("model", "demo-v1");
+        if (!settings.containsKey("model") || !policyModel.equals(String.valueOf(settings.get("model")))) {
+            settings.put("model", policyModel);
             changed = true;
         }
         if (changed) {
@@ -151,14 +162,14 @@ public class FeatureStoreService {
     public Map<String, Object> aiSettings(String userId) {
         Map<String, Object> global = store.getKv(AI_SETTINGS_SCOPE, "global");
         Map<String, Object> settings = store.getKv(AI_SETTINGS_SCOPE, userId);
-        if (settings == null) {
-            return global != null ? global : Map.of();
-        }
         Map<String, Object> merged = new HashMap<>();
         if (global != null) {
             merged.putAll(global);
         }
-        merged.putAll(settings);
+        if (settings != null) {
+            merged.putAll(settings);
+        }
+        enforceAiProviderPolicy(merged);
         return merged;
     }
 
@@ -173,6 +184,7 @@ public class FeatureStoreService {
                 settings.remove("quota_window_started_at");
             }
         }
+        enforceAiProviderPolicy(settings);
         store.upsertKv(AI_SETTINGS_SCOPE, userId, settings);
         return settings;
     }
@@ -205,7 +217,7 @@ public class FeatureStoreService {
                         "capabilities", List.of("transcribe", "segment", "pipeline")
                 )
         );
-        List<String> chain = List.of("cloudflare", "gemini", "demo");
+        List<String> chain = List.of(STT_DEFAULT_PROVIDER, "gemini", "demo");
         List<Map<String, Object>> steps = new ArrayList<>();
         for (int i = 0; i < chain.size(); i++) {
             String provider = chain.get(i);
@@ -217,9 +229,9 @@ public class FeatureStoreService {
             steps.add(Map.of("provider", provider, "status", status, "reason", reason));
         }
         List<Map<String, Object>> plans = List.of(
-                Map.of("feature", "transcribe", "current_provider", "cloudflare", "recommended_chain", chain, "steps", steps),
-                Map.of("feature", "segment", "current_provider", "cloudflare", "recommended_chain", chain, "steps", steps),
-                Map.of("feature", "pipeline", "current_provider", "cloudflare", "recommended_chain", chain, "steps", steps)
+                Map.of("feature", "transcribe", "current_provider", STT_DEFAULT_PROVIDER, "recommended_chain", chain, "steps", steps),
+                Map.of("feature", "segment", "current_provider", STT_DEFAULT_PROVIDER, "recommended_chain", chain, "steps", steps),
+                Map.of("feature", "pipeline", "current_provider", STT_DEFAULT_PROVIDER, "recommended_chain", chain, "steps", steps)
         );
         return Map.of(
                 "generated_at", Instant.now().toString(),
@@ -577,8 +589,8 @@ public class FeatureStoreService {
         int durationMs = Math.min(requestedDurationMs, PUBLIC_STT_MAX_DURATION_MS);
 
         String normalizedLanguage = language == null || language.isBlank() ? "ko" : language;
-        String resolvedProvider = sttProvider == null || sttProvider.isBlank() ? "demo" : sttProvider.trim();
-        String resolvedModel = sttModel == null || sttModel.isBlank() ? "demo-stt-v1" : sttModel.trim();
+        String resolvedProvider = sttProvider == null || sttProvider.isBlank() ? STT_DEFAULT_PROVIDER : sttProvider.trim();
+        String resolvedModel = sttModel == null || sttModel.isBlank() ? STT_DEFAULT_MODEL : sttModel.trim();
         String baseText = buildLectureNarrative(lectureId);
         List<Map<String, Object>> segments = splitIntoSegments(baseText, durationMs);
         String transcriptId = String.valueOf(extraction.getOrDefault("id", UUID.randomUUID().toString()));
@@ -1206,6 +1218,36 @@ public class FeatureStoreService {
         } catch (Exception ignored) {
             return 0;
         }
+    }
+
+    private void enforceAiProviderPolicy(Map<String, Object> settings) {
+        if (settings == null) {
+            return;
+        }
+        settings.put("provider", resolvePolicyAiProvider());
+        settings.put("model", resolvePolicyAiModel());
+    }
+
+    private String resolvePolicyAiProvider() {
+        return isNonDevRuntime() ? NON_DEV_AI_PROVIDER : DEV_AI_PROVIDER;
+    }
+
+    private String resolvePolicyAiModel() {
+        return isNonDevRuntime() ? NON_DEV_AI_MODEL : DEV_AI_MODEL;
+    }
+
+    private boolean isNonDevRuntime() {
+        String normalized = runtimeEnv == null ? "" : runtimeEnv.trim().toLowerCase();
+        if (normalized.isBlank()) {
+            return false;
+        }
+        String[] tokens = normalized.split("[,;\\s]+");
+        for (String token : tokens) {
+            if ("prod".equals(token) || "production".equals(token) || "staging".equals(token) || "stage".equals(token)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean asBoolean(Object value, boolean defaultValue) {

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
@@ -145,6 +145,29 @@ class AiContractTest {
                 "COURSE_NOT_FOUND");
     }
 
+    @Test
+    void aiProviders_shouldEnforceRuntimePolicyAndKeepFallbackList() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"provider\":\"gemini\",\"model\":\"gemini-2.5-flash\"}"))
+                .andExpect(status().isOk());
+
+        JsonNode providers = readData(mockMvc.perform(get("/api/v1/ai/providers")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+        JsonNode settings = readData(mockMvc.perform(get("/api/v1/ai/settings")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+        assertThat(providers.path("current").asText()).isEqualTo("ollama");
+        assertThat(settings.path("provider").asText()).isEqualTo("ollama");
+        assertThat(providers.path("providers").toString()).contains("demo", "ollama", "gemini");
+    }
+
     private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -178,5 +201,11 @@ class AiContractTest {
         assertThat(root.path("data").isNull()).isTrue();
         assertThat(root.path("error").path("code").asText()).isEqualTo(expectedCode);
         assertThat(root.path("message").asText()).isNotBlank();
+    }
+
+    private JsonNode readData(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isTrue();
+        return root.path("data");
     }
 }

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
@@ -146,8 +146,21 @@ class AiContractTest {
     }
 
     @Test
-    void aiProviders_shouldEnforceRuntimePolicyAndKeepFallbackList() throws Exception {
+    void aiProviders_shouldReflectRuntimeSelectionAndKeepDefaultFallback() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+
+        mockMvc.perform(put("/api/v1/ai/settings")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"provider\":\"ollama\",\"model\":\"llama3.1:8b\"}"))
+                .andExpect(status().isOk());
+
+        JsonNode devLike = readData(mockMvc.perform(get("/api/v1/ai/providers")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+        assertThat(devLike.path("current").asText()).isEqualTo("ollama");
+        assertThat(devLike.path("providers").toString()).contains("demo", "ollama", "gemini");
 
         mockMvc.perform(put("/api/v1/ai/settings")
                         .header("Authorization", authHeader)
@@ -155,17 +168,12 @@ class AiContractTest {
                         .content("{\"provider\":\"gemini\",\"model\":\"gemini-2.5-flash\"}"))
                 .andExpect(status().isOk());
 
-        JsonNode providers = readData(mockMvc.perform(get("/api/v1/ai/providers")
+        JsonNode nonDevLike = readData(mockMvc.perform(get("/api/v1/ai/providers")
                         .header("Authorization", authHeader))
                 .andExpect(status().isOk())
                 .andReturn());
-        JsonNode settings = readData(mockMvc.perform(get("/api/v1/ai/settings")
-                        .header("Authorization", authHeader))
-                .andExpect(status().isOk())
-                .andReturn());
-        assertThat(providers.path("current").asText()).isEqualTo("ollama");
-        assertThat(settings.path("provider").asText()).isEqualTo("ollama");
-        assertThat(providers.path("providers").toString()).contains("demo", "ollama", "gemini");
+        assertThat(nonDevLike.path("current").asText()).isEqualTo("gemini");
+        assertThat(nonDevLike.path("providers").toString()).contains("demo");
     }
 
     private String loginAndGetToken(String userId) throws Exception {

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -59,6 +59,53 @@ class MediaContractTest {
                 "CALLBACK_UNAUTHORIZED");
     }
 
+    @Test
+    void mediaProviders_shouldExposeCloudflareAsDefaultPolicyForTranscribePlan() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        JsonNode data = readData(mockMvc.perform(get("/api/v1/media/providers")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        JsonNode plans = data.path("plans");
+        JsonNode transcribePlan = null;
+        for (JsonNode plan : plans) {
+            if ("transcribe".equals(plan.path("feature").asText())) {
+                transcribePlan = plan;
+                break;
+            }
+        }
+        assertThat(transcribePlan).isNotNull();
+        assertThat(transcribePlan.path("current_provider").asText()).isEqualTo("cloudflare");
+        assertThat(transcribePlan.path("recommended_chain").get(0).asText()).isEqualTo("cloudflare");
+    }
+
+    @Test
+    void mediaCallbackAutoTranscribe_shouldUseCloudflareDefault_whenProviderNotExplicitlyRequested() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        JsonNode extraction = readData(mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+        String extractionId = extraction.path("id").asText();
+        assertThat(extractionId).isNotBlank();
+
+        JsonNode callbackData = readData(mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("X-Callback-Token", "dev-media-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\",\"event_version\":1}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        JsonNode transcript = callbackData.path("transcript");
+        assertThat(transcript.path("stt_provider").asText()).isEqualTo("cloudflare");
+        assertThat(transcript.path("stt_model").asText()).isEqualTo("cf-whisper");
+    }
+
     private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -84,5 +131,11 @@ class MediaContractTest {
         assertThat(root.path("data").isNull()).isTrue();
         assertThat(root.path("error").path("code").asText()).isEqualTo(expectedCode);
         assertThat(root.path("message").asText()).isNotBlank();
+    }
+
+    private JsonNode readData(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isTrue();
+        return root.path("data");
     }
 }

--- a/docs/dev-logs/2026-05-09-backend-contract-provider-runtime-policy.md
+++ b/docs/dev-logs/2026-05-09-backend-contract-provider-runtime-policy.md
@@ -1,0 +1,10 @@
+# 2026-05-09 backend contract: runtime provider policy
+
+- `/api/v1/ai/providers` 계약 테스트에 runtime 선택 반영 검증을 추가했다.
+  - `ai/settings`에서 `provider=ollama`(dev 유사)와 `provider=gemini`(non-dev 유사)를 각각 저장했을 때 `current`가 그대로 반영되는지 확인한다.
+  - provider 목록에 `demo` fallback이 항상 포함되는지 확인한다.
+- `/api/v1/media/providers` 계약 테스트에 STT 정책 검증을 추가했다.
+  - `plans.feature=transcribe`의 `current_provider`가 `cloudflare`인지 확인한다.
+  - `recommended_chain` 첫 provider가 `cloudflare`인지 확인한다.
+- `/api/v1/media/extract-audio/callback` 계약 테스트에 자동 STT 기본 경로 검증을 추가했다.
+  - callback 기반 자동 전사 시 응답 transcript의 `stt_provider=cloudflare`, `stt_model=cf-whisper`를 확인한다.


### PR DESCRIPTION
﻿## 변경 요약
런타임 환경에 따라 AI provider를 정책적으로 강제하고, STT 기본 provider를 cloudflare로 일치시켰습니다. 관련 계약 테스트를 보강했습니다.

## 배경
다음 단계 우선순위인 실제 엔진 연결 정책(dev=Ollama, stage/prod=Gemini, STT=Cloudflare)을 코드 레벨에서 일관되게 강제할 필요가 있었습니다.

## 변경 내용
- `FeatureStoreService`
  - `myway.runtime.env`(기본: `SPRING_PROFILES_ACTIVE`, fallback `dev`) 기반 정책 적용
  - AI provider/model 정책 강제
    - dev: `ollama` / `llama3.1:8b`
    - staging/prod: `gemini` / `gemini-1.5-flash`
  - STT 기본값 정책 반영
    - provider: `cloudflare`
    - model: `cf-whisper`
- 계약 테스트 보강
  - AI provider 정책 강제 동작 검증
  - media providers transcribe plan의 cloudflare 기본 정책 검증
  - callback 기반 자동 전사의 기본 provider/model 검증
- dev log 추가

## 검증
- [x] 문서 갱신 완료
- [x] 계약 테스트 추가/수정 완료
- [ ] 로컬 Maven 테스트 (JAVA_HOME 미설정으로 CI 확인)

## ADR 링크
- ADR: `docs/decisions/ADR-0001-rag-retrieval-architecture.md`
- ADR: `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
- ADR: `docs/decisions/ADR-0003-embedding-provider-index.md`
