### PR TITLE
test: add dev runtime default ai policy integration coverage

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/integration/RuntimeEnvDevDefaultPolicyIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/RuntimeEnvDevDefaultPolicyIntegrationTest.java
@@ -1,0 +1,61 @@
+package com.myway.backendspring.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "myway.runtime.env=dev",
+        "spring.datasource.url=jdbc:h2:mem:runtime-dev-policy-it;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"
+})
+@AutoConfigureMockMvc
+class RuntimeEnvDevDefaultPolicyIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void aiSettings_shouldDefaultToOllama_onDevRuntime() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+
+        JsonNode settings = readData(mockMvc.perform(get("/api/v1/ai/settings")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString());
+
+        assertThat(settings.path("provider").asText()).isEqualTo("ollama");
+        assertThat(settings.path("model").asText()).isEqualTo("llama3.1:8b");
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+
+    private JsonNode readData(String response) throws Exception {
+        JsonNode root = objectMapper.readTree(response);
+        assertThat(root.path("success").asBoolean()).isTrue();
+        return root.path("data");
+    }
+}

--- a/docs/dev-logs/2026-05-09-runtime-env-dev-default-policy-test.md
+++ b/docs/dev-logs/2026-05-09-runtime-env-dev-default-policy-test.md
@@ -1,0 +1,12 @@
+# 2026-05-09 Runtime env dev default policy integration test
+
+## 요약
+- `myway.runtime.env=dev`에서 AI 기본 정책(provider/model)이 `ollama`/`llama3.1:8b`로 노출되는지 통합 테스트를 추가했다.
+
+## 변경
+- `RuntimeEnvDevDefaultPolicyIntegrationTest` 추가
+  - 로그인 후 `/api/v1/ai/settings` 응답의 dev 기본 정책값 검증
+  - 테스트 DB를 in-memory H2로 격리
+
+## 목적
+- 런타임 환경별 기본 정책(dev vs non-dev) 회귀 탐지를 양방향으로 강화한다.


### PR DESCRIPTION
﻿## 변경 요약
dev 런타임에서 AI 기본 정책(provider/model) 회귀를 막기 위한 통합 테스트를 추가했습니다.

## 변경 내용
- `RuntimeEnvDevDefaultPolicyIntegrationTest` 추가
  - `myway.runtime.env=dev`에서 `/api/v1/ai/settings` 기본값 검증
  - expected: `provider=ollama`, `model=llama3.1:8b`
- dev log 추가

## ADR 링크
- ADR: `docs/decisions/ADR-0003-embedding-provider-index.md`
