### PR TITLE
test: verify transcribe api defaults to cloudflare provider

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -148,6 +148,21 @@ class MediaContractTest {
         assertThat(transcript.path("stt_model").asText()).isEqualTo("cf-whisper");
     }
 
+    @Test
+    void transcribe_shouldUseCloudflareDefaults_whenProviderAndModelAreOmitted() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        JsonNode transcript = readData(mockMvc.perform(post("/api/v1/media/transcribe")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\",\"language\":\"ko\"}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+
+        assertThat(transcript.path("stt_provider").asText()).isEqualTo("cloudflare");
+        assertThat(transcript.path("stt_model").asText()).isEqualTo("cf-whisper");
+    }
+
     private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/docs/dev-logs/2026-05-09-transcribe-default-provider-contract.md
+++ b/docs/dev-logs/2026-05-09-transcribe-default-provider-contract.md
@@ -1,0 +1,12 @@
+# 2026-05-09 Transcribe default provider contract
+
+## 요약
+- `/api/v1/media/transcribe` 직접 호출에서 `stt_provider`, `stt_model`을 생략해도 기본 정책이 유지되는지 계약 테스트를 추가했다.
+
+## 변경
+- `MediaContractTest.transcribe_shouldUseCloudflareDefaults_whenProviderAndModelAreOmitted`
+  - 입력에서 provider/model 생략
+  - 응답 기본값 `cloudflare` / `cf-whisper` 검증
+
+## 목적
+- 자동 전사(callback)뿐 아니라 직접 전사 API 경로에서도 기본 STT 정책 회귀를 방지한다.


### PR DESCRIPTION
﻿## 변경 요약
직접 transcribe API 호출에서도 기본 STT provider/model 정책이 유지되는지 계약 테스트를 추가했습니다.

## 변경 내용
- `MediaContractTest`
  - provider/model 생략 시 `cloudflare`/`cf-whisper` 기본값 검증
- dev log 추가

## ADR 링크
- ADR: `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
