### PR TITLE
feat: 안전한 auto-fix 옵트인 모드 추가

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -64,6 +64,13 @@
 - 예: `WORKER_BACKEND_FAILED`, `CHECK_TESTS_FAILED`, `REMOTE_RUNTIME_UNAVAILABLE`
 - 재라운드 진입 시 `requestChangeCodes`별 부분 복구 명령(예: 테스트 재실행, 보안 감사, 빌드 스모크)을 자동 실행한 뒤 재판정한다.
 
+## Safe Auto-Fix (옵트인)
+- 기본값 비활성: `ops/workflow/policy.yaml.autofix.enabled: false`
+- 활성화 방법:
+  - 정책 변경: `autofix.enabled: true`, `autofix.mode: safe`
+  - 또는 일회성: `set ORCH_AUTOFIX=1`
+- safe 모드에서는 allowlist 명령만 실행한다(예: `npm audit fix --package-lock-only`).
+
 ## Reviewer fail-fast
 - `review-rules*.yaml`의 `required.<metric>.fail_fast: true`인 항목이 기준 미달이면 총점과 무관하게 즉시 `reject`한다.
 - 결과는 `scorecard.required_failed`, `scorecard.fail_fast_triggered`에 기록된다.

--- a/ops/workflow/policy.yaml
+++ b/ops/workflow/policy.yaml
@@ -15,3 +15,6 @@ agent_runtime:
   endpoint: ""
   timeout_seconds: 60
   api_key_env: ORCH_AGENT_API_KEY
+autofix:
+  enabled: false
+  mode: safe

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -34,6 +34,10 @@ interface Policy {
     timeout_seconds?: number;
     api_key_env?: string;
   };
+  autofix?: {
+    enabled?: boolean;
+    mode?: "safe" | "off";
+  };
 }
 
 const taskId = process.env.TASK_ID || `task-${Date.now()}`;
@@ -57,6 +61,8 @@ const agentMode = (process.env.ORCH_AGENT_MODE as "local" | "remote") || policy.
 const agentEndpoint = process.env.ORCH_AGENT_ENDPOINT || policy.agent_runtime?.endpoint || "";
 const agentTimeoutMs = (policy.agent_runtime?.timeout_seconds ?? 60) * 1000;
 const agentApiKeyEnv = policy.agent_runtime?.api_key_env || "ORCH_AGENT_API_KEY";
+const autofixEnabled = process.env.ORCH_AUTOFIX === "1" || policy.autofix?.enabled === true;
+const autofixMode = policy.autofix?.mode || "off";
 
 function stateLog(from: string | null, to: string, actor: string): void {
   appendFileSync(join(logsDir, "state-transitions.jsonl"), JSON.stringify({ taskId, traceId, from, to, actor, at: new Date().toISOString() }) + "\n");
@@ -282,6 +288,25 @@ function runCodeBasedRecovery(codes: RequestChangeCode[]): Array<{ code: Request
   return results;
 }
 
+function runAutoFix(codes: RequestChangeCode[]): Array<{ code: RequestChangeCode; command: string; pass: boolean }> {
+  if (!autofixEnabled || autofixMode !== "safe") return [];
+  const safeFixByCode: Partial<Record<RequestChangeCode, string>> = {
+    CHECK_SECURITY_FAILED: "npm audit fix --package-lock-only",
+    CHECK_STYLE_FAILED: "npm run build:frontend",
+    CHECK_TESTS_FAILED: "npm run test:backend:clean"
+  };
+  const uniqueCommands = new Set<string>();
+  const results: Array<{ code: RequestChangeCode; command: string; pass: boolean }> = [];
+  for (const code of [...new Set(codes)]) {
+    const command = safeFixByCode[code];
+    if (!command || uniqueCommands.has(command)) continue;
+    uniqueCommands.add(command);
+    const pass = runWithRetry(() => runCmd(command, workerTimeoutMs), workerMaxRetries);
+    results.push({ code, command, pass });
+  }
+  return results;
+}
+
 function remediationActionForCode(code: RequestChangeCode): { action: string; owner: WorkerRole | "reviewer" | "manager" } {
   if (code === "WORKER_BACKEND_FAILED") return { action: "백엔드 빌드/계약 오류 수정 후 `npm run build:backend` 재실행", owner: "backend-dev" };
   if (code === "WORKER_FRONTEND_FAILED") return { action: "프론트 빌드 오류 수정 후 `npm run build:frontend` 재실행", owner: "frontend-dev" };
@@ -473,6 +498,12 @@ async function main(): Promise<void> {
 
   if (shouldRetryRound) {
     const initialRequestChangeCodes = requestChangeCodesFromFailures(failedWorkers, failedChecks, finalWorkerReports);
+    const autofixResults = runAutoFix(initialRequestChangeCodes);
+    if (autofixResults.length > 0) {
+      auditLog({ type: "auto-fix", enabled: true, mode: autofixMode, requested: initialRequestChangeCodes, results: autofixResults });
+    } else {
+      auditLog({ type: "auto-fix", enabled: autofixEnabled, mode: autofixMode, requested: initialRequestChangeCodes, results: [] });
+    }
     const recoveryResults = runCodeBasedRecovery(initialRequestChangeCodes);
     auditLog({ type: "code-based-recovery", requested: initialRequestChangeCodes, results: recoveryResults });
     remediationRound(


### PR DESCRIPTION
## 변경 사항
- 오케스트레이터에 Safe Auto-Fix 옵트인 모드를 추가했습니다.
- 기본 비활성(policy.autofix.enabled: false)이며, 활성화 시 allowlist 명령만 실행합니다.
- 일회성 활성화: ORCH_AUTOFIX=1
- auto-fix 실행 결과는 audit log 	ype=auto-fix로 기록합니다.
- 운영 문서에 활성화/제약 사항을 추가했습니다.

## 검증
- 
pm run orch:run 통과
- 
pm run orch:report 최신 decision 반영 확인
