### PR TITLE
feat(orchestration): reviewer 임시 waiver 정책 추가

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -80,6 +80,18 @@
 - `review-rules*.yaml`의 `required.<metric>.fail_fast: true`인 항목이 기준 미달이면 총점과 무관하게 즉시 `reject`한다.
 - 결과는 `scorecard.required_failed`, `scorecard.fail_fast_triggered`에 기록된다.
 
+## Temporary waiver(예외 승인)
+- 파일: `ops/workflow/review-waivers.yaml`
+- 목적: 제한된 기간 동안 특정 metric fail-fast/required 기준을 예외 처리한다.
+- 필드:
+  - `metric`: `tests | style | security | performance`
+  - `branch`(선택): 지정 시 해당 브랜치에서만 적용
+  - `expires_at`: ISO-8601 만료 시각(만료 후 자동 무효)
+  - `reason`, `approved_by`: 감사 추적용 필수 메타데이터
+- 반영 결과:
+  - `scorecard.waived_required`에 예외 적용 metric 기록
+  - `scorecard.waiver_notes`에 사유/승인자/만료 시각 기록
+
 ## 실행 예시
 1. strict 기본 검증
 - `set ORCH_PROFILE=strict && npm run orch:run`

--- a/ops/workflow/contracts/review_scorecard.json
+++ b/ops/workflow/contracts/review_scorecard.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ReviewScorecard",
   "type": "object",
-  "required": ["taskId", "scores", "required_pass", "required_failed", "fail_fast_triggered", "total", "verdict", "timestamp"],
+  "required": ["taskId", "scores", "required_pass", "required_failed", "waived_required", "waiver_notes", "fail_fast_triggered", "total", "verdict", "timestamp"],
   "properties": {
     "taskId": { "type": "string", "minLength": 1 },
     "scores": {
@@ -20,6 +20,14 @@
     "required_failed": {
       "type": "array",
       "items": { "type": "string", "enum": ["tests", "style", "security", "performance"] }
+    },
+    "waived_required": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["tests", "style", "security", "performance"] }
+    },
+    "waiver_notes": {
+      "type": "array",
+      "items": { "type": "string" }
     },
     "fail_fast_triggered": { "type": "boolean" },
     "total": { "type": "number", "minimum": 0, "maximum": 100 },

--- a/ops/workflow/review-waivers.yaml
+++ b/ops/workflow/review-waivers.yaml
@@ -1,0 +1,8 @@
+version: 1
+waivers: []
+# example:
+# - metric: tests
+#   branch: dev
+#   expires_at: "2026-05-31T23:59:59+09:00"
+#   reason: "temporary external dependency outage"
+#   approved_by: "tech-lead"

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
 import YAML from "yaml";
 import { runChecks, type OrchestratorProfile } from "./checks";
 import { validateOrThrow } from "./validate";
-import { buildScorecard, loadRules } from "./score";
+import { buildScorecard, loadRules, loadWaivers } from "./score";
 
 type WorkerRole = "backend-dev" | "frontend-dev" | "test-engineer" | "docs-writer";
 
