### PR TITLE
feat(orchestration): 자율 멀티-LLM 토론 엔진 추가

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -58,6 +58,19 @@
 - `POST {ORCH_AGENT_ENDPOINT}/debate/sessions/{sessionId}` (close)
 - 오케스트레이터는 remote 모드에서 위 API를 우선 사용하고, 미지원 런타임이면 `/debate/round`로 자동 폴백한다.
 
+4. 자율 멀티-LLM 토론(옵트인)
+- `POST {ORCH_AGENT_ENDPOINT}/debate/autonomous`
+- 요청 필드: `taskId`, `profile`, `options(A/B/C)`, `rounds(1~3)`
+- 응답 필드: `chosen`, `rationale`, `messages[]`
+- 런타임 활성화:
+  - `AGENT_RUNTIME_AUTONOMOUS_DEBATE=1`
+  - `AGENT_RUNTIME_LLM_API_KEY` (또는 `OPENAI_API_KEY`)
+  - 선택: `AGENT_RUNTIME_LLM_BASE_URL`, `AGENT_RUNTIME_LLM_MODEL`, `AGENT_RUNTIME_LLM_TIMEOUT_MS`
+- 오케스트레이터 활성화:
+  - 정책: `ops/workflow/policy.yaml`의 `debate.remote_autonomous_enabled: true`
+  - 또는 일회성: `ORCH_REMOTE_AUTONOMOUS_DEBATE=1`
+- 실패/미지원 시 세션 토론(`/debate/sessions/*`)으로 자동 폴백한다.
+
 ## 로컬 에이전트 런타임 서버 실행
 1. 서버 시작
 - `npm run agent-runtime:start`

--- a/ops/workflow/policy.yaml
+++ b/ops/workflow/policy.yaml
@@ -10,6 +10,8 @@ fallback:
   allow_partial_report: true
 debate:
   max_rounds: 2
+  remote_autonomous_enabled: false
+  remote_autonomous_rounds: 2
 agent_runtime:
   mode: local
   endpoint: ""

--- a/tools/agent-runtime/server.ts
+++ b/tools/agent-runtime/server.ts
@@ -39,6 +39,13 @@ interface DebateSessionDecideRequest {
   options: { A: string; B: string; C?: string };
 }
 
+interface AutonomousDebateRequest {
+  taskId: string;
+  profile: OrchestratorProfile;
+  options: { A: string; B: string; C?: string };
+  rounds?: number;
+}
+
 const port = Number(process.env.AGENT_RUNTIME_PORT || "8787");
 const host = process.env.AGENT_RUNTIME_HOST || "127.0.0.1";
 const apiKey = process.env.ORCH_AGENT_API_KEY || "";
