### PR TITLE
test: enforce media admin-only policy in contract checks

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -60,6 +60,32 @@ class MediaContractTest {
     }
 
     @Test
+    void mediaManagementEndpoints_shouldAllowOnlyInstructorOrAdmin() throws Exception {
+        String studentAuth = "Bearer " + loginAndGetToken("usr_std_001");
+        String instructorAuth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", studentAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isForbidden())
+                .andReturn(), "FORBIDDEN");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/upload-video")
+                        .header("Authorization", studentAuth)
+                        .queryParam("lecture_id", "lec_java_01"))
+                .andExpect(status().isForbidden())
+                .andReturn(), "FORBIDDEN");
+
+        assertSuccessEnvelope(mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", instructorAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+    }
+
+    @Test
     void mediaProviders_shouldExposeCloudflareAsDefaultPolicyForTranscribePlan() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
 

--- a/docs/dev-logs/2026-05-09-media-admin-policy-contract.md
+++ b/docs/dev-logs/2026-05-09-media-admin-policy-contract.md
@@ -1,0 +1,12 @@
+# 2026-05-09 Media Admin Policy Contract
+
+## 요약
+- 공개 테스트 정책 고정을 위해 media 관리 엔드포인트 권한 계약 테스트를 보강했다.
+
+## 변경
+- `MediaContractTest`에 역할 기반 접근 제어 검증 추가
+  - 학생(`usr_std_001`)은 `/api/v1/media/extract-audio`, `/api/v1/media/upload-video`에서 `FORBIDDEN`
+  - 강사(`usr_ins_001`)는 `/api/v1/media/extract-audio` 정상 생성(`201`)
+
+## 기대 효과
+- `upload-video`, `extract-audio`의 관리자(강사/운영자) 전용 정책이 회귀되지 않도록 CI에서 지속 검증한다.


### PR DESCRIPTION
﻿## 변경 요약
`upload-video`, `extract-audio`의 관리자(강사/운영자) 전용 정책을 계약 테스트로 고정했습니다.

## 변경 내용
- `MediaContractTest`
  - 학생 계정 접근 시 `FORBIDDEN` 검증
  - 강사 계정 접근 시 `extract-audio` 생성 성공 검증
- dev log 추가

## 검증
- CI contract/integration 테스트에서 확인

## ADR 링크
- ADR: N/A (정책 회귀 방지 테스트 보강)
