### PR TITLE
test: add staging runtime default ai policy integration coverage

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/integration/RuntimeEnvDefaultPolicyIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/RuntimeEnvDefaultPolicyIntegrationTest.java
@@ -1,0 +1,58 @@
+package com.myway.backendspring.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "myway.runtime.env=staging")
+@AutoConfigureMockMvc
+class RuntimeEnvDefaultPolicyIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void aiSettings_shouldDefaultToGemini_onNonDevRuntime() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+
+        JsonNode settings = readData(mockMvc.perform(get("/api/v1/ai/settings")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString());
+
+        assertThat(settings.path("provider").asText()).isEqualTo("gemini");
+        assertThat(settings.path("model").asText()).isEqualTo("gemini-1.5-flash");
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+
+    private JsonNode readData(String response) throws Exception {
+        JsonNode root = objectMapper.readTree(response);
+        assertThat(root.path("success").asBoolean()).isTrue();
+        return root.path("data");
+    }
+}

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/RuntimeEnvDefaultPolicyIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/RuntimeEnvDefaultPolicyIntegrationTest.java
@@ -14,7 +14,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(properties = "myway.runtime.env=staging")
+@SpringBootTest(properties = {
+        "myway.runtime.env=staging",
+        "spring.datasource.url=jdbc:h2:mem:runtime-policy-it;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"
+})
 @AutoConfigureMockMvc
 class RuntimeEnvDefaultPolicyIntegrationTest {
 

--- a/docs/dev-logs/2026-05-09-runtime-env-default-policy-test.md
+++ b/docs/dev-logs/2026-05-09-runtime-env-default-policy-test.md
@@ -1,0 +1,11 @@
+# 2026-05-09 Runtime env default policy integration test
+
+## 요약
+- `myway.runtime.env=staging` 환경에서 AI 기본 provider/model이 `gemini`/`gemini-1.5-flash`로 노출되는지 통합 테스트를 추가했다.
+
+## 변경
+- `RuntimeEnvDefaultPolicyIntegrationTest` 추가
+  - 로그인 후 `/api/v1/ai/settings` 응답의 기본 정책값 검증
+
+## 목적
+- 런타임 환경별 기본 정책(dev vs non-dev) 회귀를 CI에서 조기에 탐지한다.


### PR DESCRIPTION
﻿## 변경 요약
staging/non-dev 런타임에서 AI 기본 정책(provider/model)이 의도대로 노출되는지 통합 테스트를 추가했습니다.

## 변경 내용
- `RuntimeEnvDefaultPolicyIntegrationTest` 추가
  - `myway.runtime.env=staging`에서 `/api/v1/ai/settings` 기본값 검증
  - expected: `provider=gemini`, `model=gemini-1.5-flash`
- dev log 추가

## 검증
- CI backend/verify 체크 기준

## ADR 링크
- ADR: `docs/decisions/ADR-0003-embedding-provider-index.md`
