### PR TITLE
feat: orchestration-gate 실행 아티팩트 자동 업로드

### DIFF
--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -45,6 +45,22 @@ jobs:
         run: |
           node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync('_workspace/decision.json','utf8'));if(d.state!=='approved'){console.error('state is not approved:',d.state);process.exit(1);}"
 
+      - name: Upload orchestration artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: orchestration-artifacts-${{ github.run_id }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            _workspace/decision.json
+            _workspace/scorecard.json
+            _workspace/remediation.json
+            _workspace/logs/audit-events.jsonl
+            _workspace/logs/state-transitions.jsonl
+            _workspace/reports/*.json
+            _workspace/threads/*.jsonl
+
       - name: Comment PR with gate result
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7

--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -26,6 +26,7 @@
 - 오케스트레이션 결과는 `_workspace/decision.json`, `_workspace/scorecard.json`, `_workspace/logs/*.jsonl`로 추적한다.
 - 실패 시 `_workspace/remediation.json`에 `requestChangeCodes` 기반 수정 가이드(담당/액션)가 생성된다.
 - 각 실행에는 `traceId`가 발급되며, `decision.json`/감사 로그/PR gate 코멘트에 동일하게 기록된다.
+- GitHub Actions `orchestration-gate`는 실행마다 핵심 `_workspace` 산출물을 아티팩트로 업로드한다(보관 14일).
 - `request_changes` 또는 `rejected` 시 원인 워커 리포트(`_workspace/reports/*.json`)를 우선 확인한다.
 - 실패가 발생하면 정책(`ops/workflow/policy.yaml`)의 `debate.max_rounds` 범위 내에서 1회 재토론/재실행 후 최종 판정한다.
 - 임시/산출물 파일(`_workspace/`, `.github/.tmp_*`, `backend-spring/target/`)은 커밋하지 않는다.


### PR DESCRIPTION
## 변경 사항
- orchestration-gate에 아티팩트 업로드 스텝을 추가했습니다.
- 성공/실패와 무관하게 _workspace 핵심 파일을 업로드합니다.
- 보관 기간: 14일
- 운영 문서에 아티팩트 보관 규칙을 반영했습니다.

## 검증
- 
pm run orch:run 통과
