### PR TITLE
feat(orchestration): 세션 기반 토론 런타임 + waiver 거버넌스

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -50,6 +50,14 @@
 - 요청 필드: `taskId`, `profile`, `optionA`, `optionB`, `optionC(선택)`
 - 응답 필드: `chosen(A|B|C)`, `rationale`, `messages[]`
 
+3. 세션 기반 토론(권장)
+- `POST {ORCH_AGENT_ENDPOINT}/debate/sessions/open`
+- `POST {ORCH_AGENT_ENDPOINT}/debate/sessions/message`
+- `POST {ORCH_AGENT_ENDPOINT}/debate/sessions/decide`
+- `GET  {ORCH_AGENT_ENDPOINT}/debate/sessions/{sessionId}`
+- `POST {ORCH_AGENT_ENDPOINT}/debate/sessions/{sessionId}` (close)
+- 오케스트레이터는 remote 모드에서 위 API를 우선 사용하고, 미지원 런타임이면 `/debate/round`로 자동 폴백한다.
+
 ## 로컬 에이전트 런타임 서버 실행
 1. 서버 시작
 - `npm run agent-runtime:start`
@@ -82,12 +90,19 @@
 
 ## Temporary waiver(예외 승인)
 - 파일: `ops/workflow/review-waivers.yaml`
+- 거버넌스: `ops/workflow/waiver-governance.yaml`
 - 목적: 제한된 기간 동안 특정 metric fail-fast/required 기준을 예외 처리한다.
 - 필드:
   - `metric`: `tests | style | security | performance`
   - `branch`(선택): 지정 시 해당 브랜치에서만 적용
   - `expires_at`: ISO-8601 만료 시각(만료 후 자동 무효)
   - `reason`, `approved_by`: 감사 추적용 필수 메타데이터
+  - `ticket`: 거버넌스에서 요구 시 필수
+- 거버넌스 규칙:
+  - `require_ticket`: 티켓 번호 필수 여부
+  - `allowed_branches`: waiver 적용 허용 브랜치
+  - `allowed_approvers`: 승인 가능 사용자/역할
+  - `max_duration_hours`: metric별 최대 유효 기간
 - 반영 결과:
   - `scorecard.waived_required`에 예외 적용 metric 기록
   - `scorecard.waiver_notes`에 사유/승인자/만료 시각 기록

--- a/ops/workflow/review-waivers.yaml
+++ b/ops/workflow/review-waivers.yaml
@@ -6,3 +6,4 @@ waivers: []
 #   expires_at: "2026-05-31T23:59:59+09:00"
 #   reason: "temporary external dependency outage"
 #   approved_by: "tech-lead"
+#   ticket: "OPS-123"

--- a/ops/workflow/waiver-governance.yaml
+++ b/ops/workflow/waiver-governance.yaml
@@ -1,0 +1,12 @@
+version: 1
+require_ticket: true
+allowed_branches:
+  - dev
+allowed_approvers:
+  - tech-lead
+  - platform-owner
+max_duration_hours:
+  tests: 72
+  style: 72
+  security: 24
+  performance: 48

--- a/tools/agent-runtime/server.ts
+++ b/tools/agent-runtime/server.ts
@@ -22,6 +22,23 @@ interface DebateRoundRequest {
   optionC?: string;
 }
 
+interface DebateSessionOpenRequest {
+  taskId: string;
+  profile: OrchestratorProfile;
+  participants?: string[];
+}
+
+interface DebateSessionMessageRequest {
+  sessionId: string;
+  role: string;
+  message: string;
+}
+
+interface DebateSessionDecideRequest {
+  sessionId: string;
+  options: { A: string; B: string; C?: string };
+}
+
 const port = Number(process.env.AGENT_RUNTIME_PORT || "8787");
 const host = process.env.AGENT_RUNTIME_HOST || "127.0.0.1";
 const apiKey = process.env.ORCH_AGENT_API_KEY || "";
