### PR TITLE
feat: Reviewer fail-fast 필수항목 판정 및 gate 가시화

### DIFF
--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -69,6 +69,8 @@ jobs:
               `- decision: ${d.decision}`,
               `- reason: ${d.reason}`,
               s ? `- total score: ${s.total}` : '- total score: n/a',
+              s ? `- required failed: ${(Array.isArray(s.required_failed) && s.required_failed.length > 0) ? s.required_failed.join(', ') : 'none'}` : '- required failed: n/a',
+              s ? `- fail-fast triggered: ${Boolean(s.fail_fast_triggered)}` : '- fail-fast triggered: n/a',
               `- request change codes: ${codes}`,
               `- next actions: ${nextActions}`
             ].join('\n');

--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -62,6 +62,10 @@
 - 실패 시 `decision.json.requestChangeCodes`에 구조화 원인 코드를 기록한다.
 - 예: `WORKER_BACKEND_FAILED`, `CHECK_TESTS_FAILED`, `REMOTE_RUNTIME_UNAVAILABLE`
 
+## Reviewer fail-fast
+- `review-rules*.yaml`의 `required.<metric>.fail_fast: true`인 항목이 기준 미달이면 총점과 무관하게 즉시 `reject`한다.
+- 결과는 `scorecard.required_failed`, `scorecard.fail_fast_triggered`에 기록된다.
+
 ## 실행 예시
 1. strict 기본 검증
 - `set ORCH_PROFILE=strict && npm run orch:run`

--- a/ops/workflow/contracts/review_scorecard.json
+++ b/ops/workflow/contracts/review_scorecard.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ReviewScorecard",
   "type": "object",
-  "required": ["taskId", "scores", "required_pass", "total", "verdict", "timestamp"],
+  "required": ["taskId", "scores", "required_pass", "required_failed", "fail_fast_triggered", "total", "verdict", "timestamp"],
   "properties": {
     "taskId": { "type": "string", "minLength": 1 },
     "scores": {
@@ -17,6 +17,11 @@
       "additionalProperties": false
     },
     "required_pass": { "type": "boolean" },
+    "required_failed": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["tests", "style", "security", "performance"] }
+    },
+    "fail_fast_triggered": { "type": "boolean" },
     "total": { "type": "number", "minimum": 0, "maximum": 100 },
     "verdict": { "type": "string", "enum": ["approve", "reject"] },
     "notes": { "type": "array", "items": { "type": "string" } },

--- a/ops/workflow/review-rules.baseline.yaml
+++ b/ops/workflow/review-rules.baseline.yaml
@@ -7,6 +7,7 @@ weights:
 required:
   tests:
     min: 70
+    fail_fast: true
 cutoff:
   total_min: 70
 decision_map:

--- a/ops/workflow/review-rules.yaml
+++ b/ops/workflow/review-rules.yaml
@@ -7,8 +7,10 @@ weights:
 required:
   tests:
     min: 80
+    fail_fast: true
   security:
     min: 70
+    fail_fast: true
 cutoff:
   total_min: 75
 decision_map:

--- a/tools/orchestrator/score.ts
+++ b/tools/orchestrator/score.ts
@@ -4,7 +4,7 @@ import type { CheckResult, CheckName } from "./checks";
 
 interface Rules {
   weights: Record<CheckName, number>;
-  required: Partial<Record<CheckName, { min: number }>>;
+  required: Partial<Record<CheckName, { min: number; fail_fast?: boolean }>>;
   cutoff: { total_min: number };
 }
 
@@ -12,6 +12,8 @@ export interface Scorecard {
   taskId: string;
   scores: Record<CheckName, number>;
   required_pass: boolean;
+  required_failed: CheckName[];
+  fail_fast_triggered: boolean;
   total: number;
   verdict: "approve" | "reject";
   notes: string[];
@@ -42,19 +44,35 @@ export function buildScorecard(taskId: string, checks: CheckResult[], rules: Rul
     scores.performance * rules.weights.performance
   ).toFixed(2));
 
-  const requiredPass = Object.entries(rules.required).every(([key, value]) => {
+  const requiredFailed = Object.entries(rules.required)
+    .filter(([key, value]) => {
+      const metric = key as CheckName;
+      return scores[metric] < (value?.min ?? 0);
+    })
+    .map(([key]) => key as CheckName);
+  const requiredPass = requiredFailed.length === 0;
+  const failFastTriggered = Object.entries(rules.required).some(([key, value]) => {
     const metric = key as CheckName;
-    return scores[metric] >= (value?.min ?? 0);
+    return Boolean(value?.fail_fast) && scores[metric] < (value?.min ?? 0);
   });
 
-  const pass = total >= rules.cutoff.total_min && requiredPass;
+  const pass = !failFastTriggered && total >= rules.cutoff.total_min && requiredPass;
+  const notes = pass
+    ? ["review rules satisfied"]
+    : [
+        "review rules not satisfied",
+        requiredFailed.length > 0 ? `required_failed=${requiredFailed.join(",")}` : "required_failed=none",
+        failFastTriggered ? "fail_fast_triggered=true" : "fail_fast_triggered=false"
+      ];
   return {
     taskId,
     scores,
     required_pass: requiredPass,
+    required_failed: requiredFailed,
+    fail_fast_triggered: failFastTriggered,
     total,
     verdict: pass ? "approve" : "reject",
-    notes: pass ? ["review rules satisfied"] : ["review rules not satisfied"],
+    notes,
     timestamp: new Date().toISOString()
   };
 }


### PR DESCRIPTION
## 변경 사항
- 리뷰 규칙 equired.*.fail_fast 지원 추가
- fail-fast 항목 미달 시 총점과 무관하게 즉시 reject
- scorecard에 equired_failed, ail_fast_triggered 필드 추가
- gate PR 코멘트에 equired failed, ail-fast triggered 노출
- 운영 문서에 fail-fast 정책 반영

## 검증
- 
pm run orch:run 통과
- _workspace/scorecard.json에서 새 필드 반영 확인
