### PR TITLE
chore: make verify command cross-platform for maven wrapper

### DIFF
--- a/.github/workflows/verify-workspace.yml
+++ b/.github/workflows/verify-workspace.yml
@@ -43,8 +43,4 @@ jobs:
         run: npm install --no-save @rollup/rollup-linux-x64-gnu
 
       - name: Verify workspace
-        run: |
-          npm run build:frontend
-          cd backend-spring
-          chmod +x mvnw
-          ./mvnw test
+        run: npm run verify

--- a/docs/dev-logs/2026-05-09-cross-platform-verify-command.md
+++ b/docs/dev-logs/2026-05-09-cross-platform-verify-command.md
@@ -1,0 +1,18 @@
+# 2026-05-09 Cross-platform verify command
+
+## 요약
+- 루트 `npm run verify`가 Windows/리눅스에서 동일하게 동작하도록 Maven wrapper 실행을 공통 스크립트로 통합했다.
+
+## 변경 내용
+- `scripts/run-maven-wrapper.mjs` 추가
+  - Windows: `mvnw.cmd`
+  - Non-Windows: `sh mvnw ...`
+- `package.json` 스크립트 교체
+  - `dev:backend`, `build:backend`, `test:backend`
+- `verify-workspace` 워크플로 단순화
+  - 수동 `cd/chmod` 단계 제거
+  - `npm run verify` 직접 실행
+
+## 기대 효과
+- 로컬/CI 검증 절차가 단일 명령으로 일치한다.
+- OS별 Maven wrapper 차이로 인한 CI/로컬 불일치가 줄어든다.

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "scripts": {
     "dev": "npm run dev:frontend",
     "dev:frontend": "npm --workspace @myway/frontend run dev",
-    "dev:backend": "cd backend-spring && mvnw.cmd spring-boot:run",
+    "dev:backend": "node scripts/run-maven-wrapper.mjs spring-boot:run",
     "dev:backend:legacy": "npm --workspace @myway/backend run dev",
     "build:frontend": "npm --workspace @myway/frontend run build",
-    "build:backend": "cd backend-spring && mvnw.cmd -DskipTests package",
-    "test:backend": "cd backend-spring && mvnw.cmd test",
+    "build:backend": "node scripts/run-maven-wrapper.mjs -DskipTests package",
+    "test:backend": "node scripts/run-maven-wrapper.mjs test",
     "verify": "npm run build:frontend && npm run test:backend",
     "build:backend:legacy": "npm --workspace @myway/backend run build",
     "build": "npm run build:frontend && npm run build:backend"

--- a/scripts/run-maven-wrapper.mjs
+++ b/scripts/run-maven-wrapper.mjs
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+import { platform } from "node:os";
+
+const args = process.argv.slice(2);
+const isWindows = platform() === "win32";
+const command = isWindows ? "mvnw.cmd" : "sh";
+const commandArgs = isWindows ? args : ["mvnw", ...args];
+
+const result = spawnSync(command, commandArgs, {
+  cwd: "backend-spring",
+  stdio: "inherit",
+  shell: isWindows,
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
﻿## 변경 요약
루트 `npm run verify`를 OS 독립적으로 실행하도록 Maven wrapper 호출을 공통 스크립트로 통합했습니다.

## 변경 내용
- `scripts/run-maven-wrapper.mjs` 추가
  - Windows: `mvnw.cmd`
  - Linux/macOS: `sh mvnw`
- `package.json`
  - `dev:backend`, `build:backend`, `test:backend`를 공통 스크립트 기반으로 교체
- `.github/workflows/verify-workspace.yml`
  - 수동 `cd/chmod` 제거, `npm run verify` 직접 실행
- dev log 추가

## 검증
- CI `verify` / `test-backend-spring` 체크로 확인

## ADR 링크
- ADR: N/A (개발/검증 자동화 개선)
