### PR TITLE
feat: 오케스트레이션 고도화(Option C/코드화/실행계획/런타임 큐)

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -34,22 +34,30 @@
 1. 워커 실행
 - `POST {ORCH_AGENT_ENDPOINT}/workers/run`
 - 요청 필드: `taskId`, `role`, `profile`, `projectDir`, `timeoutMs`, `filesChangedHint`
-- 응답 필드: `summary`, `filesChanged[]`, `risks[]`, `pass`, `messages[]`
+- 응답 필드: `summary`, `filesChanged[]`, `risks[]`, `pass`, `messages[]`, `executionPlan`
 
 2. 토론 라운드(선택)
 - `POST {ORCH_AGENT_ENDPOINT}/debate/round`
-- 요청 필드: `taskId`, `profile`, `optionA`, `optionB`
-- 응답 필드: `chosen`, `rationale`, `messages[]`
+- 요청 필드: `taskId`, `profile`, `optionA`, `optionB`, `optionC(선택)`
+- 응답 필드: `chosen(A|B|C)`, `rationale`, `messages[]`
 
 ## 로컬 에이전트 런타임 서버 실행
 1. 서버 시작
 - `npm run agent-runtime:start`
 - 기본 주소: `http://127.0.0.1:8787`
+- 운영 파라미터:
+  - `AGENT_RUNTIME_CONCURRENCY` (기본 `1`)
+  - `AGENT_RUNTIME_COMMAND_RETRIES` (기본 `1`)
+  - `AGENT_RUNTIME_QUEUE_TIMEOUT_MS` (기본 `120000`)
 
 2. 오케스트레이터를 remote 모드로 실행
 - `set ORCH_AGENT_MODE=remote`
 - `set ORCH_AGENT_ENDPOINT=http://127.0.0.1:8787`
 - `npm run orch:run`
+
+## request_changes 코드 표준
+- 실패 시 `decision.json.requestChangeCodes`에 구조화 원인 코드를 기록한다.
+- 예: `WORKER_BACKEND_FAILED`, `CHECK_TESTS_FAILED`, `REMOTE_RUNTIME_UNAVAILABLE`
 
 ## 실행 예시
 1. strict 기본 검증

--- a/ops/workflow/contracts/manager_decision.json
+++ b/ops/workflow/contracts/manager_decision.json
@@ -8,6 +8,24 @@
     "state": { "type": "string", "enum": ["draft", "debate", "review", "approved", "merged", "rejected"] },
     "decision": { "type": "string", "enum": ["approve", "reject", "request_changes"] },
     "reason": { "type": "string", "minLength": 1 },
+    "requestChangeCodes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "WORKER_BACKEND_FAILED",
+          "WORKER_FRONTEND_FAILED",
+          "WORKER_TEST_FAILED",
+          "WORKER_DOCS_FAILED",
+          "CHECK_TESTS_FAILED",
+          "CHECK_STYLE_FAILED",
+          "CHECK_SECURITY_FAILED",
+          "CHECK_PERFORMANCE_FAILED",
+          "CHECK_UNKNOWN_FAILED",
+          "REMOTE_RUNTIME_UNAVAILABLE"
+        ]
+      }
+    },
     "timestamp": { "type": "string", "format": "date-time" },
     "nextActions": { "type": "array", "items": { "type": "string" } }
   },

--- a/ops/workflow/contracts/worker_report.json
+++ b/ops/workflow/contracts/worker_report.json
@@ -2,13 +2,23 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "WorkerReport",
   "type": "object",
-  "required": ["taskId", "role", "summary", "filesChanged", "risks", "timestamp"],
+  "required": ["taskId", "role", "summary", "filesChanged", "risks", "timestamp", "executionPlan"],
   "properties": {
     "taskId": { "type": "string", "minLength": 1 },
     "role": { "type": "string", "enum": ["backend-dev", "frontend-dev", "test-engineer", "docs-writer"] },
     "summary": { "type": "string", "minLength": 1 },
     "filesChanged": { "type": "array", "items": { "type": "string" } },
     "risks": { "type": "array", "items": { "type": "string" } },
+    "executionPlan": {
+      "type": "object",
+      "required": ["steps", "commands", "riskLevel"],
+      "properties": {
+        "steps": { "type": "array", "items": { "type": "string" } },
+        "commands": { "type": "array", "items": { "type": "string" } },
+        "riskLevel": { "type": "string", "enum": ["low", "medium", "high"] }
+      },
+      "additionalProperties": false
+    },
     "timestamp": { "type": "string", "format": "date-time" }
   },
   "additionalProperties": false

