### PR TITLE
test: enforce upload-video lecture_id input contract

### DIFF
--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -89,10 +89,9 @@ class MediaContractTest {
     void uploadVideo_shouldRequireLectureId_forInstructorOrAdmin() throws Exception {
         String instructorAuth = "Bearer " + loginAndGetToken("usr_ins_001");
 
-        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/upload-video")
+        mockMvc.perform(post("/api/v1/media/upload-video")
                         .header("Authorization", instructorAuth))
-                .andExpect(status().isBadRequest())
-                .andReturn(), "LECTURE_ID_REQUIRED");
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -86,6 +86,16 @@ class MediaContractTest {
     }
 
     @Test
+    void uploadVideo_shouldRequireLectureId_forInstructorOrAdmin() throws Exception {
+        String instructorAuth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/upload-video")
+                        .header("Authorization", instructorAuth))
+                .andExpect(status().isBadRequest())
+                .andReturn(), "LECTURE_ID_REQUIRED");
+    }
+
+    @Test
     void mediaProviders_shouldExposeCloudflareAsDefaultPolicyForTranscribePlan() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
 

--- a/docs/dev-logs/2026-05-09-media-upload-input-contract.md
+++ b/docs/dev-logs/2026-05-09-media-upload-input-contract.md
@@ -1,0 +1,11 @@
+# 2026-05-09 Media upload input contract
+
+## 요약
+- 미디어 업로드 API의 입력 계약 회귀 방지를 위해 `lecture_id` 필수 검증 테스트를 추가했다.
+
+## 변경
+- `MediaContractTest.uploadVideo_shouldRequireLectureId_forInstructorOrAdmin`
+  - 강사/운영자 권한이 있어도 `lecture_id` 누락 시 `400` + `LECTURE_ID_REQUIRED` 검증
+
+## 목적
+- 권한 검증과 입력 검증이 함께 유지되도록 API 계약 안정성을 높인다.


### PR DESCRIPTION
﻿## 변경 요약
`upload-video` API의 입력 계약(`lecture_id` 필수)을 계약 테스트로 고정했습니다.

## 변경 내용
- `MediaContractTest`
  - 강사/운영자 권한이어도 `lecture_id` 누락 시 `400` + `LECTURE_ID_REQUIRED` 검증
- dev log 추가

## ADR 링크
- ADR: N/A (API 계약 테스트 보강)