@@ -485,8 +485,10 @@ async function main(): Promise<void> {
       : targetBranch === "main"
         ? join(projectDir, "ops/workflow/review-rules.main.yaml")
         : join(projectDir, "ops/workflow/review-rules.yaml");
+  const waiversPath = join(projectDir, "ops/workflow/review-waivers.yaml");
   const rules = loadRules(rulesPath);
-  const scorecard = buildScorecard(taskId, checksOutput.checks, rules);
+  const waivers = existsSync(waiversPath) ? loadWaivers(waiversPath) : { waivers: [] };
+  const scorecard = buildScorecard(taskId, checksOutput.checks, rules, { waivers, branch: targetBranch });
   validateOrThrow(join(projectDir, "ops/workflow/contracts/review_scorecard.json"), scorecard, "review scorecard");
 
   let failedWorkers = workerReports
@@ -529,7 +531,7 @@ async function main(): Promise<void> {
     checksOutput = rerunChecks;
     failedWorkers = finalWorkerReports.filter((report) => report.risks.length > 0).map((report) => ({ role: report.role, risks: report.risks }));
     failedChecks = checksOutput.checks.filter((check) => !check.pass).map((check) => check.name);
-    finalScorecard = buildScorecard(taskId, checksOutput.checks, rules);
+    finalScorecard = buildScorecard(taskId, checksOutput.checks, rules, { waivers, branch: targetBranch });
     validateOrThrow(join(projectDir, "ops/workflow/contracts/review_scorecard.json"), finalScorecard, "review scorecard rerun");
     auditLog({ type: "remediation-round", rerun: 1, workerFailures: failedWorkers, checkFailures: failedChecks });
   }

--- a/tools/orchestrator/score.ts
+++ b/tools/orchestrator/score.ts
@@ -1,4 +1,4 @@
-﻿import { readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import YAML from "yaml";
 import type { CheckResult, CheckName } from "./checks";
 
@@ -8,11 +8,25 @@ interface Rules {
   cutoff: { total_min: number };
 }
 
+interface WaiverItem {
+  metric: CheckName;
+  branch?: string;
+  expires_at: string;
+  reason: string;
+  approved_by: string;
+}
+
+interface WaiverConfig {
+  waivers?: WaiverItem[];
+}
+
 export interface Scorecard {
   taskId: string;
   scores: Record<CheckName, number>;
   required_pass: boolean;
   required_failed: CheckName[];
+  waived_required: CheckName[];
+  waiver_notes: string[];
   fail_fast_triggered: boolean;
   total: number;
   verdict: "approve" | "reject";
@@ -24,12 +38,21 @@ export function loadRules(path: string): Rules {
   return YAML.parse(readFileSync(path, "utf-8")) as Rules;
 }
 
+export function loadWaivers(path: string): WaiverConfig {
+  return YAML.parse(readFileSync(path, "utf-8")) as WaiverConfig;
+}
+
 function metricScore(check: CheckResult): number {
   if (check.skipped) return 70;
   return check.pass ? 90 : 40;
 }
 
-export function buildScorecard(taskId: string, checks: CheckResult[], rules: Rules): Scorecard {
+export function buildScorecard(
+  taskId: string,
+  checks: CheckResult[],
+  rules: Rules,
+  opts?: { waivers?: WaiverConfig; branch?: string; nowIso?: string }
+): Scorecard {
   const scores = {
     tests: metricScore(checks.find((c) => c.name === "tests")!),
     style: metricScore(checks.find((c) => c.name === "style")!),
@@ -44,16 +67,27 @@ export function buildScorecard(taskId: string, checks: CheckResult[], rules: Rul
     scores.performance * rules.weights.performance
   ).toFixed(2));
 
-  const requiredFailed = Object.entries(rules.required)
+  const nowMs = Date.parse(opts?.nowIso || new Date().toISOString());
+  const branch = opts?.branch || "dev";
+  const activeWaivers = (opts?.waivers?.waivers || []).filter((w) => {
+    const expireMs = Date.parse(w.expires_at);
+    const branchMatch = !w.branch || w.branch === branch;
+    return branchMatch && Number.isFinite(expireMs) && expireMs >= nowMs;
+  });
+  const waivedRequired = new Set<CheckName>(activeWaivers.map((w) => w.metric));
+  const waiverNotes = activeWaivers.map((w) => `${w.metric}:${w.reason} (by ${w.approved_by}, until ${w.expires_at})`);
+
+  const requiredFailedRaw = Object.entries(rules.required)
     .filter(([key, value]) => {
       const metric = key as CheckName;
       return scores[metric] < (value?.min ?? 0);
     })
     .map(([key]) => key as CheckName);
+  const requiredFailed = requiredFailedRaw.filter((metric) => !waivedRequired.has(metric));
   const requiredPass = requiredFailed.length === 0;
   const failFastTriggered = Object.entries(rules.required).some(([key, value]) => {
     const metric = key as CheckName;
-    return Boolean(value?.fail_fast) && scores[metric] < (value?.min ?? 0);
+    return Boolean(value?.fail_fast) && scores[metric] < (value?.min ?? 0) && !waivedRequired.has(metric);
   });
 
   const pass = !failFastTriggered && total >= rules.cutoff.total_min && requiredPass;
@@ -69,6 +103,8 @@ export function buildScorecard(taskId: string, checks: CheckResult[], rules: Rul
     scores,
     required_pass: requiredPass,
     required_failed: requiredFailed,
+    waived_required: [...waivedRequired],
+    waiver_notes: waiverNotes,
     fail_fast_triggered: failFastTriggered,
     total,
     verdict: pass ? "approve" : "reject",


### PR DESCRIPTION
# 변경 요약
오케스트레이션 reviewer 규칙에 시간/브랜치 기반 임시 waiver(예외 승인) 정책을 추가했습니다.

## 배경
fail-fast/required 규칙은 품질 게이트에 유효하지만, 외부 의존 장애 같은 단기 이슈에 대한 운영상 예외 통로가 필요했습니다.

## 변경 내용
- `ops/workflow/review-waivers.yaml` 신규 추가(waiver 목록/만료/승인자 메타데이터)
- `tools/orchestrator/score.ts`에 waiver 로딩/적용 로직 추가
  - 만료 시각(`expires_at`) 및 브랜치(`branch`) 조건으로 활성 waiver 필터링
  - `required_failed`/`fail_fast` 판정에서 waiver metric 제외
  - `scorecard.waived_required`, `scorecard.waiver_notes` 기록
- `tools/orchestrator/run.ts`에서 waiver 파일 로드 및 `buildScorecard`로 전달
- `ops/workflow/contracts/review_scorecard.json` 스키마에 waiver 필드 반영
- 운영 문서(`docs/project/22-orchestration-operations.md`)에 waiver 정책/운영 기준 추가

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- waiver 만료/브랜치 조건이 의도대로 필터링되는지
- fail-fast 강제 규칙이 waiver된 metric에는 적용되지 않는지
- scorecard 스키마와 런타임 출력 필드가 일치하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