--- a/tools/agent-runtime/server.ts
+++ b/tools/agent-runtime/server.ts
@@ -19,12 +19,48 @@ interface DebateRoundRequest {
   profile: OrchestratorProfile;
   optionA: string;
   optionB: string;
+  optionC?: string;
 }
 
 const port = Number(process.env.AGENT_RUNTIME_PORT || "8787");
 const host = process.env.AGENT_RUNTIME_HOST || "127.0.0.1";
 const apiKey = process.env.ORCH_AGENT_API_KEY || "";
 const allowedRoot = resolve(process.env.AGENT_RUNTIME_ALLOWED_ROOT || process.cwd());
+const queueConcurrency = Math.max(1, Number(process.env.AGENT_RUNTIME_CONCURRENCY || "1"));
+const commandRetries = Math.max(0, Number(process.env.AGENT_RUNTIME_COMMAND_RETRIES || "1"));
+const queueTimeoutMs = Math.max(5_000, Number(process.env.AGENT_RUNTIME_QUEUE_TIMEOUT_MS || "120000"));
+
+type QueueJob = {
+  run: () => Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+};
+
+const queue: QueueJob[] = [];
+let activeWorkers = 0;
+
+function enqueue<T>(run: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    queue.push({ run, resolve: resolve as (value: unknown) => void, reject });
+    drainQueue();
+  });
+}
+
+function drainQueue(): void {
+  while (activeWorkers < queueConcurrency && queue.length > 0) {
+    const job = queue.shift();
+    if (!job) return;
+    activeWorkers += 1;
+    job
+      .run()
+      .then((result) => job.resolve(result))
+      .catch((error) => job.reject(error))
+      .finally(() => {
+        activeWorkers -= 1;
+        drainQueue();
+      });
+  }
+}
 
 function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
   res.statusCode = statusCode;
@@ -68,12 +104,22 @@ function runCommand(projectDir: string, command: string, timeoutMs: number): { p
   };
 }
 
