### PR TITLE
feat: requestChangeCodes 기반 remediation 가이드 자동 생성

### DIFF
--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -55,11 +55,17 @@ jobs:
             const s = fs.existsSync('_workspace/scorecard.json')
               ? JSON.parse(fs.readFileSync('_workspace/scorecard.json','utf8'))
               : null;
+            const r = fs.existsSync('_workspace/remediation.json')
+              ? JSON.parse(fs.readFileSync('_workspace/remediation.json','utf8'))
+              : null;
             const codes = Array.isArray(d.requestChangeCodes) && d.requestChangeCodes.length > 0
               ? d.requestChangeCodes.join(', ')
               : 'none';
             const nextActions = Array.isArray(d.nextActions) && d.nextActions.length > 0
               ? d.nextActions.join(' | ')
+              : 'n/a';
+            const topActions = r && Array.isArray(r.actions)
+              ? r.actions.slice(0, 3).map((a) => `[${a.code}] ${a.action} (${a.owner})`).join(' | ')
               : 'n/a';
             const body = [
               '### Orchestration Gate Result',
@@ -72,7 +78,8 @@ jobs:
               s ? `- required failed: ${(Array.isArray(s.required_failed) && s.required_failed.length > 0) ? s.required_failed.join(', ') : 'none'}` : '- required failed: n/a',
               s ? `- fail-fast triggered: ${Boolean(s.fail_fast_triggered)}` : '- fail-fast triggered: n/a',
               `- request change codes: ${codes}`,
-              `- next actions: ${nextActions}`
+              `- next actions: ${nextActions}`,
+              `- remediation (top 3): ${topActions}`
             ].join('\n');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -23,6 +23,7 @@
 
 ## 운영 수칙
 - 오케스트레이션 결과는 `_workspace/decision.json`, `_workspace/scorecard.json`, `_workspace/logs/*.jsonl`로 추적한다.
+- 실패 시 `_workspace/remediation.json`에 `requestChangeCodes` 기반 수정 가이드(담당/액션)가 생성된다.
 - 각 실행에는 `traceId`가 발급되며, `decision.json`/감사 로그/PR gate 코멘트에 동일하게 기록된다.
 - `request_changes` 또는 `rejected` 시 원인 워커 리포트(`_workspace/reports/*.json`)를 우선 확인한다.
 - 실패가 발생하면 정책(`ops/workflow/policy.yaml`)의 `debate.max_rounds` 범위 내에서 1회 재토론/재실행 후 최종 판정한다.

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -194,6 +194,15 @@ type RequestChangeCode =
   | "CHECK_UNKNOWN_FAILED"
   | "REMOTE_RUNTIME_UNAVAILABLE";
 
