### PR TITLE
feat(orchestration): 전략 학습 + 동적 역할 재배치

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -141,3 +141,15 @@
 
 4. 원격 멀티에이전트 실행
 - `set ORCH_AGENT_MODE=remote && set ORCH_AGENT_ENDPOINT=https://your-agent-runtime.example && npm run orch:run`
+
+## 전략 학습/동적 라우팅
+- 학습 메모리 파일: `_workspace/strategy-memory.json`
+- 기록 항목: 프로필/브랜치/토론선택/최종상태/실패워커/실패체크
+- 동작:
+  - 최근 실행 이력을 토대로 토론 옵션 힌트(`recent_approvals/rejects`)를 생성
+  - 변경 파일 기반 우선 워커 + 최근 실패 워커를 앞 순서로 자동 배치
+  - 재라운드 시 실패 체크 유형을 역할로 매핑해 추가 재실행(예: `tests` -> `test-engineer`)
+- 정책: `ops/workflow/policy.yaml.learning`
+  - `enabled`
+  - `history_limit`
+  - `dynamic_role_routing`

--- a/ops/workflow/policy.yaml
+++ b/ops/workflow/policy.yaml
@@ -12,6 +12,10 @@ debate:
   max_rounds: 2
   remote_autonomous_enabled: false
   remote_autonomous_rounds: 2