@@ -46,6 +53,11 @@ const allowedRoot = resolve(process.env.AGENT_RUNTIME_ALLOWED_ROOT || process.cw
 const queueConcurrency = Math.max(1, Number(process.env.AGENT_RUNTIME_CONCURRENCY || "1"));
 const commandRetries = Math.max(0, Number(process.env.AGENT_RUNTIME_COMMAND_RETRIES || "1"));
 const queueTimeoutMs = Math.max(5_000, Number(process.env.AGENT_RUNTIME_QUEUE_TIMEOUT_MS || "120000"));
+const autonomousDebateEnabled = process.env.AGENT_RUNTIME_AUTONOMOUS_DEBATE === "1";
+const llmBaseUrl = (process.env.AGENT_RUNTIME_LLM_BASE_URL || "https://api.openai.com/v1").replace(/\/$/, "");
+const llmApiKey = process.env.AGENT_RUNTIME_LLM_API_KEY || process.env.OPENAI_API_KEY || "";
+const llmModel = process.env.AGENT_RUNTIME_LLM_MODEL || "gpt-4.1-mini";
+const llmTimeoutMs = Math.max(5_000, Number(process.env.AGENT_RUNTIME_LLM_TIMEOUT_MS || "30000"));
 
 type QueueJob = {
   run: () => Promise<unknown>;
@@ -114,6 +126,85 @@ function getPathname(urlRaw?: string): string {
   } catch {
     return urlRaw;
   }
+}
+
+async function callLlm(role: string, prompt: string): Promise<string> {
+  const response = await fetch(`${llmBaseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${llmApiKey}`
+    },
+    body: JSON.stringify({
+      model: llmModel,
+      temperature: 0.2,
+      messages: [
+        { role: "system", content: `You are ${role}. Return concise, actionable text only.` },
+        { role: "user", content: prompt }
+      ]
+    }),
+    signal: AbortSignal.timeout(llmTimeoutMs)
+  });
+  if (!response.ok) {
+    throw new Error(`llm call failed: ${response.status} ${response.statusText}`);
+  }
+  const payload = (await response.json()) as { choices?: Array<{ message?: { content?: string } }> };
+  const content = payload.choices?.[0]?.message?.content?.trim();
+  if (!content) throw new Error("empty llm response");
+  return content;
+}
+
+async function runAutonomousDebate(body: AutonomousDebateRequest): Promise<{
+  chosen: "A" | "B" | "C";
+  rationale: string;
+  messages: Array<{ role: string; message: string }>;
+}> {
+  const rounds = Math.max(1, Math.min(body.rounds ?? 2, 3));
+  const messages: Array<{ role: string; message: string }> = [];
+  const history = (): string => messages.map((m) => `${m.role}: ${m.message}`).join("\n");
+
+  for (let round = 1; round <= rounds; round += 1) {
+    const proposalA = await callLlm(
+      "worker-A",
+      `Task ${body.taskId}, profile=${body.profile}, round=${round}. Defend option A:\n${body.options.A}\n\nPrior discussion:\n${history() || "none"}`
+    );
+    messages.push({ role: "worker-A", message: `[round ${round}] ${proposalA}` });
+
+    const proposalB = await callLlm(
+      "worker-B",
+      `Task ${body.taskId}, profile=${body.profile}, round=${round}. Defend option B:\n${body.options.B}\n\nPrior discussion:\n${history()}`
+    );
+    messages.push({ role: "worker-B", message: `[round ${round}] ${proposalB}` });
+
+    if (body.options.C) {
+      const mergeView = await callLlm(
+        "critic",
+        `Task ${body.taskId}, profile=${body.profile}, round=${round}. Evaluate if option C merge is viable.\nOption C:\n${body.options.C}\n\nDiscussion:\n${history()}`
+      );
+      messages.push({ role: "critic", message: `[round ${round}] ${mergeView}` });
+    }
+  }
+
+  const decision = await callLlm(
+    "manager",
+    `Choose one final option: A, B, or C. Return format:
+chosen=<A|B|C>
+rationale=<one paragraph>
+
+Options:
+A=${body.options.A}
+B=${body.options.B}
+C=${body.options.C || "N/A"}
+
+Discussion:\n${history()}`
+  );
+  const chosenMatch = /chosen\s*=\s*([ABC])/i.exec(decision);
+  const rationaleMatch = /rationale\s*=\s*([\s\S]+)/i.exec(decision);
+  const chosen = (chosenMatch?.[1]?.toUpperCase() as "A" | "B" | "C") || (body.options.C ? "C" : body.profile === "strict" ? "A" : "B");
+  const rationale = (rationaleMatch?.[1] || decision).trim();
+  messages.push({ role: "manager", message: `selected ${chosen}: ${rationale}` });
+
+  return { chosen, rationale, messages };
 }
 
 function isAuthorized(req: IncomingMessage): boolean {
@@ -275,6 +366,25 @@ const server = createServer(async (req, res) => {
           { role: "manager", message: `execute plan ${chosen} for ${body.profile} profile` }
         ]
       });
