### PR TITLE
feat: 브랜치별 오케스트레이션 리뷰 룰 분리(main 강화)

### DIFF
--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -37,6 +37,7 @@ jobs:
         run: npm run orch:run
         env:
           ORCH_PROFILE: strict
+          ORCH_TARGET_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
 
       - name: Ensure decision artifact exists
         run: test -f _workspace/decision.json

--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -10,6 +10,9 @@
 ## strict 사용 기준
 - PR 검증, 병합 전 최종 검증, 릴리즈 직전 검증에 사용한다.
 - 필수: 백엔드 테스트(`npm run test:backend`) 통과, 오케스트레이터 최종 상태 `approved`.
+- 브랜치별 룰:
+  - `dev` -> `ops/workflow/review-rules.yaml`
+  - `main` -> `ops/workflow/review-rules.main.yaml` (더 엄격)
 
 ## baseline 사용 기준
 - 로컬 빠른 확인 또는 일시적 환경 제약(예: 외부 의존 서비스 장애)에서만 사용한다.

--- a/ops/workflow/review-rules.main.yaml
+++ b/ops/workflow/review-rules.main.yaml
@@ -1,0 +1,21 @@
+version: 1
+weights:
+  tests: 0.45
+  style: 0.15
+  security: 0.25
+  performance: 0.15
+required:
+  tests:
+    min: 85
+    fail_fast: true
+  security:
+    min: 85
+    fail_fast: true
+  performance:
+    min: 70
+    fail_fast: true
+cutoff:
+  total_min: 82
+decision_map:
+  pass: approve
+  fail: reject

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -44,6 +44,7 @@ const taskId = process.env.TASK_ID || `task-${Date.now()}`;
 const traceId = process.env.TRACE_ID || `${taskId}-${Math.random().toString(36).slice(2, 10)}`;
 const projectDir = process.env.PROJECT_DIR || process.cwd();
 const profile = (process.env.ORCH_PROFILE as OrchestratorProfile) || "strict";
+const targetBranch = process.env.ORCH_TARGET_BRANCH || "dev";
 const workspaceDir = join(projectDir, "_workspace");
 const logsDir = join(workspaceDir, "logs");
 const threadsDir = join(workspaceDir, "threads");
@@ -481,7 +482,9 @@ async function main(): Promise<void> {
   const rulesPath =
     profile === "baseline"
       ? join(projectDir, "ops/workflow/review-rules.baseline.yaml")
-      : join(projectDir, "ops/workflow/review-rules.yaml");
+      : targetBranch === "main"
+        ? join(projectDir, "ops/workflow/review-rules.main.yaml")
+        : join(projectDir, "ops/workflow/review-rules.yaml");
   const rules = loadRules(rulesPath);
   const scorecard = buildScorecard(taskId, checksOutput.checks, rules);
   validateOrThrow(join(projectDir, "ops/workflow/contracts/review_scorecard.json"), scorecard, "review scorecard");
@@ -560,6 +563,7 @@ async function main(): Promise<void> {
         taskId,
         traceId,
         profile,
+        targetBranch,
         state: finalState,
         workerPass: finalWorkerReports.every((report) => report.risks.length === 0),
         checksPass: checksOutput.pass,


### PR DESCRIPTION
## 변경 사항
- main 대상 전용 리뷰 룰 파일 ops/workflow/review-rules.main.yaml 추가
- 오케스트레이터가 ORCH_TARGET_BRANCH에 따라 룰을 선택하도록 변경
  - baseline -> baseline rules
  - strict + main -> main rules
  - strict + dev -> default strict rules
- gate workflow에서 ORCH_TARGET_BRANCH를 자동 주입
- 운영 문서에 브랜치별 룰 정책 반영

## 검증
- ORCH_TARGET_BRANCH=dev npm run orch:run 통과
- ORCH_TARGET_BRANCH=main npm run orch:run 통과
