### PR TITLE
feat: 오케스트레이터 재토론 1회/워커 변경파일 추적 추가

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -22,6 +22,7 @@
 ## 운영 수칙
 - 오케스트레이션 결과는 `_workspace/decision.json`, `_workspace/scorecard.json`, `_workspace/logs/*.jsonl`로 추적한다.
 - `request_changes` 또는 `rejected` 시 원인 워커 리포트(`_workspace/reports/*.json`)를 우선 확인한다.
+- 실패가 발생하면 정책(`ops/workflow/policy.yaml`)의 `debate.max_rounds` 범위 내에서 1회 재토론/재실행 후 최종 판정한다.
 - 임시/산출물 파일(`_workspace/`, `.github/.tmp_*`, `backend-spring/target/`)은 커밋하지 않는다.
 
 ## 실행 예시

--- a/ops/workflow/policy.yaml
+++ b/ops/workflow/policy.yaml
@@ -8,3 +8,5 @@ timeouts:
 fallback:
   on_repeated_failure: manual_review_required
   allow_partial_report: true
+debate:
+  max_rounds: 2

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -22,6 +22,7 @@ interface Policy {
   retry?: { worker_max_retries?: number; check_max_retries?: number };
   timeouts?: { worker_timeout_minutes?: number; review_timeout_minutes?: number };
   fallback?: { on_repeated_failure?: string; allow_partial_report?: boolean };
+  debate?: { max_rounds?: number };
 }
 
 const taskId = process.env.TASK_ID || `task-${Date.now()}`;
@@ -60,10 +61,45 @@ function runCmd(cmd: string, timeoutMs: number): boolean {
   return out.status === 0;
 }
 
+function runCmdOut(cmd: string, timeoutMs: number): string {
+  const out = spawnSync(cmd, {
+    cwd: projectDir,
+    shell: true,
+    stdio: "pipe",
+    timeout: timeoutMs,
+    maxBuffer: 20 * 1024 * 1024
+  });
+  return (out.stdout || "").toString("utf-8").trim();
+}
+
 function runWithRetry(action: () => boolean, retries: number): boolean {
   for (let i = 0; i <= retries; i += 1) {
     if (action()) return true;
   }
+  return false;
+}
+
+function getGitChangedFiles(): string[] {
+  const tracked = runCmdOut("git diff --name-only", 10_000)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const staged = runCmdOut("git diff --cached --name-only", 10_000)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const untracked = runCmdOut("git ls-files --others --exclude-standard", 10_000)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return Array.from(new Set([...tracked, ...staged, ...untracked]));
+}
+
+function roleOwnsFile(role: WorkerRole, filePath: string): boolean {
+  if (role === "backend-dev") return filePath.startsWith("backend-spring/") || filePath.startsWith("backend/");
+  if (role === "frontend-dev") return filePath.startsWith("frontend/") || filePath.startsWith("myway-class-ui");
+  if (role === "test-engineer") return /test|spec|contract/i.test(filePath);
+  if (role === "docs-writer") return filePath.startsWith("docs/") || filePath.endsWith(".md");
   return false;
 }
 
@@ -100,11 +136,12 @@ function runWorker(role: WorkerRole): WorkerReport {
     summary = "docs worker placeholder: no docs change requested";
   }
 
+  const changedFiles = getGitChangedFiles().filter((filePath) => roleOwnsFile(role, filePath));
   const report: WorkerReport = {
     taskId,
     role,
     summary,
-    filesChanged: [],
+    filesChanged: changedFiles,
     risks: pass ? [] : [`${role} command failed`],
     timestamp: new Date().toISOString()
   };
@@ -124,9 +161,24 @@ function debateRound(): { chosen: "A" | "B"; rationale: string } {
     join(threadsDir, `${taskId}.jsonl`),
     JSON.stringify({ role: "worker-A", message: optionA, at: new Date().toISOString() }) + "\n" +
       JSON.stringify({ role: "worker-B", message: optionB, at: new Date().toISOString() }) + "\n" +
-      JSON.stringify({ role: "critic", message: `selected ${chosen}: ${rationale}`, at: new Date().toISOString() }) + "\n"
+      JSON.stringify({ role: "critic", message: `selected ${chosen}: ${rationale}`, at: new Date().toISOString() }) + "\n" +
+      JSON.stringify({ role: "manager", message: `execute plan ${chosen} for ${profile} profile`, at: new Date().toISOString() }) + "\n"
   );
   return { chosen, rationale };
