### PR TITLE
feat: 운영 리포트 필터 및 Slack 반복실패 에스컬레이션

### DIFF
--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -141,8 +141,20 @@ jobs:
               : 'none';
             const pr = context.payload.pull_request;
             const target = pr ? `PR #${pr.number}` : context.ref;
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'orchestration-gate.yml',
+              branch: context.ref.replace('refs/heads/', ''),
+              per_page: 20
+            });
+            const recentFailures = (runs.data.workflow_runs || [])
+              .filter((r) => r.conclusion === 'failure')
+              .slice(0, 5).length;
+            const escalation = recentFailures >= 3 ? ':fire: repeated failures detected (last5 failures >=3)' : '';
             const text = [
               ':rotating_light: orchestration-gate failed',
+              escalation,
               `repo: ${context.repo.owner}/${context.repo.repo}`,
               `target: ${target}`,
               `trace: ${d.traceId || 'n/a'}`,
@@ -150,6 +162,7 @@ jobs:
               `state: ${d.state || 'n/a'} / decision: ${d.decision || 'n/a'}`,
               `reason: ${d.reason || 'n/a'}`,
               `codes: ${codeText}`,
+              `recent failures(last5): ${recentFailures}`,
               `run: ${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
             ].join('\n');
             await fetch(process.env.SLACK_WEBHOOK_URL, {

--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -86,7 +86,12 @@
 
 2-1. 운영 요약 리포트
 - `npm run orch:report`
+- 기간/Top 필터: `npm run orch:report -- --days 7 --top 10`
 - 출력: 최신 decision(traceId 포함), 상태 분포, requestChangeCodes Top N, 자동복구 성공률
+
+## 실패 알림 에스컬레이션
+- `SLACK_WEBHOOK_URL`가 설정된 경우 gate 실패 시 Slack 알림 전송
+- 최근 5개 실행 중 실패가 3회 이상이면 에스컬레이션 문구(`:fire:`)를 포함한다.
 
 3. 로컬 빠른 확인(예외)
 - `set ORCH_PROFILE=baseline && npm run orch:run`

--- a/tools/orchestrator/report.ts
+++ b/tools/orchestrator/report.ts
@@ -14,6 +14,29 @@ interface AuditEvent extends JsonObject {
   results?: Array<{ code: string; command: string; pass: boolean }>;
 }
 
+function parseArgs(argv: string[]): { days: number | null; top: number } {
+  let days: number | null = null;
+  let top = 5;
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--days") {
+      const raw = argv[i + 1];
+      if (raw && !Number.isNaN(Number(raw))) {
+        days = Number(raw);
+        i += 1;
+      }
+    }
+    if (token === "--top") {
+      const raw = argv[i + 1];
+      if (raw && !Number.isNaN(Number(raw))) {
+        top = Math.max(1, Number(raw));
+        i += 1;
+      }
+    }
+  }
+  return { days, top };
+}
+
 function readJsonl(path: string): AuditEvent[] {
   if (!existsSync(path)) return [];
   return readFileSync(path, "utf-8")
@@ -34,11 +57,18 @@ function topN(entries: Map<string, number>, n: number): Array<[string, number]> 
 }
 
 function main(): void {
+  const { days, top } = parseArgs(process.argv.slice(2));
   const projectDir = process.env.PROJECT_DIR || process.cwd();
   const workspaceDir = join(projectDir, "_workspace");
   const logsDir = join(workspaceDir, "logs");
   const auditPath = join(logsDir, "audit-events.jsonl");
-  const audit = readJsonl(auditPath);
+  const allAudit = readJsonl(auditPath);
+  const cutoffMs = days !== null ? Date.now() - days * 24 * 60 * 60 * 1000 : null;
+  const audit = allAudit.filter((e) => {
+    if (cutoffMs === null) return true;
+    const at = e.at ? Date.parse(String(e.at)) : Number.NaN;
+    return Number.isFinite(at) && at >= cutoffMs;
+  });
 
   const decisions = audit.filter((e) => e.type === "decision");
   const recoveries = audit.filter((e) => e.type === "code-based-recovery");
@@ -88,12 +118,13 @@ function main(): void {
     },
     latestDecision: latestSummary,
     stateBreakdown: Object.fromEntries(stateCount.entries()),
-    topRequestChangeCodes: topN(codeCount, 5).map(([code, count]) => ({ code, count })),
+    topRequestChangeCodes: topN(codeCount, top).map(([code, count]) => ({ code, count })),
     recoveryStats: {
       attemptedCommands: recoveryAttempted,
       passedCommands: recoveryPassed,
       passRate: recoveryAttempted > 0 ? Number(((recoveryPassed / recoveryAttempted) * 100).toFixed(2)) : null
-    }
+    },
+    filters: { days, top }
   };
 
   process.stdout.write(JSON.stringify(report, null, 2));


### PR DESCRIPTION
## 변경 사항
- orch:report에 필터 인자 추가
  - --days <N>: 최근 N일
  - --top <N>: Top N 코드 집계
- gate 실패 Slack 알림에 최근 실패 횟수(last5) 포함
- 최근 5회 실패 3회 이상 시 에스컬레이션 문구(:fire:) 추가
- 운영 문서 반영

## 검증
- 
pm run orch:report -- --days 7 --top 10 확인
- 
pm run orch:run 통과
