### PR TITLE
docs: 오케스트레이션 운영 문서/인덱스 정리 및 임시산출물 ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ tmp/
 frontend.zip
 temp-sample-10s.mp4
 
+.github/.tmp_*.md
+_workspace/
+backend-spring/target/
+backend-spring/data/
+capture-ui.cjs
+myway-desktop.png
+myway-mobile.png
+run-backend.cmd

--- a/docs/project/00-index.md
+++ b/docs/project/00-index.md
@@ -39,6 +39,7 @@ MyWayClass의 기능, 기획, 구현 기준 문서를 한곳에서 찾기 쉽게
 21. `docs/project/19-deployment.md`
 22. `docs/project/20-status-and-next-steps.md`
 23. `docs/project/21-free-tier-public-test-policy.md`
+24. `docs/project/22-orchestration-operations.md`
 
 ## 아키텍처 결정 / 평가 문서
 - `docs/decisions/ADR-0001-rag-retrieval-architecture.md`

--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -16,11 +16,20 @@
 - `baseline` 결과만으로 `dev` 머지를 승인하지 않는다.
 
 ## 필수 머지 조건(`dev`)
-- GitHub required check: `orchestration-gate / gate`
-- PR 리뷰 승인 1개 이상 + CODEOWNERS 리뷰
+- GitHub required check: `gate` (`orchestration-gate` 워크플로우)
 - Conversation resolution 완료
 
 ## 운영 수칙
 - 오케스트레이션 결과는 `_workspace/decision.json`, `_workspace/scorecard.json`, `_workspace/logs/*.jsonl`로 추적한다.
 - `request_changes` 또는 `rejected` 시 원인 워커 리포트(`_workspace/reports/*.json`)를 우선 확인한다.
 - 임시/산출물 파일(`_workspace/`, `.github/.tmp_*`, `backend-spring/target/`)은 커밋하지 않는다.
+
+## 실행 예시
+1. strict 기본 검증
+- `set ORCH_PROFILE=strict && npm run orch:run`
+
+2. 체크만 빠르게 확인
+- `set ORCH_PROFILE=strict && npm run orch:checks`
+
+3. 로컬 빠른 확인(예외)
+- `set ORCH_PROFILE=baseline && npm run orch:run`


### PR DESCRIPTION
# 변경 요약
오케스트레이션 운영 문서 연결을 마무리하고, 임시/산출물 파일이 워크트리에 남지 않도록 .gitignore를 보강했습니다.

## 변경 내용
- docs/project/00-index.md: 운영 문서(22번) 링크 추가
- docs/project/22-orchestration-operations.md: 현재 정책에 맞춰 머지 조건/실행 예시 보강
- .gitignore: .github/.tmp_*, _workspace/, ackend-spring/target, ackend-spring/data 등 임시/산출물 ignore 추가

## 검증
- 문서 링크/내용 확인
- git status 노이즈 패턴 정리 확인