+}
+
+function remediationRound(failedWorkers: string[], failedChecks: string[]): void {
+  appendFileSync(
+    join(threadsDir, `${taskId}.jsonl`),
+    JSON.stringify({
+      role: "manager",
+      message: `remediation requested. failedWorkers=${failedWorkers.join(",") || "none"}, failedChecks=${failedChecks.join(",") || "none"}`,
+      at: new Date().toISOString()
+    }) + "\n" +
+      JSON.stringify({ role: "worker-A", message: "propose targeted rerun and minimal patch", at: new Date().toISOString() }) + "\n" +
+      JSON.stringify({ role: "worker-B", message: "propose fallback path and risk containment", at: new Date().toISOString() }) + "\n" +
+      JSON.stringify({ role: "critic", message: "approve one remediation round only", at: new Date().toISOString() }) + "\n"
+  );
 }
 
 stateLog(null, "draft", "manager");
@@ -157,12 +209,41 @@ const rules = loadRules(rulesPath);
 const scorecard = buildScorecard(taskId, checksOutput.checks, rules);
 validateOrThrow(join(projectDir, "ops/workflow/contracts/review_scorecard.json"), scorecard, "review scorecard");
 
-const allWorkersPassed = workerReports.every((report) => report.risks.length === 0);
-const failedWorkers = workerReports
+let failedWorkers = workerReports
   .filter((report) => report.risks.length > 0)
   .map((report) => ({ role: report.role, risks: report.risks }));
-const failedChecks = checksOutput.checks.filter((check) => !check.pass).map((check) => check.name);
-const approved = allWorkersPassed && scorecard.verdict === "approve";
+let failedChecks = checksOutput.checks.filter((check) => !check.pass).map((check) => check.name);
+
+const maxDebateRounds = Math.max(1, policy.debate?.max_rounds ?? 2);
+const shouldRetryRound = (failedWorkers.length > 0 || failedChecks.length > 0) && maxDebateRounds > 1;
+let finalWorkerReports = workerReports;
+let finalScorecard = scorecard;
+
+if (shouldRetryRound) {
+  remediationRound(
+    failedWorkers.map((worker) => worker.role),
+    failedChecks
+  );
+  const rerunRoles = new Set(failedWorkers.map((worker) => worker.role as WorkerRole));
+  const rerunReports = finalWorkerReports.map((report) => (rerunRoles.has(report.role) ? runWorker(report.role) : report));
+  finalWorkerReports = rerunReports;
+
+  let rerunChecks = runChecks(projectDir, profile);
+  if (!rerunChecks.pass && checkMaxRetries > 0) {
+    for (let i = 0; i < checkMaxRetries; i += 1) {
+      rerunChecks = runChecks(projectDir, profile);
+      if (rerunChecks.pass) break;
+    }
+  }
+  checksOutput = rerunChecks;
+  failedWorkers = finalWorkerReports.filter((report) => report.risks.length > 0).map((report) => ({ role: report.role, risks: report.risks }));
+  failedChecks = checksOutput.checks.filter((check) => !check.pass).map((check) => check.name);
+  finalScorecard = buildScorecard(taskId, checksOutput.checks, rules);
+  validateOrThrow(join(projectDir, "ops/workflow/contracts/review_scorecard.json"), finalScorecard, "review scorecard rerun");
+  auditLog({ type: "remediation-round", rerun: 1, workerFailures: failedWorkers, checkFailures: failedChecks });
+}
+
+const approved = finalWorkerReports.every((report) => report.risks.length === 0) && finalScorecard.verdict === "approve";
 const finalState = approved ? "approved" : "rejected";
 stateLog("review", finalState, "manager");
 
@@ -176,7 +257,7 @@ const decision = {
 };
 validateOrThrow(join(projectDir, "ops/workflow/contracts/manager_decision.json"), decision, "manager decision");
 
-writeFileSync(join(workspaceDir, "scorecard.json"), JSON.stringify(scorecard, null, 2));
+writeFileSync(join(workspaceDir, "scorecard.json"), JSON.stringify(finalScorecard, null, 2));
 writeFileSync(join(workspaceDir, "decision.json"), JSON.stringify(decision, null, 2));
 auditLog({ type: "decision", decision: decision.decision, state: finalState });
 
@@ -186,7 +267,7 @@ process.stdout.write(
       taskId,
       profile,
       state: finalState,
-      workerPass: allWorkersPassed,
+      workerPass: finalWorkerReports.every((report) => report.risks.length === 0),
       checksPass: checksOutput.pass,
       checksHash,
       failedWorkers,


### PR DESCRIPTION
## 변경 사항
- 오케스트레이터에 실패 시 1회 재토론/재실행 라운드(debate.max_rounds)를 추가했습니다.
- 워커 리포트 ilesChanged를 실제 Git 변경 파일 기반으로 채우도록 개선했습니다.
- 스레드 로그에 manager/worker/critic 대화 이벤트를 추가해 토론 흐름 추적성을 높였습니다.
- 운영 정책/문서에 재토론 라운드 규칙을 반영했습니다.

## 검증
- 
pm run orch:run (strict) 통과
- 결과: _workspace/decision.json -> pproved