@@ -38,6 +55,18 @@ type QueueJob = {
 
 const queue: QueueJob[] = [];
 let activeWorkers = 0;
+const debateSessions = new Map<
+  string,
+  {
+    sessionId: string;
+    taskId: string;
+    profile: OrchestratorProfile;
+    participants: string[];
+    messages: Array<{ role: string; message: string; at: string }>;
+    openedAt: string;
+    closedAt?: string;
+  }
+>();
 
 function enqueue<T>(run: () => Promise<T>): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -76,6 +105,15 @@ async function parseJson<T>(req: IncomingMessage): Promise<T> {
   const raw = Buffer.concat(chunks).toString("utf-8");
   if (!raw.trim()) return {} as T;
   return JSON.parse(raw) as T;
+}
+
+function getPathname(urlRaw?: string): string {
+  if (!urlRaw) return "";
+  try {
+    return new URL(urlRaw, "http://127.0.0.1").pathname;
+  } catch {
+    return urlRaw;
+  }
 }
 
 function isAuthorized(req: IncomingMessage): boolean {
@@ -238,6 +276,90 @@ const server = createServer(async (req, res) => {
         ]
       });
       return;
+    }
+
+    if (req.method === "POST" && req.url === "/debate/sessions/open") {
+      const body = await parseJson<DebateSessionOpenRequest>(req);
+      if (!body?.taskId || !body?.profile) {
+        writeJson(res, 400, { error: "invalid session payload" });
+        return;
+      }
+      const sessionId = `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const session = {
+        sessionId,
+        taskId: body.taskId,
+        profile: body.profile,
+        participants: body.participants ?? ["worker-A", "worker-B", "critic", "manager"],
+        messages: [] as Array<{ role: string; message: string; at: string }>,
+        openedAt: new Date().toISOString()
+      };
+      debateSessions.set(sessionId, session);
+      writeJson(res, 200, { sessionId, openedAt: session.openedAt, participants: session.participants });
+      return;
+    }
+
+    if (req.method === "POST" && req.url === "/debate/sessions/message") {
+      const body = await parseJson<DebateSessionMessageRequest>(req);
+      if (!body?.sessionId || !body?.role || !body?.message) {
+        writeJson(res, 400, { error: "invalid message payload" });
+        return;
+      }
+      const session = debateSessions.get(body.sessionId);
+      if (!session) {
+        writeJson(res, 404, { error: "session not found" });
+        return;
+      }
+      if (session.closedAt) {
+        writeJson(res, 409, { error: "session already closed" });
+        return;
+      }
+      const entry = { role: body.role, message: body.message, at: new Date().toISOString() };
+      session.messages.push(entry);
+      writeJson(res, 200, { ok: true, entry, count: session.messages.length });
+      return;
+    }
+
+    if (req.method === "POST" && req.url === "/debate/sessions/decide") {
+      const body = await parseJson<DebateSessionDecideRequest>(req);
+      if (!body?.sessionId || !body?.options?.A || !body?.options?.B) {
+        writeJson(res, 400, { error: "invalid decide payload" });
+        return;
+      }
+      const session = debateSessions.get(body.sessionId);
+      if (!session) {
+        writeJson(res, 404, { error: "session not found" });
+        return;
+      }
+      const combinedMessages = session.messages.map((m) => `${m.role}:${m.message}`).join(" | ").toLowerCase();
+      const preferStrict = combinedMessages.includes("strict") || session.profile === "strict";
+      const hasMergeHint = combinedMessages.includes("merge") || combinedMessages.includes("병합");
+      const chosen: "A" | "B" | "C" = body.options.C && hasMergeHint ? "C" : preferStrict ? "A" : "B";
+      const rationale = chosen === "A" ? body.options.A : chosen === "B" ? body.options.B : body.options.C ?? `${body.options.A} + ${body.options.B}`;
+      const criticMessage = { role: "critic", message: `selected ${chosen}: ${rationale}`, at: new Date().toISOString() };
+      const managerMessage = { role: "manager", message: `execute plan ${chosen} for ${session.profile} profile`, at: new Date().toISOString() };
+      session.messages.push(criticMessage, managerMessage);
+      writeJson(res, 200, { chosen, rationale, messages: session.messages });
+      return;
+    }
+
+    const pathname = getPathname(req.url);
+    const sessionPathMatch = /^\/debate\/sessions\/([^/]+)$/.exec(pathname);
+    if (sessionPathMatch) {
+      const sessionId = decodeURIComponent(sessionPathMatch[1]);
+      const session = debateSessions.get(sessionId);
+      if (!session) {
+        writeJson(res, 404, { error: "session not found" });
+        return;
+      }
+      if (req.method === "GET") {
+        writeJson(res, 200, session);
+        return;
+      }
+      if (req.method === "POST") {
+        session.closedAt = new Date().toISOString();
+        writeJson(res, 200, { ok: true, sessionId, closedAt: session.closedAt });
+        return;
+      }
     }
 
     writeJson(res, 404, { error: "not found" });

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
 import YAML from "yaml";
 import { runChecks, type OrchestratorProfile } from "./checks";
 import { validateOrThrow } from "./validate";
-import { buildScorecard, loadRules, loadWaivers } from "./score";
+import { buildScorecard, loadRules, loadWaiverGovernance, loadWaivers } from "./score";
 
 type WorkerRole = "backend-dev" | "frontend-dev" | "test-engineer" | "docs-writer";
 
@@ -413,7 +413,60 @@ async function debateRound(): Promise<{ chosen: "A" | "B" | "C"; rationale: stri
   if (agentMode === "remote" && agentEndpoint) {
     try {
       const apiKey = process.env[agentApiKeyEnv];
-      const response = await fetch(`${agentEndpoint.replace(/\/$/, "")}/debate/round`, {
+      const endpoint = agentEndpoint.replace(/\/$/, "");
+      const sessionResponse = await fetch(`${endpoint}/debate/sessions/open`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {})
+        },
+        body: JSON.stringify({ taskId, profile, participants: ["worker-A", "worker-B", "critic", "manager"] }),
+        signal: AbortSignal.timeout(agentTimeoutMs)
+      });
+      if (sessionResponse.ok) {
+        const sessionPayload = (await sessionResponse.json()) as { sessionId: string };
+        const postMessage = async (role: string, message: string): Promise<void> => {
+          await fetch(`${endpoint}/debate/sessions/message`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {})
+            },
+            body: JSON.stringify({ sessionId: sessionPayload.sessionId, role, message }),
+            signal: AbortSignal.timeout(agentTimeoutMs)
+          });
+        };
+        await postMessage("worker-A", optionA);
+        await postMessage("worker-B", optionB);
+        if (optionC) await postMessage("critic", `proposed merge option C: ${optionC}`);
+
+        const decideResponse = await fetch(`${endpoint}/debate/sessions/decide`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {})
+          },
+          body: JSON.stringify({ sessionId: sessionPayload.sessionId, options: { A: optionA, B: optionB, C: optionC } }),
+          signal: AbortSignal.timeout(agentTimeoutMs)
+        });
+        if (!decideResponse.ok) throw new Error(`remote debate decide failed: ${decideResponse.status}`);
+        const decidePayload = (await decideResponse.json()) as {
+          messages?: Array<{ role: string; message: string; at?: string }>;
+          chosen?: "A" | "B" | "C";
+          rationale?: string;
+        };
+        for (const entry of decidePayload.messages ?? []) {
+          appendFileSync(join(threadsDir, `${taskId}.jsonl`), JSON.stringify({ role: entry.role, message: entry.message, at: entry.at || new Date().toISOString() }) + "\n");
+        }
+        await fetch(`${endpoint}/debate/sessions/${encodeURIComponent(sessionPayload.sessionId)}`, {
+          method: "POST",
+          headers: { ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}) },
+          signal: AbortSignal.timeout(agentTimeoutMs)
+        });
+        return { chosen: decidePayload.chosen || chosen, rationale: decidePayload.rationale || rationale };
+      }
+
+      const fallbackResponse = await fetch(`${endpoint}/debate/round`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -422,8 +475,8 @@ async function debateRound(): Promise<{ chosen: "A" | "B" | "C"; rationale: stri
         body: JSON.stringify({ taskId, profile, optionA, optionB, optionC }),
         signal: AbortSignal.timeout(agentTimeoutMs)
       });
-      if (response.ok) {
-        const payload = (await response.json()) as { messages?: Array<{ role: string; message: string }>; chosen?: "A" | "B" | "C"; rationale?: string };
+      if (fallbackResponse.ok) {
+        const payload = (await fallbackResponse.json()) as { messages?: Array<{ role: string; message: string }>; chosen?: "A" | "B" | "C"; rationale?: string };
         for (const entry of payload.messages ?? []) {
           appendFileSync(join(threadsDir, `${taskId}.jsonl`), JSON.stringify({ role: entry.role, message: entry.message, at: new Date().toISOString() }) + "\n");
         }
@@ -486,9 +539,11 @@ async function main(): Promise<void> {
         ? join(projectDir, "ops/workflow/review-rules.main.yaml")
         : join(projectDir, "ops/workflow/review-rules.yaml");
   const waiversPath = join(projectDir, "ops/workflow/review-waivers.yaml");
+  const waiverGovernancePath = join(projectDir, "ops/workflow/waiver-governance.yaml");
   const rules = loadRules(rulesPath);
   const waivers = existsSync(waiversPath) ? loadWaivers(waiversPath) : { waivers: [] };
-  const scorecard = buildScorecard(taskId, checksOutput.checks, rules, { waivers, branch: targetBranch });
+  const governance = existsSync(waiverGovernancePath) ? loadWaiverGovernance(waiverGovernancePath) : {};
+  const scorecard = buildScorecard(taskId, checksOutput.checks, rules, { waivers, branch: targetBranch, governance });
   validateOrThrow(join(projectDir, "ops/workflow/contracts/review_scorecard.json"), scorecard, "review scorecard");
 
   let failedWorkers = workerReports
@@ -531,7 +586,7 @@ async function main(): Promise<void> {
     checksOutput = rerunChecks;
     failedWorkers = finalWorkerReports.filter((report) => report.risks.length > 0).map((report) => ({ role: report.role, risks: report.risks }));
     failedChecks = checksOutput.checks.filter((check) => !check.pass).map((check) => check.name);
-    finalScorecard = buildScorecard(taskId, checksOutput.checks, rules, { waivers, branch: targetBranch });
+    finalScorecard = buildScorecard(taskId, checksOutput.checks, rules, { waivers, branch: targetBranch, governance });
     validateOrThrow(join(projectDir, "ops/workflow/contracts/review_scorecard.json"), finalScorecard, "review scorecard rerun");
     auditLog({ type: "remediation-round", rerun: 1, workerFailures: failedWorkers, checkFailures: failedChecks });
   }

--- a/tools/orchestrator/score.ts
+++ b/tools/orchestrator/score.ts
@@ -14,10 +14,18 @@ interface WaiverItem {
   expires_at: string;
   reason: string;
   approved_by: string;
+  ticket?: string;
 }
 
 interface WaiverConfig {
   waivers?: WaiverItem[];
+}
+
+interface WaiverGovernanceConfig {
+  require_ticket?: boolean;
+  allowed_branches?: string[];
+  allowed_approvers?: string[];
+  max_duration_hours?: Partial<Record<CheckName, number>>;
 }
 
 export interface Scorecard {
@@ -42,6 +50,10 @@ export function loadWaivers(path: string): WaiverConfig {
   return YAML.parse(readFileSync(path, "utf-8")) as WaiverConfig;
 }
 
+export function loadWaiverGovernance(path: string): WaiverGovernanceConfig {
+  return YAML.parse(readFileSync(path, "utf-8")) as WaiverGovernanceConfig;
+}
+
 function metricScore(check: CheckResult): number {
   if (check.skipped) return 70;
   return check.pass ? 90 : 40;
@@ -51,7 +63,7 @@ export function buildScorecard(
   taskId: string,
   checks: CheckResult[],
   rules: Rules,
-  opts?: { waivers?: WaiverConfig; branch?: string; nowIso?: string }
+  opts?: { waivers?: WaiverConfig; branch?: string; nowIso?: string; governance?: WaiverGovernanceConfig }
 ): Scorecard {
   const scores = {
     tests: metricScore(checks.find((c) => c.name === "tests")!),
@@ -69,10 +81,40 @@ export function buildScorecard(
 
   const nowMs = Date.parse(opts?.nowIso || new Date().toISOString());
   const branch = opts?.branch || "dev";
+  const governance = opts?.governance;
+  const allowedBranches = governance?.allowed_branches || [];
+  const allowedApprovers = governance?.allowed_approvers || [];
+  const maxDurationByMetric = governance?.max_duration_hours || {};
+  const requireTicket = governance?.require_ticket === true;
+  const waiverValidationNotes: string[] = [];
+
   const activeWaivers = (opts?.waivers?.waivers || []).filter((w) => {
     const expireMs = Date.parse(w.expires_at);
+    const nowIso = new Date(nowMs).toISOString();
     const branchMatch = !w.branch || w.branch === branch;
-    return branchMatch && Number.isFinite(expireMs) && expireMs >= nowMs;
+    if (!branchMatch) return false;
+    if (!Number.isFinite(expireMs) || expireMs < nowMs) return false;
+    if (allowedBranches.length > 0 && !allowedBranches.includes(branch)) {
+      waiverValidationNotes.push(`waiver blocked by branch policy: ${w.metric}@${branch}`);
+      return false;
+    }
+    if (allowedApprovers.length > 0 && !allowedApprovers.includes(w.approved_by)) {
+      waiverValidationNotes.push(`waiver ignored: approver not allowed (${w.approved_by})`);
+      return false;
+    }
+    if (requireTicket && !w.ticket) {
+      waiverValidationNotes.push(`waiver ignored: ticket required (${w.metric})`);
+      return false;
+    }
+    const maxDurationHours = maxDurationByMetric[w.metric];
+    if (maxDurationHours && maxDurationHours > 0) {
+      const maxExpireMs = nowMs + maxDurationHours * 60 * 60 * 1000;
+      if (expireMs > maxExpireMs) {
+        waiverValidationNotes.push(`waiver truncated by max_duration_hours: ${w.metric} (now=${nowIso})`);
+        return false;
+      }
+    }
+    return true;
   });
   const waivedRequired = new Set<CheckName>(activeWaivers.map((w) => w.metric));
   const waiverNotes = activeWaivers.map((w) => `${w.metric}:${w.reason} (by ${w.approved_by}, until ${w.expires_at})`);
@@ -98,6 +140,7 @@ export function buildScorecard(
         requiredFailed.length > 0 ? `required_failed=${requiredFailed.join(",")}` : "required_failed=none",
         failFastTriggered ? "fail_fast_triggered=true" : "fail_fast_triggered=false"
       ];
+  for (const note of waiverValidationNotes) notes.push(note);
   return {
     taskId,
     scores,


### PR DESCRIPTION
# 변경 요약
원격 멀티에이전트 토론을 세션 기반 런타임으로 확장하고, waiver 예외 승인에 거버넌스 정책(승인자/브랜치/최대기간/티켓필수)을 적용했습니다.

## 배경
기존 구조는 상태머신 기반 자동화는 가능했지만, 워커 간 상호 토론은 단일 라운드 호출 중심이었고 waiver는 운영 규정 없이 단순 적용되는 한계가 있었습니다.

## 변경 내용
- `tools/agent-runtime/server.ts`
  - 세션 기반 토론 API 추가
    - `POST /debate/sessions/open`
    - `POST /debate/sessions/message`
    - `POST /debate/sessions/decide`
    - `GET /debate/sessions/{sessionId}`
    - `POST /debate/sessions/{sessionId}` (close)
  - 세션 메시지 기반으로 critic/manager 결정 메시지 기록
- `tools/orchestrator/run.ts`
  - remote 모드에서 세션 API 우선 사용
  - 세션 API 미지원 시 기존 `/debate/round` 자동 폴백 유지
  - waiver 거버넌스 파일 로드 후 score 계산에 반영
- `tools/orchestrator/score.ts`
  - waiver governance 로더 추가
  - 적용 전 검증 추가
    - 허용 브랜치
    - 허용 승인자
    - 티켓 필수 여부
    - metric별 최대 유효시간
  - 유효하지 않은 waiver는 제외하고 `scorecard.notes`에 사유 기록
- `ops/workflow/waiver-governance.yaml` 신규 추가
  - `require_ticket`, `allowed_branches`, `allowed_approvers`, `max_duration_hours`
- `ops/workflow/review-waivers.yaml`
  - 예시 필드에 `ticket` 추가
- `docs/project/22-orchestration-operations.md`
  - 세션 기반 토론 API/waiver 거버넌스 운영 기준 문서화

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

실행 검증:
- `npm run -s orch:run` (local): `state=approved`
- `ORCH_AGENT_MODE=remote`, `ORCH_AGENT_ENDPOINT=http://127.0.0.1:8787`로 `npm run -s orch:run`: `state=approved`
- `_workspace/threads/*.jsonl`에서 worker-A/B/critic/manager 메시지 플로우 확인

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- remote 세션 API가 기존 `/debate/round`와 호환되며 안정적으로 폴백되는지
- waiver governance 미충족 항목이 실제 점수 판정에서 제외되는지
- `scorecard.notes`로 운영 감사 추적이 충분한지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
