### PR TITLE
feat: 오케스트레이션 운영 리포트 CLI 추가

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -75,6 +75,10 @@
 2. 체크만 빠르게 확인
 - `set ORCH_PROFILE=strict && npm run orch:checks`
 
+2-1. 운영 요약 리포트
+- `npm run orch:report`
+- 출력: 최신 decision(traceId 포함), 상태 분포, requestChangeCodes Top N, 자동복구 성공률
+
 3. 로컬 빠른 확인(예외)
 - `set ORCH_PROFILE=baseline && npm run orch:run`
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "npm run build:frontend && npm run build:backend",
     "orch:run": "tsx tools/orchestrator/run.ts",
     "orch:checks": "tsx tools/orchestrator/checks.ts",
+    "orch:report": "tsx tools/orchestrator/report.ts",
     "agent-runtime:start": "tsx tools/agent-runtime/server.ts",
     "lint": "npm --workspace @myway/backend run build && npm --workspace @myway/frontend run build",
     "perf:smoke": "npm run build:frontend"

--- a/tools/orchestrator/report.ts
+++ b/tools/orchestrator/report.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type JsonObject = Record<string, unknown>;
+
+interface AuditEvent extends JsonObject {
+  taskId?: string;
+  traceId?: string;
+  at?: string;
+  type?: string;
+  decision?: string;
+  state?: string;
+  requested?: string[];
+  results?: Array<{ code: string; command: string; pass: boolean }>;
+}
+
+function readJsonl(path: string): AuditEvent[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf-8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as AuditEvent;
+      } catch {
+        return {};
+      }
+    });
+}
+
+function topN(entries: Map<string, number>, n: number): Array<[string, number]> {
+  return [...entries.entries()].sort((a, b) => b[1] - a[1]).slice(0, n);
+}
+
+function main(): void {
+  const projectDir = process.env.PROJECT_DIR || process.cwd();
+  const workspaceDir = join(projectDir, "_workspace");
+  const logsDir = join(workspaceDir, "logs");
+  const auditPath = join(logsDir, "audit-events.jsonl");
+  const audit = readJsonl(auditPath);
+
+  const decisions = audit.filter((e) => e.type === "decision");
+  const recoveries = audit.filter((e) => e.type === "code-based-recovery");
+  const reruns = audit.filter((e) => e.type === "remediation-round");
+
+  const stateCount = new Map<string, number>();
+  for (const d of decisions) {
+    const state = String(d.state || "unknown");
+    stateCount.set(state, (stateCount.get(state) || 0) + 1);
+  }
+
+  const codeCount = new Map<string, number>();
+  for (const recovery of recoveries) {
+    const requested = Array.isArray(recovery.requested) ? recovery.requested : [];
+    for (const code of requested) {
+      codeCount.set(String(code), (codeCount.get(String(code)) || 0) + 1);
+    }
+  }
+
+  let recoveryAttempted = 0;
+  let recoveryPassed = 0;
+  for (const recovery of recoveries) {
+    const results = Array.isArray(recovery.results) ? recovery.results : [];
+    for (const r of results) {
+      recoveryAttempted += 1;
+      if (r && r.pass) recoveryPassed += 1;
+    }
+  }
+
+  const latest = decisions.slice(-1)[0];
+  const latestSummary = latest
+    ? {
+        taskId: latest.taskId || "n/a",
+        traceId: latest.traceId || "n/a",
+        state: latest.state || "n/a",
+        at: latest.at || "n/a"
+      }
+    : null;
+
+  const report = {
+    source: auditPath,
+    totals: {
+      events: audit.length,
+      decisions: decisions.length,
+      remediationRounds: reruns.length,
+      codeRecoveries: recoveries.length
+    },
+    latestDecision: latestSummary,
+    stateBreakdown: Object.fromEntries(stateCount.entries()),
+    topRequestChangeCodes: topN(codeCount, 5).map(([code, count]) => ({ code, count })),
+    recoveryStats: {
+      attemptedCommands: recoveryAttempted,
+      passedCommands: recoveryPassed,
+      passRate: recoveryAttempted > 0 ? Number(((recoveryPassed / recoveryAttempted) * 100).toFixed(2)) : null
+    }
+  };
+
+  process.stdout.write(JSON.stringify(report, null, 2));
+}
+
+main();


### PR DESCRIPTION
## 변경 사항
- 
pm run orch:report 명령을 추가했습니다.
- _workspace/logs/audit-events.jsonl 기반으로 운영 요약을 출력합니다.
  - latest decision(traceId 포함)
  - 상태 분포
  - requestChangeCodes Top N
  - 자동복구 성공률
- 운영 문서에 report 실행법을 반영했습니다.

## 검증
- 
pm run orch:run 통과
- 
pm run orch:report 출력 확인