+interface RemediationPlan {
+  taskId: string;
+  traceId: string;
+  createdAt: string;
+  decision: "approve" | "request_changes";
+  requestChangeCodes: RequestChangeCode[];
+  actions: Array<{ code: RequestChangeCode; action: string; owner: WorkerRole | "reviewer" | "manager" }>;
+}
+
 function planForRole(role: WorkerRole, summary: string, isFail: boolean): WorkerReport["executionPlan"] {
   if (role === "backend-dev") {
     return {
@@ -246,6 +255,30 @@ function requestChangeCodesFromFailures(
     codes.add("REMOTE_RUNTIME_UNAVAILABLE");
   }
   return [...codes];
+}
+
+function remediationActionForCode(code: RequestChangeCode): { action: string; owner: WorkerRole | "reviewer" | "manager" } {
+  if (code === "WORKER_BACKEND_FAILED") return { action: "백엔드 빌드/계약 오류 수정 후 `npm run build:backend` 재실행", owner: "backend-dev" };
+  if (code === "WORKER_FRONTEND_FAILED") return { action: "프론트 빌드 오류 수정 후 `npm run build:frontend` 재실행", owner: "frontend-dev" };
+  if (code === "WORKER_TEST_FAILED") return { action: "실패 테스트 원인 수정 후 `npm run test:backend:clean` 재실행", owner: "test-engineer" };
+  if (code === "WORKER_DOCS_FAILED") return { action: "문서 변경 누락/불일치 점검 후 docs 업데이트", owner: "docs-writer" };
+  if (code === "CHECK_TESTS_FAILED") return { action: "테스트 실패 로그 우선 분석 후 회귀 수정", owner: "test-engineer" };
+  if (code === "CHECK_STYLE_FAILED") return { action: "스타일/정적검사 실패 항목 수정 후 검증 재실행", owner: "frontend-dev" };
+  if (code === "CHECK_SECURITY_FAILED") return { action: "`npm audit --audit-level=high` 실패 패키지 패치 또는 버전 업", owner: "reviewer" };
+  if (code === "CHECK_PERFORMANCE_FAILED") return { action: "성능 스모크 실패 원인(번들/빌드) 완화 후 재측정", owner: "frontend-dev" };
+  if (code === "REMOTE_RUNTIME_UNAVAILABLE") return { action: "remote 런타임 헬스(`/health`) 확인 후 복구, 필요 시 local 폴백", owner: "manager" };
+  return { action: "알 수 없는 체크 실패 항목 로그 확인 후 담당자 지정", owner: "reviewer" };
+}
+
+function buildRemediationPlan(codes: RequestChangeCode[], approved: boolean): RemediationPlan {
+  return {
+    taskId,
+    traceId,
+    createdAt: new Date().toISOString(),
+    decision: approved ? "approve" : "request_changes",
+    requestChangeCodes: codes,
+    actions: codes.map((code) => ({ code, ...remediationActionForCode(code) }))
+  };
 }
 
 async function callRemoteWorker(role: WorkerRole): Promise<WorkerReport> {
@@ -443,20 +476,23 @@ async function main(): Promise<void> {
   const finalState = approved ? "approved" : "rejected";
   stateLog("review", finalState, "manager");
 
+  const requestChangeCodes = approved ? [] : requestChangeCodesFromFailures(failedWorkers, failedChecks, finalWorkerReports);
   const decision = {
     taskId,
     traceId,
     state: finalState,
     decision: approved ? "approve" : "request_changes",
     reason: approved ? "workers and quality gate passed" : "worker/check/review gate failed",
-    requestChangeCodes: approved ? [] : requestChangeCodesFromFailures(failedWorkers, failedChecks, finalWorkerReports),
+    requestChangeCodes,
     timestamp: new Date().toISOString(),
     nextActions: approved ? ["ready for merge gate"] : [policy.fallback?.on_repeated_failure ?? "fix failures and rerun"]
   };
   validateOrThrow(join(projectDir, "ops/workflow/contracts/manager_decision.json"), decision, "manager decision");
+  const remediation = buildRemediationPlan(requestChangeCodes, approved);
 
   writeFileSync(join(workspaceDir, "scorecard.json"), JSON.stringify(finalScorecard, null, 2));
   writeFileSync(join(workspaceDir, "decision.json"), JSON.stringify(decision, null, 2));
+  writeFileSync(join(workspaceDir, "remediation.json"), JSON.stringify(remediation, null, 2));
   auditLog({ type: "decision", decision: decision.decision, state: finalState });
 
   process.stdout.write(


### PR DESCRIPTION
## 변경 사항
- 오케스트레이터가 _workspace/remediation.json을 생성하도록 추가했습니다.
- equestChangeCodes를 담당자/실행 액션으로 매핑한 가이드(ctions)를 출력합니다.
- gate PR 코멘트에 remediation 상위 3개 액션을 노출합니다.
- 운영 문서에 remediation 산출물 규칙을 반영했습니다.

## 검증
- 
pm run orch:run 통과
- _workspace/remediation.json 생성 확인