+learning:
+  enabled: true
+  history_limit: 100
+  dynamic_role_routing: true
 agent_runtime:
   mode: local
   endpoint: ""

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -28,6 +28,11 @@ interface Policy {
   timeouts?: { worker_timeout_minutes?: number; review_timeout_minutes?: number };
   fallback?: { on_repeated_failure?: string; allow_partial_report?: boolean };
   debate?: { max_rounds?: number; remote_autonomous_enabled?: boolean; remote_autonomous_rounds?: number };
+  learning?: {
+    enabled?: boolean;
+    history_limit?: number;
+    dynamic_role_routing?: boolean;
+  };
   agent_runtime?: {
     mode?: "local" | "remote";
     endpoint?: string;
@@ -66,6 +71,84 @@ const autofixEnabled = process.env.ORCH_AUTOFIX === "1" || policy.autofix?.enabl
 const autofixMode = policy.autofix?.mode || "off";
 const remoteAutonomousDebateEnabled = process.env.ORCH_REMOTE_AUTONOMOUS_DEBATE === "1" || policy.debate?.remote_autonomous_enabled === true;
 const remoteAutonomousDebateRounds = Math.max(1, Math.min(policy.debate?.remote_autonomous_rounds ?? 2, 3));
+const learningEnabled = policy.learning?.enabled !== false;
+const historyLimit = Math.max(10, Math.min(policy.learning?.history_limit ?? 100, 500));
+const dynamicRoleRoutingEnabled = policy.learning?.dynamic_role_routing !== false;
+
+interface StrategyMemoryEntry {
+  at: string;
+  profile: OrchestratorProfile;
+  targetBranch: string;
+  chosenDebate?: "A" | "B" | "C";
+  state: "approved" | "rejected";
+  failedWorkers: WorkerRole[];
+  failedChecks: string[];
+}
+
+interface StrategyMemory {
+  version: 1;
+  entries: StrategyMemoryEntry[];
+}
+
+function strategyMemoryPath(): string {
+  return join(workspaceDir, "strategy-memory.json");
+}
+
+function loadStrategyMemory(): StrategyMemory {
+  const path = strategyMemoryPath();
+  if (!existsSync(path)) return { version: 1, entries: [] };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as StrategyMemory;
+    if (!Array.isArray(parsed.entries)) return { version: 1, entries: [] };
+    return { version: 1, entries: parsed.entries };
+  } catch {
+    return { version: 1, entries: [] };
+  }
+}
+
+function saveStrategyMemory(entry: StrategyMemoryEntry): void {
+  if (!learningEnabled) return;
+  const memory = loadStrategyMemory();
+  memory.entries.push(entry);
+  if (memory.entries.length > historyLimit) {
+    memory.entries = memory.entries.slice(memory.entries.length - historyLimit);
+  }
+  writeFileSync(strategyMemoryPath(), JSON.stringify(memory, null, 2));
+}
+
+function inferPriorityRolesFromChanges(changedFiles: string[]): WorkerRole[] {
+  const roles = new Set<WorkerRole>();
+  for (const file of changedFiles) {
+    if (file.startsWith("backend/") || file.startsWith("backend-spring/")) roles.add("backend-dev");
+    if (file.startsWith("frontend/") || file.startsWith("myway-class-ui")) roles.add("frontend-dev");
+    if (/test|spec|contract/i.test(file)) roles.add("test-engineer");
+    if (file.startsWith("docs/") || file.endsWith(".md")) roles.add("docs-writer");
+  }
+  return [...roles];
+}
+
+function workerRoleFromCheck(check: string): WorkerRole {
+  const v = check.toLowerCase();
+  if (v.includes("test")) return "test-engineer";
+  if (v.includes("style") || v.includes("lint") || v.includes("perf")) return "frontend-dev";
+  if (v.includes("security") || v.includes("audit")) return "backend-dev";
+  return "backend-dev";
+}
+
+function buildExecutionWorkers(): WorkerRole[] {
+  const defaults: WorkerRole[] = ["backend-dev", "frontend-dev", "test-engineer", "docs-writer"];
+  if (!dynamicRoleRoutingEnabled) return defaults;
+  const changedFiles = getGitChangedFiles();
+  const priority = inferPriorityRolesFromChanges(changedFiles);
+  const memory = loadStrategyMemory().entries.slice(-10);
+  const recentFailed = new Set<WorkerRole>(memory.flatMap((e) => e.failedWorkers));
+  for (const role of recentFailed) {
+    if (!priority.includes(role)) priority.push(role);
+  }
+  const merged = [...priority, ...defaults.filter((role) => !priority.includes(role))];
+  auditLog({ type: "dynamic-role-routing", changedFiles, priority, executionOrder: merged });
+  return merged;
+}
 
 function stateLog(from: string | null, to: string, actor: string): void {
   appendFileSync(join(logsDir, "state-transitions.jsonl"), JSON.stringify({ taskId, traceId, from, to, actor, at: new Date().toISOString() }) + "\n");
@@ -407,9 +490,13 @@ async function runWorker(role: WorkerRole): Promise<WorkerReport> {
 }
 
 async function debateRound(): Promise<{ chosen: "A" | "B" | "C"; rationale: string }> {
+  const memory = loadStrategyMemory().entries.slice(-20);
+  const recentRejects = memory.filter((e) => e.state === "rejected").length;
+  const recentApprovals = memory.filter((e) => e.state === "approved").length;
+  const memoryHint = `recent_approvals=${recentApprovals}, recent_rejects=${recentRejects}`;
   const optionA = profile === "strict" ? "full quality gate with tests+audit" : "keep strict for production branches";
   const optionB = profile === "baseline" ? "baseline fast gate for CI" : "fallback baseline when strict repeatedly fails";
-  const optionC = "merge A+B: keep strict gate with baseline fallback only for transient external failures";
+  const optionC = `merge A+B: keep strict gate with baseline fallback only for transient external failures (${memoryHint})`;
   const chosen = profile === "strict" ? "A" : "B";
   const rationale = chosen === "A" ? optionA : optionB;
   if (agentMode === "remote" && agentEndpoint) {
@@ -546,7 +633,7 @@ async function main(): Promise<void> {
   const debate = await debateRound();
   auditLog({ type: "debate", chosen: debate.chosen, rationale: debate.rationale, mode: agentMode });
 
-  const workers: WorkerRole[] = ["backend-dev", "frontend-dev", "test-engineer", "docs-writer"];
+  const workers = buildExecutionWorkers();
   const workerReports = await Promise.all(workers.map((role) => runWorker(role)));
 
   stateLog("debate", "review", "reviewer");
@@ -599,7 +686,10 @@ async function main(): Promise<void> {
       failedWorkers.map((worker) => worker.role),
       failedChecks
     );
-    const rerunRoles = new Set(failedWorkers.map((worker) => worker.role as WorkerRole));
+    const rerunRoles = new Set<WorkerRole>(failedWorkers.map((worker) => worker.role as WorkerRole));
+    for (const checkName of failedChecks) {
+      rerunRoles.add(workerRoleFromCheck(checkName));
+    }
     const rerunReports = await Promise.all(
       finalWorkerReports.map((report) => (rerunRoles.has(report.role) ? runWorker(report.role) : Promise.resolve(report)))
     );
@@ -642,6 +732,15 @@ async function main(): Promise<void> {
   writeFileSync(join(workspaceDir, "decision.json"), JSON.stringify(decision, null, 2));
   writeFileSync(join(workspaceDir, "remediation.json"), JSON.stringify(remediation, null, 2));
   auditLog({ type: "decision", decision: decision.decision, state: finalState });
+  saveStrategyMemory({
+    at: new Date().toISOString(),
+    profile,
+    targetBranch,
+    chosenDebate: debate.chosen,
+    state: finalState,
+    failedWorkers: failedWorkers.map((v) => v.role),
+    failedChecks
+  });
 
   process.stdout.write(
     JSON.stringify(


### PR DESCRIPTION
# 변경 요약
오케스트레이터에 전략 학습(장기 메모리)과 동적 역할 재배치를 추가해, 과거 실패 패턴과 현재 변경 범위를 기반으로 실행 전략을 자동 조정하도록 확장했습니다.

## 배경
자율 토론/원격 워커까지 구현된 상태에서, 실행 전략이 매번 고정되어 있어 반복 실패 패턴을 충분히 활용하지 못했습니다.

## 변경 내용
- `tools/orchestrator/run.ts`
  - `_workspace/strategy-memory.json` 기반 전략 메모리 추가
  - 실행 종료 시 결과 축적(프로필/브랜치/토론선택/상태/실패워커/실패체크)
  - 토론 단계에서 최근 승인/반려 비율 힌트를 option C에 반영
  - 동적 역할 라우팅 추가
    - 변경 파일 기반 우선 워커 선정
    - 최근 실패 워커 우선순위 상향
    - 최종 실행 순서 감사 로그 기록(`dynamic-role-routing`)
  - 재라운드 시 실패 체크 -> 담당 워커 매핑 후 재실행 역할 자동 보강
- `ops/workflow/policy.yaml`
  - `learning.enabled`
  - `learning.history_limit`
  - `learning.dynamic_role_routing`
- `docs/project/22-orchestration-operations.md`
  - 전략 학습/동적 라우팅 운영 방법 문서화

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

실행 결과:
- `npm run -s orch:run` (local): `state=approved`
- `ORCH_AGENT_MODE=remote`, `ORCH_AGENT_ENDPOINT=http://127.0.0.1:8787`: `state=approved`
- `_workspace/strategy-memory.json` 생성/누적 확인

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- 동적 라우팅 시 실행 순서가 기대대로 계산되는지
- 재라운드에서 체크-역할 매핑이 과도/누락 없이 동작하는지
- strategy-memory가 히스토리 제한(`history_limit`)을 준수하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
