### PR TITLE
feat: 오케스트레이션 traceId 관측성 추가

### DIFF
--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -63,6 +63,8 @@ jobs:
               : 'n/a';
             const body = [
               '### Orchestration Gate Result',
+              `- trace id: ${d.traceId || 'n/a'}`,
+              `- task id: ${d.taskId || 'n/a'}`,
               `- state: ${d.state}`,
               `- decision: ${d.decision}`,
               `- reason: ${d.reason}`,

--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -23,6 +23,7 @@
 
 ## 운영 수칙
 - 오케스트레이션 결과는 `_workspace/decision.json`, `_workspace/scorecard.json`, `_workspace/logs/*.jsonl`로 추적한다.
+- 각 실행에는 `traceId`가 발급되며, `decision.json`/감사 로그/PR gate 코멘트에 동일하게 기록된다.
 - `request_changes` 또는 `rejected` 시 원인 워커 리포트(`_workspace/reports/*.json`)를 우선 확인한다.
 - 실패가 발생하면 정책(`ops/workflow/policy.yaml`)의 `debate.max_rounds` 범위 내에서 1회 재토론/재실행 후 최종 판정한다.
 - 임시/산출물 파일(`_workspace/`, `.github/.tmp_*`, `backend-spring/target/`)은 커밋하지 않는다.

--- a/ops/workflow/contracts/manager_decision.json
+++ b/ops/workflow/contracts/manager_decision.json
@@ -2,9 +2,10 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ManagerDecision",
   "type": "object",
-  "required": ["taskId", "state", "decision", "reason", "timestamp"],
+  "required": ["taskId", "traceId", "state", "decision", "reason", "timestamp"],
   "properties": {
     "taskId": { "type": "string", "minLength": 1 },
+    "traceId": { "type": "string", "minLength": 1 },
     "state": { "type": "string", "enum": ["draft", "debate", "review", "approved", "merged", "rejected"] },
     "decision": { "type": "string", "enum": ["approve", "reject", "request_changes"] },
     "reason": { "type": "string", "minLength": 1 },

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -37,6 +37,7 @@ interface Policy {
 }
 
 const taskId = process.env.TASK_ID || `task-${Date.now()}`;
+const traceId = process.env.TRACE_ID || `${taskId}-${Math.random().toString(36).slice(2, 10)}`;
 const projectDir = process.env.PROJECT_DIR || process.cwd();
 const profile = (process.env.ORCH_PROFILE as OrchestratorProfile) || "strict";
 const workspaceDir = join(projectDir, "_workspace");
@@ -58,11 +59,11 @@ const agentTimeoutMs = (policy.agent_runtime?.timeout_seconds ?? 60) * 1000;
 const agentApiKeyEnv = policy.agent_runtime?.api_key_env || "ORCH_AGENT_API_KEY";
 
 function stateLog(from: string | null, to: string, actor: string): void {
-  appendFileSync(join(logsDir, "state-transitions.jsonl"), JSON.stringify({ taskId, from, to, actor, at: new Date().toISOString() }) + "\n");
+  appendFileSync(join(logsDir, "state-transitions.jsonl"), JSON.stringify({ taskId, traceId, from, to, actor, at: new Date().toISOString() }) + "\n");
 }
 
 function auditLog(event: Record<string, unknown>): void {
-  appendFileSync(join(logsDir, "audit-events.jsonl"), JSON.stringify({ taskId, at: new Date().toISOString(), ...event }) + "\n");
+  appendFileSync(join(logsDir, "audit-events.jsonl"), JSON.stringify({ taskId, traceId, at: new Date().toISOString(), ...event }) + "\n");
 }
 
 function runCmd(cmd: string, timeoutMs: number): boolean {
@@ -444,6 +445,7 @@ async function main(): Promise<void> {
 
   const decision = {
     taskId,
+    traceId,
     state: finalState,
     decision: approved ? "approve" : "request_changes",
     reason: approved ? "workers and quality gate passed" : "worker/check/review gate failed",
@@ -461,6 +463,7 @@ async function main(): Promise<void> {
     JSON.stringify(
       {
         taskId,
+        traceId,
         profile,
         state: finalState,
         workerPass: finalWorkerReports.every((report) => report.risks.length === 0),


### PR DESCRIPTION
## 변경 사항
- decision.json에 	raceId 필드를 추가했습니다.
- 오케스트레이터 stdout/감사로그/상태로그에 동일 traceId를 기록합니다.
- gate PR 코멘트에 	race id, 	ask id를 노출합니다.
- 운영 문서에 traceId 추적 규칙을 반영했습니다.

## 검증
- 
pm run orch:run 통과
- _workspace/decision.json에서 traceId 확인
