### PR TITLE
feat: requestChangeCodes 기반 부분 자동복구 후 재라운드 실행

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -62,6 +62,7 @@
 ## request_changes 코드 표준
 - 실패 시 `decision.json.requestChangeCodes`에 구조화 원인 코드를 기록한다.
 - 예: `WORKER_BACKEND_FAILED`, `CHECK_TESTS_FAILED`, `REMOTE_RUNTIME_UNAVAILABLE`
+- 재라운드 진입 시 `requestChangeCodes`별 부분 복구 명령(예: 테스트 재실행, 보안 감사, 빌드 스모크)을 자동 실행한 뒤 재판정한다.
 
 ## Reviewer fail-fast
 - `review-rules*.yaml`의 `required.<metric>.fail_fast: true`인 항목이 기준 미달이면 총점과 무관하게 즉시 `reject`한다.

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -257,6 +257,31 @@ function requestChangeCodesFromFailures(
   return [...codes];
 }
 
+function runCodeBasedRecovery(codes: RequestChangeCode[]): Array<{ code: RequestChangeCode; command: string; pass: boolean }> {
+  const commandByCode: Partial<Record<RequestChangeCode, string>> = {
+    WORKER_BACKEND_FAILED: "npm run build:backend",
+    WORKER_FRONTEND_FAILED: "npm run build:frontend",
+    WORKER_TEST_FAILED: "npm run test:backend:clean",
+    CHECK_TESTS_FAILED: "npm run test:backend:clean",
+    CHECK_STYLE_FAILED: "npm run build:frontend",
+    CHECK_SECURITY_FAILED: "npm audit --audit-level=high",
+    CHECK_PERFORMANCE_FAILED: "npm run perf:smoke",
+    REMOTE_RUNTIME_UNAVAILABLE: "npm run orch:checks",
+    CHECK_UNKNOWN_FAILED: "npm run orch:checks"
+  };
+  const uniqueCodes = [...new Set(codes)];
+  const uniqueCommands = new Set<string>();
+  const results: Array<{ code: RequestChangeCode; command: string; pass: boolean }> = [];
+  for (const code of uniqueCodes) {
+    const command = commandByCode[code];
+    if (!command || uniqueCommands.has(command)) continue;
+    uniqueCommands.add(command);
+    const pass = runWithRetry(() => runCmd(command, workerTimeoutMs), workerMaxRetries);
+    results.push({ code, command, pass });
+  }
+  return results;
+}
+
 function remediationActionForCode(code: RequestChangeCode): { action: string; owner: WorkerRole | "reviewer" | "manager" } {
   if (code === "WORKER_BACKEND_FAILED") return { action: "백엔드 빌드/계약 오류 수정 후 `npm run build:backend` 재실행", owner: "backend-dev" };
   if (code === "WORKER_FRONTEND_FAILED") return { action: "프론트 빌드 오류 수정 후 `npm run build:frontend` 재실행", owner: "frontend-dev" };
@@ -447,6 +472,9 @@ async function main(): Promise<void> {
   let finalScorecard = scorecard;
 
   if (shouldRetryRound) {
+    const initialRequestChangeCodes = requestChangeCodesFromFailures(failedWorkers, failedChecks, finalWorkerReports);
+    const recoveryResults = runCodeBasedRecovery(initialRequestChangeCodes);
+    auditLog({ type: "code-based-recovery", requested: initialRequestChangeCodes, results: recoveryResults });
     remediationRound(
       failedWorkers.map((worker) => worker.role),
       failedChecks


### PR DESCRIPTION
## 변경 사항
- 재라운드 진입 전 equestChangeCodes를 계산하고 코드별 부분 복구 명령을 자동 실행합니다.
- 복구 실행 결과는 audit log(code-based-recovery)로 기록됩니다.
- 운영 문서에 코드 기반 자동 복구 규칙을 추가했습니다.

## 검증
- 
pm run orch:run 통과
