### PR TITLE
test: add contract coverage for public stt duration cap

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -132,6 +132,22 @@ class MediaContractTest {
         assertThat(transcript.path("stt_model").asText()).isEqualTo("cf-whisper");
     }
 
+    @Test
+    void transcribe_shouldCapDurationToPublicPolicyLimit() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        JsonNode transcript = readData(mockMvc.perform(post("/api/v1/media/transcribe")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"language\":\"ko\",\"duration_ms\":999999}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+
+        assertThat(transcript.path("duration_ms").asInt()).isEqualTo(180000);
+        assertThat(transcript.path("stt_provider").asText()).isEqualTo("cloudflare");
+        assertThat(transcript.path("stt_model").asText()).isEqualTo("cf-whisper");
+    }
+
     private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/docs/dev-logs/2026-05-09-stt-duration-cap-contract.md
+++ b/docs/dev-logs/2026-05-09-stt-duration-cap-contract.md
@@ -1,0 +1,12 @@
+# 2026-05-09 STT duration cap contract
+
+## 요약
+- 공개 테스트 정책의 STT 최대 길이(3분) 회귀를 막기 위해 계약 테스트를 추가했다.
+
+## 변경
+- `MediaContractTest.transcribe_shouldCapDurationToPublicPolicyLimit`
+  - `duration_ms=999999` 요청 시 응답 `duration_ms=180000` 검증
+  - 기본 STT provider/model이 `cloudflare`/`cf-whisper`인지 함께 검증
+
+## 목적
+- 공개 테스트 정책(최대 3분)이 코드 변경으로 깨지는 것을 CI에서 즉시 탐지한다.


### PR DESCRIPTION
﻿## 변경 요약
공개 테스트 정책의 STT 최대 길이(3분) 회귀 방지 계약 테스트를 추가했습니다.

## 변경 내용
- `MediaContractTest`
  - `duration_ms` 과대 요청(999999) 시 180000으로 제한되는지 검증
  - 기본 STT provider/model(`cloudflare`/`cf-whisper`) 검증
- dev log 추가

## 검증
- CI contract + integration 체크 기준

## ADR 링크
- ADR: `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