+function runCommandWithRetry(projectDir: string, command: string, timeoutMs: number): { pass: boolean; stdout: string; stderr: string; attempts: number } {
+  let last = { pass: false, stdout: "", stderr: "" };
+  for (let attempt = 0; attempt <= commandRetries; attempt += 1) {
+    last = runCommand(projectDir, command, timeoutMs);
+    if (last.pass) return { ...last, attempts: attempt + 1 };
+  }
+  return { ...last, attempts: commandRetries + 1 };
+}
+
 function buildWorkerResponse(body: WorkerRunRequest): {
   summary: string;
   filesChanged: string[];
   risks: string[];
   pass: boolean;
   messages: string[];
+  executionPlan: { steps: string[]; commands: string[]; riskLevel: "low" | "medium" | "high" };
 } {
   const timeoutMs = Math.min(Math.max(body.timeoutMs ?? 120_000, 5_000), 15 * 60_000);
   const filesChanged = Array.from(new Set(body.filesChangedHint ?? []));
@@ -81,31 +127,56 @@ function buildWorkerResponse(body: WorkerRunRequest): {
   const risks: string[] = [];
   let pass = true;
   let summary = `${body.role} analysis only`;
+  let executionPlan: { steps: string[]; commands: string[]; riskLevel: "low" | "medium" | "high" } = {
+    steps: ["analyze requested scope"],
+    commands: ["echo remote-analysis"],
+    riskLevel: "low"
+  };
 
   if (body.role === "backend-dev" && body.profile === "strict") {
-    const result = runCommand(body.projectDir, "npm run build:backend", timeoutMs);
+    const result = runCommandWithRetry(body.projectDir, "npm run build:backend", timeoutMs);
     pass = result.pass;
     summary = pass ? "backend build/contract check passed (remote)" : "backend build/contract check failed (remote)";
-    messages.push(`backend-dev: ${summary}`);
+    messages.push(`backend-dev: ${summary} (attempts=${result.attempts})`);
     if (!pass) risks.push("backend-dev remote command failed");
+    executionPlan = {
+      steps: ["compile backend modules", "run packaging contract checks"],
+      commands: ["npm run build:backend"],
+      riskLevel: pass ? "medium" : "high"
+    };
   }
   if (body.role === "frontend-dev" && body.profile === "strict") {
-    const result = runCommand(body.projectDir, "npm run build:frontend", timeoutMs);
+    const result = runCommandWithRetry(body.projectDir, "npm run build:frontend", timeoutMs);
     pass = result.pass;
     summary = pass ? "frontend build passed (remote)" : "frontend build failed (remote)";
-    messages.push(`frontend-dev: ${summary}`);
+    messages.push(`frontend-dev: ${summary} (attempts=${result.attempts})`);
     if (!pass) risks.push("frontend-dev remote command failed");
+    executionPlan = {
+      steps: ["compile frontend bundle", "validate static build output"],
+      commands: ["npm run build:frontend"],
+      riskLevel: pass ? "low" : "medium"
+    };
   }
   if (body.role === "test-engineer" && body.profile === "strict") {
-    const result = runCommand(body.projectDir, "npm run test:backend", timeoutMs);
+    const result = runCommandWithRetry(body.projectDir, "npm run test:backend", timeoutMs);
     pass = result.pass;
     summary = pass ? "backend tests passed (remote)" : "backend tests failed (remote)";
-    messages.push(`test-engineer: ${summary}`);
+    messages.push(`test-engineer: ${summary} (attempts=${result.attempts})`);
     if (!pass) risks.push("test-engineer remote command failed");
+    executionPlan = {
+      steps: ["run backend tests", "report failing suites"],
+      commands: ["npm run test:backend"],
+      riskLevel: pass ? "medium" : "high"
+    };
   }
   if (body.role === "docs-writer") {
     summary = "docs review completed (remote): no additional docs required";
     messages.push(`docs-writer: ${summary}`);
+    executionPlan = {
+      steps: ["review docs delta", "emit summary note"],
+      commands: ["echo docs-review"],
+      riskLevel: "low"
+    };
   }
   if (body.profile === "baseline" && (body.role === "backend-dev" || body.role === "test-engineer")) {
     summary = `${body.role} skipped in baseline profile (remote)`;
@@ -114,7 +185,7 @@ function buildWorkerResponse(body: WorkerRunRequest): {
     messages.push(summary);
   }
 
-  return { summary, filesChanged, risks, pass, messages };
+  return { summary, filesChanged, risks, pass, messages, executionPlan };
 }
 
 const server = createServer(async (req, res) => {
@@ -139,7 +210,10 @@ const server = createServer(async (req, res) => {
         writeJson(res, 403, { error: "projectDir out of allowed root" });
         return;
       }
-      const payload = buildWorkerResponse(body);
+      const payload = await Promise.race([
+        enqueue(async () => buildWorkerResponse(body)),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("worker queue timeout")), queueTimeoutMs))
+      ]);
       writeJson(res, 200, payload);
       return;
     }
@@ -150,14 +224,15 @@ const server = createServer(async (req, res) => {
         writeJson(res, 400, { error: "invalid debate payload" });
         return;
       }
-      const chosen = body.profile === "strict" ? "A" : "B";
-      const rationale = chosen === "A" ? body.optionA : body.optionB;
+      const chosen = body.optionC ? "C" : body.profile === "strict" ? "A" : "B";
+      const rationale = chosen === "A" ? body.optionA : chosen === "B" ? body.optionB : body.optionC ?? `${body.optionA} + ${body.optionB}`;
       writeJson(res, 200, {
         chosen,
         rationale,
         messages: [
           { role: "worker-A", message: body.optionA },
           { role: "worker-B", message: body.optionB },
+          ...(body.optionC ? [{ role: "critic", message: `proposed merge option C: ${body.optionC}` }] : []),
           { role: "critic", message: `selected ${chosen}: ${rationale}` },
           { role: "manager", message: `execute plan ${chosen} for ${body.profile} profile` }
         ]
@@ -174,4 +249,5 @@ const server = createServer(async (req, res) => {
 server.listen(port, host, () => {
   process.stdout.write(`[agent-runtime] listening on http://${host}:${port}\n`);
   process.stdout.write(`[agent-runtime] allowed_root=${allowedRoot}\n`);
+  process.stdout.write(`[agent-runtime] concurrency=${queueConcurrency}, retries=${commandRetries}, queue_timeout_ms=${queueTimeoutMs}\n`);
 });

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -15,6 +15,11 @@ interface WorkerReport {
   summary: string;
   filesChanged: string[];
   risks: string[];
+  executionPlan: {
+    steps: string[];
+    commands: string[];
+    riskLevel: "low" | "medium" | "high";
+  };
   timestamp: string;
 }
 
@@ -153,6 +158,7 @@ function localWorkerReport(role: WorkerRole): WorkerReport {
     summary,
     filesChanged: changedFiles,
     risks: pass ? [] : [`${role} command failed`],
+    executionPlan: planForRole(role, summary, !pass),
     timestamp: new Date().toISOString()
   };
 
@@ -168,6 +174,77 @@ interface RemoteWorkerResponse {
   risks?: string[];
   pass?: boolean;
   messages?: string[];
+  executionPlan?: {
+    steps?: string[];
+    commands?: string[];
+    riskLevel?: "low" | "medium" | "high";
+  };
+}
+
+type RequestChangeCode =
+  | "WORKER_BACKEND_FAILED"
+  | "WORKER_FRONTEND_FAILED"
+  | "WORKER_TEST_FAILED"
+  | "WORKER_DOCS_FAILED"
+  | "CHECK_TESTS_FAILED"
+  | "CHECK_STYLE_FAILED"
+  | "CHECK_SECURITY_FAILED"
+  | "CHECK_PERFORMANCE_FAILED"
+  | "CHECK_UNKNOWN_FAILED"
+  | "REMOTE_RUNTIME_UNAVAILABLE";
+
+function planForRole(role: WorkerRole, summary: string, isFail: boolean): WorkerReport["executionPlan"] {
+  if (role === "backend-dev") {
+    return {
+      steps: ["compile backend modules", "run contract-sensitive packaging"],
+      commands: ["npm run build:backend"],
+      riskLevel: isFail ? "high" : "medium"
+    };
+  }
+  if (role === "frontend-dev") {
+    return {
+      steps: ["compile frontend bundle", "validate build output"],
+      commands: ["npm run build:frontend"],
+      riskLevel: isFail ? "medium" : "low"
+    };
+  }
+  if (role === "test-engineer") {
+    return {
+      steps: ["run backend tests", "collect failures for remediation"],
+      commands: ["npm run test:backend"],
+      riskLevel: isFail ? "high" : "medium"
+    };
+  }
+  return {
+    steps: ["inspect docs impact", "record documentation actions"],
+    commands: ["echo docs-worker-noop"],
+    riskLevel: summary.includes("no docs") ? "low" : "medium"
+  };
+}
+
+function requestChangeCodesFromFailures(
+  failedWorkers: Array<{ role: WorkerRole; risks: string[] }>,
+  failedChecks: string[],
+  finalReports: WorkerReport[]
+): RequestChangeCode[] {
+  const codes = new Set<RequestChangeCode>();
+  for (const worker of failedWorkers) {
+    if (worker.role === "backend-dev") codes.add("WORKER_BACKEND_FAILED");
+    if (worker.role === "frontend-dev") codes.add("WORKER_FRONTEND_FAILED");
+    if (worker.role === "test-engineer") codes.add("WORKER_TEST_FAILED");
+    if (worker.role === "docs-writer") codes.add("WORKER_DOCS_FAILED");
+  }
+  for (const checkName of failedChecks) {
+    if (checkName.toLowerCase().includes("test")) codes.add("CHECK_TESTS_FAILED");
+    else if (checkName.toLowerCase().includes("lint") || checkName.toLowerCase().includes("style")) codes.add("CHECK_STYLE_FAILED");
+    else if (checkName.toLowerCase().includes("security") || checkName.toLowerCase().includes("audit")) codes.add("CHECK_SECURITY_FAILED");
+    else if (checkName.toLowerCase().includes("perf")) codes.add("CHECK_PERFORMANCE_FAILED");
+    else codes.add("CHECK_UNKNOWN_FAILED");
+  }
+  if (finalReports.some((report) => report.risks.some((risk) => risk.includes("remote worker unavailable")))) {
+    codes.add("REMOTE_RUNTIME_UNAVAILABLE");
+  }
+  return [...codes];
 }
 
 async function callRemoteWorker(role: WorkerRole): Promise<WorkerReport> {
@@ -199,12 +276,18 @@ async function callRemoteWorker(role: WorkerRole): Promise<WorkerReport> {
   const payload = (await response.json()) as RemoteWorkerResponse;
   const pass = payload.pass ?? (payload.risks?.length ?? 0) === 0;
   const summary = payload.summary || `${role} remote execution ${pass ? "passed" : "failed"}`;
+  const fallbackPlan = planForRole(role, summary, !pass);
   const report: WorkerReport = {
     taskId,
     role,
     summary,
     filesChanged: Array.from(new Set([...(payload.filesChanged ?? []), ...ownedChangedFiles])),
     risks: payload.risks ?? (pass ? [] : [`${role} remote execution failed`]),
+    executionPlan: {
+      steps: payload.executionPlan?.steps ?? fallbackPlan.steps,
+      commands: payload.executionPlan?.commands ?? fallbackPlan.commands,
+      riskLevel: payload.executionPlan?.riskLevel ?? fallbackPlan.riskLevel
+    },
     timestamp: new Date().toISOString()
   };
   for (const message of payload.messages ?? []) {
@@ -236,9 +319,10 @@ async function runWorker(role: WorkerRole): Promise<WorkerReport> {
   return localWorkerReport(role);
 }
 
-async function debateRound(): Promise<{ chosen: "A" | "B"; rationale: string }> {
+async function debateRound(): Promise<{ chosen: "A" | "B" | "C"; rationale: string }> {
   const optionA = profile === "strict" ? "full quality gate with tests+audit" : "keep strict for production branches";
   const optionB = profile === "baseline" ? "baseline fast gate for CI" : "fallback baseline when strict repeatedly fails";
+  const optionC = "merge A+B: keep strict gate with baseline fallback only for transient external failures";
   const chosen = profile === "strict" ? "A" : "B";
   const rationale = chosen === "A" ? optionA : optionB;
   if (agentMode === "remote" && agentEndpoint) {
@@ -250,11 +334,11 @@ async function debateRound(): Promise<{ chosen: "A" | "B"; rationale: string }> 
           "content-type": "application/json",
           ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {})
         },
-        body: JSON.stringify({ taskId, profile, optionA, optionB }),
+        body: JSON.stringify({ taskId, profile, optionA, optionB, optionC }),
         signal: AbortSignal.timeout(agentTimeoutMs)
       });
       if (response.ok) {
-        const payload = (await response.json()) as { messages?: Array<{ role: string; message: string }>; chosen?: "A" | "B"; rationale?: string };
+        const payload = (await response.json()) as { messages?: Array<{ role: string; message: string }>; chosen?: "A" | "B" | "C"; rationale?: string };
         for (const entry of payload.messages ?? []) {
           appendFileSync(join(threadsDir, `${taskId}.jsonl`), JSON.stringify({ role: entry.role, message: entry.message, at: new Date().toISOString() }) + "\n");
         }
@@ -268,6 +352,7 @@ async function debateRound(): Promise<{ chosen: "A" | "B"; rationale: string }> 
     join(threadsDir, `${taskId}.jsonl`),
     JSON.stringify({ role: "worker-A", message: optionA, at: new Date().toISOString() }) + "\n" +
       JSON.stringify({ role: "worker-B", message: optionB, at: new Date().toISOString() }) + "\n" +
+      JSON.stringify({ role: "critic", message: `proposed merge option C: ${optionC}`, at: new Date().toISOString() }) + "\n" +
       JSON.stringify({ role: "critic", message: `selected ${chosen}: ${rationale}`, at: new Date().toISOString() }) + "\n" +
       JSON.stringify({ role: "manager", message: `execute plan ${chosen} for ${profile} profile`, at: new Date().toISOString() }) + "\n"
   );
@@ -362,6 +447,7 @@ async function main(): Promise<void> {
     state: finalState,
     decision: approved ? "approve" : "request_changes",
     reason: approved ? "workers and quality gate passed" : "worker/check/review gate failed",
+    requestChangeCodes: approved ? [] : requestChangeCodesFromFailures(failedWorkers, failedChecks, finalWorkerReports),
     timestamp: new Date().toISOString(),
     nextActions: approved ? ["ready for merge gate"] : [policy.fallback?.on_repeated_failure ?? "fix failures and rerun"]
   };


### PR DESCRIPTION
## 변경 사항
- Critic이 병합안 Option C를 제안/선택할 수 있도록 debate 계약 확장
- decision.json에 equestChangeCodes 구조화 원인 코드 추가
- worker_report에 표준 executionPlan(steps/commands/riskLevel) 추가
- agent-runtime 서버에 큐/동시성/명령 재시도/큐 타임아웃 제어 추가
  - AGENT_RUNTIME_CONCURRENCY
  - AGENT_RUNTIME_COMMAND_RETRIES
  - AGENT_RUNTIME_QUEUE_TIMEOUT_MS
- 운영 문서에 새 계약/운영 파라미터 반영

## 검증
- 
pm run orch:run (local) 통과
- local 런타임 서버 기동 후 ORCH_AGENT_MODE=remote npm run orch:run 통과
- decision.json에서 equestChangeCodes 확인