+      return;
+    }
+
+    if (req.method === "POST" && req.url === "/debate/autonomous") {
+      if (!autonomousDebateEnabled) {
+        writeJson(res, 501, { error: "autonomous debate disabled" });
+        return;
+      }
+      if (!llmApiKey) {
+        writeJson(res, 501, { error: "AGENT_RUNTIME_LLM_API_KEY (or OPENAI_API_KEY) is required" });
+        return;
+      }
+      const body = await parseJson<AutonomousDebateRequest>(req);
+      if (!body?.taskId || !body?.profile || !body?.options?.A || !body?.options?.B) {
+        writeJson(res, 400, { error: "invalid autonomous debate payload" });
+        return;
+      }
+      const result = await runAutonomousDebate(body);
+      writeJson(res, 200, result);
       return;
     }
 

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -27,7 +27,7 @@ interface Policy {
   retry?: { worker_max_retries?: number; check_max_retries?: number };
   timeouts?: { worker_timeout_minutes?: number; review_timeout_minutes?: number };
   fallback?: { on_repeated_failure?: string; allow_partial_report?: boolean };
-  debate?: { max_rounds?: number };
+  debate?: { max_rounds?: number; remote_autonomous_enabled?: boolean; remote_autonomous_rounds?: number };
   agent_runtime?: {
     mode?: "local" | "remote";
     endpoint?: string;
@@ -64,6 +64,8 @@ const agentTimeoutMs = (policy.agent_runtime?.timeout_seconds ?? 60) * 1000;
 const agentApiKeyEnv = policy.agent_runtime?.api_key_env || "ORCH_AGENT_API_KEY";
 const autofixEnabled = process.env.ORCH_AUTOFIX === "1" || policy.autofix?.enabled === true;
 const autofixMode = policy.autofix?.mode || "off";
+const remoteAutonomousDebateEnabled = process.env.ORCH_REMOTE_AUTONOMOUS_DEBATE === "1" || policy.debate?.remote_autonomous_enabled === true;
+const remoteAutonomousDebateRounds = Math.max(1, Math.min(policy.debate?.remote_autonomous_rounds ?? 2, 3));
 
 function stateLog(from: string | null, to: string, actor: string): void {
   appendFileSync(join(logsDir, "state-transitions.jsonl"), JSON.stringify({ taskId, traceId, from, to, actor, at: new Date().toISOString() }) + "\n");
@@ -414,6 +416,33 @@ async function debateRound(): Promise<{ chosen: "A" | "B" | "C"; rationale: stri
     try {
       const apiKey = process.env[agentApiKeyEnv];
       const endpoint = agentEndpoint.replace(/\/$/, "");
+      if (remoteAutonomousDebateEnabled) {
+        const autonomousResponse = await fetch(`${endpoint}/debate/autonomous`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {})
+          },
+          body: JSON.stringify({
+            taskId,
+            profile,
+            options: { A: optionA, B: optionB, C: optionC },
+            rounds: remoteAutonomousDebateRounds
+          }),
+          signal: AbortSignal.timeout(agentTimeoutMs)
+        });
+        if (autonomousResponse.ok) {
+          const autonomousPayload = (await autonomousResponse.json()) as {
+            chosen?: "A" | "B" | "C";
+            rationale?: string;
+            messages?: Array<{ role: string; message: string }>;
+          };
+          for (const entry of autonomousPayload.messages ?? []) {
+            appendFileSync(join(threadsDir, `${taskId}.jsonl`), JSON.stringify({ role: entry.role, message: entry.message, at: new Date().toISOString() }) + "\n");
+          }
+          return { chosen: autonomousPayload.chosen || chosen, rationale: autonomousPayload.rationale || rationale };
+        }
+      }
       const sessionResponse = await fetch(`${endpoint}/debate/sessions/open`, {
         method: "POST",
         headers: {


### PR DESCRIPTION
# 변경 요약
원격 오케스트레이션에 자율 멀티-LLM 토론 엔진을 옵트인으로 추가하고, 실패 시 기존 세션 토론으로 자동 폴백되도록 확장했습니다.

## 배경
기존 remote 토론은 규칙 기반/세션 기반 메시지 조정이 중심이었고, 독립 LLM 워커 간 다중 라운드 자율 토론 실행 경로가 없었습니다.

## 변경 내용
- `tools/agent-runtime/server.ts`
  - 신규 엔드포인트: `POST /debate/autonomous`
  - 다중 라운드(1~3) 자율 토론 실행
    - worker-A 제안
    - worker-B 반론/대안
    - critic 통합 관점(옵션 C 있을 때)
    - manager 최종 선택(`A|B|C`) 및 근거
  - 환경변수 기반 LLM 설정
    - `AGENT_RUNTIME_AUTONOMOUS_DEBATE=1`
    - `AGENT_RUNTIME_LLM_API_KEY`(또는 `OPENAI_API_KEY`)
    - `AGENT_RUNTIME_LLM_BASE_URL`(기본 `https://api.openai.com/v1`)
    - `AGENT_RUNTIME_LLM_MODEL`(기본 `gpt-4.1-mini`)
    - `AGENT_RUNTIME_LLM_TIMEOUT_MS`
- `tools/orchestrator/run.ts`
  - remote 토론 시 `/debate/autonomous` 우선 호출
  - 실패/미지원이면 기존 `/debate/sessions/*` -> `/debate/round` 순서로 폴백
  - 정책/환경변수로 활성화 제어
- `ops/workflow/policy.yaml`
  - `debate.remote_autonomous_enabled`
  - `debate.remote_autonomous_rounds`
- `docs/project/22-orchestration-operations.md`
  - 자율 멀티-LLM 토론 API 및 운영 활성화 절차 문서화

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

실행 결과:
- `npm run -s orch:run` (local) -> `state=approved`
- `ORCH_AGENT_MODE=remote`, `ORCH_AGENT_ENDPOINT=http://127.0.0.1:8787` -> `state=approved`

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- autonomous 엔드포인트 실패 시 폴백 경로가 안정적으로 동작하는지
- round 수 제한(1~3)과 timeout이 과도한 지연 없이 동작하는지
- LLM 응답 파싱 실패 시 결정 기본값이 안전하게 동작하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
