### PR TITLE
feat: gate 실패 Slack 알림 및 코멘트 always 처리

### DIFF
--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -109,12 +109,13 @@ jobs:
             }
 
       - name: Notify Slack on gate failure
-        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        if: failure()
         uses: actions/github-script@v7
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           script: |
+            if (!process.env.SLACK_WEBHOOK_URL) return;
             const fs = require('fs');
             const d = fs.existsSync('_workspace/decision.json')
               ? JSON.parse(fs.readFileSync('_workspace/decision.json','utf8'))

--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -46,12 +46,14 @@ jobs:
           node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync('_workspace/decision.json','utf8'));if(d.state!=='approved'){console.error('state is not approved:',d.state);process.exit(1);}"
 
       - name: Comment PR with gate result
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const d = JSON.parse(fs.readFileSync('_workspace/decision.json','utf8'));
+            const d = fs.existsSync('_workspace/decision.json')
+              ? JSON.parse(fs.readFileSync('_workspace/decision.json','utf8'))
+              : { traceId: 'n/a', taskId: 'n/a', state: 'unknown', decision: 'unknown', reason: 'decision artifact missing', requestChangeCodes: [], nextActions: [] };
             const s = fs.existsSync('_workspace/scorecard.json')
               ? JSON.parse(fs.readFileSync('_workspace/scorecard.json','utf8'))
               : null;
@@ -105,6 +107,39 @@ jobs:
                 body
               });
             }
+
+      - name: Notify Slack on gate failure
+        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        uses: actions/github-script@v7
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          script: |
+            const fs = require('fs');
+            const d = fs.existsSync('_workspace/decision.json')
+              ? JSON.parse(fs.readFileSync('_workspace/decision.json','utf8'))
+              : { traceId: 'n/a', taskId: 'n/a', state: 'unknown', decision: 'unknown', reason: 'decision artifact missing', requestChangeCodes: [] };
+            const codeText = Array.isArray(d.requestChangeCodes) && d.requestChangeCodes.length > 0
+              ? d.requestChangeCodes.join(', ')
+              : 'none';
+            const pr = context.payload.pull_request;
+            const target = pr ? `PR #${pr.number}` : context.ref;
+            const text = [
+              ':rotating_light: orchestration-gate failed',
+              `repo: ${context.repo.owner}/${context.repo.repo}`,
+              `target: ${target}`,
+              `trace: ${d.traceId || 'n/a'}`,
+              `task: ${d.taskId || 'n/a'}`,
+              `state: ${d.state || 'n/a'} / decision: ${d.decision || 'n/a'}`,
+              `reason: ${d.reason || 'n/a'}`,
+              `codes: ${codeText}`,
+              `run: ${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+            ].join('\n');
+            await fetch(process.env.SLACK_WEBHOOK_URL, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ text })
+            });
 
       - name: Auto-approve PR when gate approved
         if: github.event_name == 'pull_request' && github.base_ref == 'dev'

--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -20,6 +20,7 @@
 - Conversation resolution 완료
 - Gate 코멘트에는 `requestChangeCodes`, `nextActions`가 포함된다.
 - 자동 승인(AI review)은 `dev` 대상 PR에서만 시도한다(`main` 제외).
+- `SLACK_WEBHOOK_URL` GitHub Secret이 설정된 경우 gate 실패 시 Slack 알림을 전송한다.
 
 ## 운영 수칙
 - 오케스트레이션 결과는 `_workspace/decision.json`, `_workspace/scorecard.json`, `_workspace/logs/*.jsonl`로 추적한다.


### PR DESCRIPTION
## 변경 사항
- gate PR 코멘트를 lways()로 변경해 실패 시에도 최신 상태를 남깁니다.
- SLACK_WEBHOOK_URL secret이 설정된 경우 gate 실패 시 Slack으로 알림을 전송합니다.
- decision artifact가 없는 경우도 기본 fallback 메시지로 알림/코멘트가 동작합니다.
- 운영 문서에 Slack secret 설정 내용을 반영했습니다.

## 검증
- 
pm run orch:run 통과
