### PR TITLE
feat(orchestration): 자율토론 품질·메모리 관리·A/B 자동튜닝

### DIFF
--- a/docs/project/22-orchestration-operations.md
+++ b/docs/project/22-orchestration-operations.md
@@ -66,6 +66,8 @@
   - `AGENT_RUNTIME_AUTONOMOUS_DEBATE=1`
   - `AGENT_RUNTIME_LLM_API_KEY` (또는 `OPENAI_API_KEY`)
   - 선택: `AGENT_RUNTIME_LLM_BASE_URL`, `AGENT_RUNTIME_LLM_MODEL`, `AGENT_RUNTIME_LLM_TIMEOUT_MS`
+  - 선택(역할별 모델): `AGENT_RUNTIME_LLM_MODEL_WORKER_A`, `AGENT_RUNTIME_LLM_MODEL_WORKER_B`, `AGENT_RUNTIME_LLM_MODEL_CRITIC`, `AGENT_RUNTIME_LLM_MODEL_MANAGER`
+  - 선택(비용 제한): `AGENT_RUNTIME_LLM_MAX_OUTPUT_TOKENS`
 - 오케스트레이터 활성화:
   - 정책: `ops/workflow/policy.yaml`의 `debate.remote_autonomous_enabled: true`
   - 또는 일회성: `ORCH_REMOTE_AUTONOMOUS_DEBATE=1`
@@ -153,3 +155,16 @@
   - `enabled`
   - `history_limit`
   - `dynamic_role_routing`
+  - `ttl_days`: 장기 메모리 만료 일수
+  - `summary_bucket_days`: 오래된 실행 압축 요약 단위
+  - `bias_guard_reject_ratio_min`: 반려율이 너무 낮을 때 보수적 힌트 강제 기준
+
+## 정책 A/B 자동 튜닝
+- 정책: `ops/workflow/policy.yaml.experiments`
+  - `enabled`, `seed`, `variant_ratio`, `warmup_runs`
+  - `control`, `variant` 각각에 `remote_autonomous_enabled`, `remote_autonomous_rounds`, `dynamic_role_routing` 설정
+- 수집 지표(실행별): 승인 여부, 재라운드 횟수, 리드타임(ms)
+- 자동 튜닝 로직:
+  - warmup 이후 control/variant 최근 성능 점수 비교
+  - 점수 우위 변형의 노출 비율을 자동 가중(기본 비율 대비 ±0.2)
+  - 점수는 `approve_rate - rerun_penalty - leadtime_penalty` 기반

--- a/ops/workflow/policy.yaml
+++ b/ops/workflow/policy.yaml
@@ -16,6 +16,22 @@ learning:
   enabled: true
   history_limit: 100
   dynamic_role_routing: true
+  ttl_days: 30
+  summary_bucket_days: 7
+  bias_guard_reject_ratio_min: 0.1
+experiments:
+  enabled: true
+  seed: "myway-orch-ab"
+  variant_ratio: 0.5
+  warmup_runs: 20
+  control:
+    remote_autonomous_enabled: false
+    remote_autonomous_rounds: 1
+    dynamic_role_routing: true
+  variant:
+    remote_autonomous_enabled: true
+    remote_autonomous_rounds: 2
+    dynamic_role_routing: true
 agent_runtime:
   mode: local
   endpoint: ""

--- a/tools/agent-runtime/server.ts
+++ b/tools/agent-runtime/server.ts
@@ -58,6 +58,13 @@ const llmBaseUrl = (process.env.AGENT_RUNTIME_LLM_BASE_URL || "https://api.opena
 const llmApiKey = process.env.AGENT_RUNTIME_LLM_API_KEY || process.env.OPENAI_API_KEY || "";
 const llmModel = process.env.AGENT_RUNTIME_LLM_MODEL || "gpt-4.1-mini";
 const llmTimeoutMs = Math.max(5_000, Number(process.env.AGENT_RUNTIME_LLM_TIMEOUT_MS || "30000"));
+const llmMaxOutputTokens = Math.max(64, Number(process.env.AGENT_RUNTIME_LLM_MAX_OUTPUT_TOKENS || "280"));
+const llmRoleModels = {
+  workerA: process.env.AGENT_RUNTIME_LLM_MODEL_WORKER_A || llmModel,
+  workerB: process.env.AGENT_RUNTIME_LLM_MODEL_WORKER_B || llmModel,
+  critic: process.env.AGENT_RUNTIME_LLM_MODEL_CRITIC || llmModel,
+  manager: process.env.AGENT_RUNTIME_LLM_MODEL_MANAGER || llmModel
+};
 
 type QueueJob = {
   run: () => Promise<unknown>;
@@ -128,6 +135,26 @@ function getPathname(urlRaw?: string): string {
   }
 }
 
+function roleModel(role: string): string {
+  if (role === "worker-A") return llmRoleModels.workerA;
+  if (role === "worker-B") return llmRoleModels.workerB;
+  if (role === "critic") return llmRoleModels.critic;
+  return llmRoleModels.manager;
+}
+
+function roleSystemPrompt(role: string): string {
+  if (role === "worker-A") {
+    return "You are worker-A. Prioritize reliability, explicit risks, and deterministic execution. Be concise.";
+  }
+  if (role === "worker-B") {
+    return "You are worker-B. Prioritize speed and low operational cost while preserving correctness. Be concise.";
+  }
+  if (role === "critic") {
+    return "You are critic. Compare trade-offs, reject weak claims, and propose mergeable improvements. Be concise.";
+  }
+  return "You are manager. Make a single final decision with clear rationale and no ambiguity.";
+}
+
 async function callLlm(role: string, prompt: string): Promise<string> {
   const response = await fetch(`${llmBaseUrl}/chat/completions`, {
     method: "POST",
@@ -136,10 +163,11 @@ async function callLlm(role: string, prompt: string): Promise<string> {
       authorization: `Bearer ${llmApiKey}`
     },
     body: JSON.stringify({
-      model: llmModel,
+      model: roleModel(role),
       temperature: 0.2,
+      max_tokens: llmMaxOutputTokens,
       messages: [
-        { role: "system", content: `You are ${role}. Return concise, actionable text only.` },
+        { role: "system", content: roleSystemPrompt(role) },
         { role: "user", content: prompt }
       ]
     }),
@@ -162,24 +190,28 @@ async function runAutonomousDebate(body: AutonomousDebateRequest): Promise<{
   const rounds = Math.max(1, Math.min(body.rounds ?? 2, 3));
   const messages: Array<{ role: string; message: string }> = [];
   const history = (): string => messages.map((m) => `${m.role}: ${m.message}`).join("\n");
+  const compactHistory = (): string => {
+    const lines = history().split("\n");
+    return lines.slice(Math.max(0, lines.length - 12)).join("\n");
+  };
 
   for (let round = 1; round <= rounds; round += 1) {
     const proposalA = await callLlm(
       "worker-A",
-      `Task ${body.taskId}, profile=${body.profile}, round=${round}. Defend option A:\n${body.options.A}\n\nPrior discussion:\n${history() || "none"}`
+      `Task ${body.taskId}, profile=${body.profile}, round=${round}. Defend option A with concrete checks/commands and one key risk.\nOption A:\n${body.options.A}\n\nPrior discussion:\n${compactHistory() || "none"}`
     );
     messages.push({ role: "worker-A", message: `[round ${round}] ${proposalA}` });
 
     const proposalB = await callLlm(
       "worker-B",
-      `Task ${body.taskId}, profile=${body.profile}, round=${round}. Defend option B:\n${body.options.B}\n\nPrior discussion:\n${history()}`
+      `Task ${body.taskId}, profile=${body.profile}, round=${round}. Defend option B with lower-cost alternative and one key risk.\nOption B:\n${body.options.B}\n\nPrior discussion:\n${compactHistory()}`
     );
     messages.push({ role: "worker-B", message: `[round ${round}] ${proposalB}` });
 
     if (body.options.C) {
       const mergeView = await callLlm(
         "critic",
-        `Task ${body.taskId}, profile=${body.profile}, round=${round}. Evaluate if option C merge is viable.\nOption C:\n${body.options.C}\n\nDiscussion:\n${history()}`
+        `Task ${body.taskId}, profile=${body.profile}, round=${round}. Evaluate if option C merge is viable. Output: strengths, weaknesses, merge recommendation.\nOption C:\n${body.options.C}\n\nDiscussion:\n${compactHistory()}`
       );
       messages.push({ role: "critic", message: `[round ${round}] ${mergeView}` });
     }
@@ -196,7 +228,7 @@ A=${body.options.A}
 B=${body.options.B}
 C=${body.options.C || "N/A"}
 
-Discussion:\n${history()}`
+Discussion:\n${compactHistory()}`
   );
   const chosenMatch = /chosen\s*=\s*([ABC])/i.exec(decision);
   const rationaleMatch = /rationale\s*=\s*([\s\S]+)/i.exec(decision);

--- a/tools/orchestrator/run.ts
+++ b/tools/orchestrator/run.ts
@@ -32,6 +32,25 @@ interface Policy {
     enabled?: boolean;
     history_limit?: number;
     dynamic_role_routing?: boolean;
+    ttl_days?: number;
+    summary_bucket_days?: number;
+    bias_guard_reject_ratio_min?: number;
+  };
+  experiments?: {
+    enabled?: boolean;
+    seed?: string;
+    variant_ratio?: number;
+    warmup_runs?: number;
+    control?: {
+      remote_autonomous_enabled?: boolean;
+      remote_autonomous_rounds?: number;
+      dynamic_role_routing?: boolean;
+    };
+    variant?: {
+      remote_autonomous_enabled?: boolean;
+      remote_autonomous_rounds?: number;
+      dynamic_role_routing?: boolean;
+    };
   };
   agent_runtime?: {
     mode?: "local" | "remote";
@@ -73,14 +92,20 @@ const remoteAutonomousDebateEnabled = process.env.ORCH_REMOTE_AUTONOMOUS_DEBATE 
 const remoteAutonomousDebateRounds = Math.max(1, Math.min(policy.debate?.remote_autonomous_rounds ?? 2, 3));
 const learningEnabled = policy.learning?.enabled !== false;
 const historyLimit = Math.max(10, Math.min(policy.learning?.history_limit ?? 100, 500));
-const dynamicRoleRoutingEnabled = policy.learning?.dynamic_role_routing !== false;
+const memoryTtlDays = Math.max(7, Math.min(policy.learning?.ttl_days ?? 30, 365));
+const summaryBucketDays = Math.max(1, Math.min(policy.learning?.summary_bucket_days ?? 7, 30));
+const biasGuardRejectRatioMin = Math.max(0.05, Math.min(policy.learning?.bias_guard_reject_ratio_min ?? 0.1, 0.9));
+const dynamicRoleRoutingEnabledDefault = policy.learning?.dynamic_role_routing !== false;
 
 interface StrategyMemoryEntry {
   at: string;
   profile: OrchestratorProfile;
   targetBranch: string;
+  experimentVariant?: "control" | "variant";
   chosenDebate?: "A" | "B" | "C";
   state: "approved" | "rejected";
+  rerunCount: number;
+  leadTimeMs: number;
   failedWorkers: WorkerRole[];
   failedChecks: string[];
 }
@@ -88,6 +113,22 @@ interface StrategyMemoryEntry {
 interface StrategyMemory {
   version: 1;
   entries: StrategyMemoryEntry[];
+  summaries?: Array<{
+    from: string;
+    to: string;
+    totalRuns: number;
+    approvedRuns: number;
+    rejectedRuns: number;
+    topFailedChecks: string[];
+    topFailedWorkers: WorkerRole[];
+  }>;
+}
+
+interface ExperimentConfig {
+  variantName: "control" | "variant";
+  remoteAutonomousEnabled: boolean;
+  remoteAutonomousRounds: number;
+  dynamicRoleRoutingEnabled: boolean;
 }
 
 function strategyMemoryPath(): string {
@@ -96,13 +137,13 @@ function strategyMemoryPath(): string {
 
 function loadStrategyMemory(): StrategyMemory {
   const path = strategyMemoryPath();
-  if (!existsSync(path)) return { version: 1, entries: [] };
+  if (!existsSync(path)) return { version: 1, entries: [], summaries: [] };
   try {
     const parsed = JSON.parse(readFileSync(path, "utf-8")) as StrategyMemory;
-    if (!Array.isArray(parsed.entries)) return { version: 1, entries: [] };
-    return { version: 1, entries: parsed.entries };
+    if (!Array.isArray(parsed.entries)) return { version: 1, entries: [], summaries: [] };
+    return { version: 1, entries: parsed.entries, summaries: Array.isArray(parsed.summaries) ? parsed.summaries : [] };
   } catch {
-    return { version: 1, entries: [] };
+    return { version: 1, entries: [], summaries: [] };
   }
 }
 
@@ -110,10 +151,88 @@ function saveStrategyMemory(entry: StrategyMemoryEntry): void {
   if (!learningEnabled) return;
   const memory = loadStrategyMemory();
   memory.entries.push(entry);
+  const ttlMs = memoryTtlDays * 24 * 60 * 60 * 1000;
+  const nowMs = Date.now();
+  memory.entries = memory.entries.filter((e) => {
+    const atMs = Date.parse(e.at);
+    return Number.isFinite(atMs) && nowMs - atMs <= ttlMs;
+  });
   if (memory.entries.length > historyLimit) {
-    memory.entries = memory.entries.slice(memory.entries.length - historyLimit);
+    const overflow = memory.entries.length - historyLimit;
+    const expired = memory.entries.slice(0, overflow);
+    const kept = memory.entries.slice(overflow);
+    const byMetric = new Map<string, number>();
+    const byWorker = new Map<WorkerRole, number>();
+    for (const e of expired) {
+      for (const c of e.failedChecks) byMetric.set(c, (byMetric.get(c) || 0) + 1);
+      for (const w of e.failedWorkers) byWorker.set(w, (byWorker.get(w) || 0) + 1);
+    }
+    const topFailedChecks = [...byMetric.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3).map((v) => v[0]);
+    const topFailedWorkers = [...byWorker.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3).map((v) => v[0]);
+    memory.summaries = memory.summaries || [];
+    memory.summaries.push({
+      from: expired[0]?.at || new Date(nowMs - summaryBucketDays * 86400000).toISOString(),
+      to: expired[expired.length - 1]?.at || new Date().toISOString(),
+      totalRuns: expired.length,
+      approvedRuns: expired.filter((e) => e.state === "approved").length,
+      rejectedRuns: expired.filter((e) => e.state === "rejected").length,
+      topFailedChecks,
+      topFailedWorkers
+    });
+    if (memory.summaries.length > 50) {
+      memory.summaries = memory.summaries.slice(memory.summaries.length - 50);
+    }
+    memory.entries = kept;
   }
   writeFileSync(strategyMemoryPath(), JSON.stringify(memory, null, 2));
+}
+
+function hashString(input: string): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i += 1) h = (h * 31 + input.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+function resolveExperimentConfig(memory: StrategyMemory): ExperimentConfig {
+  const base: ExperimentConfig = {
+    variantName: "control",
+    remoteAutonomousEnabled: remoteAutonomousDebateEnabled,
+    remoteAutonomousRounds: remoteAutonomousDebateRounds,
+    dynamicRoleRoutingEnabled: dynamicRoleRoutingEnabledDefault
+  };
+  if (policy.experiments?.enabled !== true) return base;
+  const warmupRuns = Math.max(0, policy.experiments?.warmup_runs ?? 20);
+  if (memory.entries.length < warmupRuns) return base;
+  const defaultRatio = Math.max(0.05, Math.min(policy.experiments?.variant_ratio ?? 0.5, 0.95));
+  const recent = memory.entries.slice(-120).filter((e) => e.experimentVariant);
+  const byVariant = {
+    control: recent.filter((e) => e.experimentVariant === "control"),
+    variant: recent.filter((e) => e.experimentVariant === "variant")
+  };
+  const score = (items: StrategyMemoryEntry[]): number => {
+    if (items.length === 0) return 0;
+    const approveRate = items.filter((i) => i.state === "approved").length / items.length;
+    const rerunPenalty = items.reduce((s, i) => s + i.rerunCount, 0) / items.length;
+    const leadTimePenalty = items.reduce((s, i) => s + i.leadTimeMs, 0) / items.length / 60_000;
+    return approveRate * 100 - rerunPenalty * 10 - leadTimePenalty;
+  };
+  const controlScore = score(byVariant.control);
+  const variantScore = score(byVariant.variant);
+  const tunedRatio = byVariant.control.length >= 10 && byVariant.variant.length >= 10
+    ? variantScore > controlScore
+      ? Math.min(0.9, defaultRatio + 0.2)
+      : Math.max(0.1, defaultRatio - 0.2)
+    : defaultRatio;
+  const seed = policy.experiments?.seed || "orch-exp";
+  const pick = (hashString(`${seed}:${taskId}:${targetBranch}`) % 1000) / 1000;
+  const variantName: "control" | "variant" = pick < tunedRatio ? "variant" : "control";
+  const selected = variantName === "variant" ? policy.experiments?.variant : policy.experiments?.control;
+  return {
+    variantName,
+    remoteAutonomousEnabled: selected?.remote_autonomous_enabled ?? base.remoteAutonomousEnabled,
+    remoteAutonomousRounds: Math.max(1, Math.min(selected?.remote_autonomous_rounds ?? base.remoteAutonomousRounds, 3)),
+    dynamicRoleRoutingEnabled: selected?.dynamic_role_routing ?? base.dynamicRoleRoutingEnabled
+  };
 }
 
 function inferPriorityRolesFromChanges(changedFiles: string[]): WorkerRole[] {
@@ -135,7 +254,7 @@ function workerRoleFromCheck(check: string): WorkerRole {
   return "backend-dev";
 }
 
-function buildExecutionWorkers(): WorkerRole[] {
+function buildExecutionWorkers(dynamicRoleRoutingEnabled: boolean): WorkerRole[] {
   const defaults: WorkerRole[] = ["backend-dev", "frontend-dev", "test-engineer", "docs-writer"];
   if (!dynamicRoleRoutingEnabled) return defaults;
   const changedFiles = getGitChangedFiles();
@@ -489,11 +608,13 @@ async function runWorker(role: WorkerRole): Promise<WorkerReport> {
   return localWorkerReport(role);
 }
 
-async function debateRound(): Promise<{ chosen: "A" | "B" | "C"; rationale: string }> {
+async function debateRound(experiment: ExperimentConfig): Promise<{ chosen: "A" | "B" | "C"; rationale: string }> {
   const memory = loadStrategyMemory().entries.slice(-20);
   const recentRejects = memory.filter((e) => e.state === "rejected").length;
   const recentApprovals = memory.filter((e) => e.state === "approved").length;
-  const memoryHint = `recent_approvals=${recentApprovals}, recent_rejects=${recentRejects}`;
+  const rejectRatio = recentApprovals + recentRejects === 0 ? 0 : recentRejects / (recentApprovals + recentRejects);
+  const biasGuard = rejectRatio < biasGuardRejectRatioMin ? "bias_guard=force_conservative_checks" : "bias_guard=normal";
+  const memoryHint = `recent_approvals=${recentApprovals}, recent_rejects=${recentRejects}, ${biasGuard}`;
   const optionA = profile === "strict" ? "full quality gate with tests+audit" : "keep strict for production branches";
   const optionB = profile === "baseline" ? "baseline fast gate for CI" : "fallback baseline when strict repeatedly fails";
   const optionC = `merge A+B: keep strict gate with baseline fallback only for transient external failures (${memoryHint})`;
@@ -503,7 +624,7 @@ async function debateRound(): Promise<{ chosen: "A" | "B" | "C"; rationale: stri
     try {
       const apiKey = process.env[agentApiKeyEnv];
       const endpoint = agentEndpoint.replace(/\/$/, "");
-      if (remoteAutonomousDebateEnabled) {
+      if (experiment.remoteAutonomousEnabled) {
         const autonomousResponse = await fetch(`${endpoint}/debate/autonomous`, {
           method: "POST",
           headers: {
@@ -514,7 +635,7 @@ async function debateRound(): Promise<{ chosen: "A" | "B" | "C"; rationale: stri
             taskId,
             profile,
             options: { A: optionA, B: optionB, C: optionC },
-            rounds: remoteAutonomousDebateRounds
+            rounds: experiment.remoteAutonomousRounds
           }),
           signal: AbortSignal.timeout(agentTimeoutMs)
         });
@@ -628,12 +749,23 @@ function remediationRound(failedWorkers: string[], failedChecks: string[]): void
 }
 
 async function main(): Promise<void> {
+  const startedAtMs = Date.now();
+  const memoryAtStart = loadStrategyMemory();
+  const experiment = resolveExperimentConfig(memoryAtStart);
+  auditLog({
+    type: "experiment",
+    variant: experiment.variantName,
+    remoteAutonomousEnabled: experiment.remoteAutonomousEnabled,
+    remoteAutonomousRounds: experiment.remoteAutonomousRounds,
+    dynamicRoleRoutingEnabled: experiment.dynamicRoleRoutingEnabled
+  });
+
   stateLog(null, "draft", "manager");
   stateLog("draft", "debate", "manager");
-  const debate = await debateRound();
+  const debate = await debateRound(experiment);
   auditLog({ type: "debate", chosen: debate.chosen, rationale: debate.rationale, mode: agentMode });
 
-  const workers = buildExecutionWorkers();
+  const workers = buildExecutionWorkers(experiment.dynamicRoleRoutingEnabled);
   const workerReports = await Promise.all(workers.map((role) => runWorker(role)));
 
   stateLog("debate", "review", "reviewer");
@@ -669,10 +801,12 @@ async function main(): Promise<void> {
 
   const maxDebateRounds = Math.max(1, policy.debate?.max_rounds ?? 2);
   const shouldRetryRound = (failedWorkers.length > 0 || failedChecks.length > 0) && maxDebateRounds > 1;
+  let rerunCount = 0;
   let finalWorkerReports = workerReports;
   let finalScorecard = scorecard;
 
   if (shouldRetryRound) {
+    rerunCount = 1;
     const initialRequestChangeCodes = requestChangeCodesFromFailures(failedWorkers, failedChecks, finalWorkerReports);
     const autofixResults = runAutoFix(initialRequestChangeCodes);
     if (autofixResults.length > 0) {
@@ -736,8 +870,11 @@ async function main(): Promise<void> {
     at: new Date().toISOString(),
     profile,
     targetBranch,
+    experimentVariant: experiment.variantName,
     chosenDebate: debate.chosen,
     state: finalState,
+    rerunCount,
+    leadTimeMs: Date.now() - startedAtMs,
     failedWorkers: failedWorkers.map((v) => v.role),
     failedChecks
   });


### PR DESCRIPTION
# 변경 요약
자율 토론 품질(프롬프트/역할별 모델/토큰 제한), 메모리 품질(만료/요약/편향 가드), 정책 실험 A/B 자동 튜닝을 오케스트레이션에 추가했습니다.

## 배경
기존 자율 토론/메모리/실험은 기초 기능 중심이어서, 비용/지연 최적화와 장기 운영 품질 관리, 데이터 기반 정책 튜닝이 부족했습니다.

## 변경 내용
- `tools/agent-runtime/server.ts`
  - 역할별 모델 분리
    - `AGENT_RUNTIME_LLM_MODEL_WORKER_A`
    - `AGENT_RUNTIME_LLM_MODEL_WORKER_B`
    - `AGENT_RUNTIME_LLM_MODEL_CRITIC`
    - `AGENT_RUNTIME_LLM_MODEL_MANAGER`
  - 역할별 시스템 프롬프트 분리(신뢰성/속도/비평/의사결정)
  - 출력 토큰 상한 도입: `AGENT_RUNTIME_LLM_MAX_OUTPUT_TOKENS`
  - 토론 프롬프트 개선 + 최근 히스토리 슬라이싱으로 비용/지연 절감
- `tools/orchestrator/run.ts`
  - 메모리 품질 관리
    - `ttl_days` 기반 만료
    - `history_limit` 초과 시 오래된 엔트리 요약 압축(`summaries`)
    - `bias_guard_reject_ratio_min` 기반 편향 가드 힌트
  - 정책 실험 A/B 자동 튜닝
    - `control/variant` 설정 기반 변형 배정
    - warmup 이후 승인율/재라운드/리드타임 점수 비교
    - 성능 우위 변형에 노출비 자동 가중(±0.2)
  - 실행 메모리 항목 확장
    - `experimentVariant`, `rerunCount`, `leadTimeMs`
  - 동적 역할 라우팅은 실험 설정값으로 제어
- `ops/workflow/policy.yaml`
  - `learning.ttl_days`, `learning.summary_bucket_days`, `learning.bias_guard_reject_ratio_min`
  - `experiments` 블록 추가(control/variant 포함)
- `docs/project/22-orchestration-operations.md`
  - 역할별 모델/비용 제한 env 문서화
  - 메모리 품질/편향 가드/요약 압축 문서화
  - A/B 자동 튜닝 로직 문서화

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

실행 결과:
- `npm run -s orch:run` (local) -> `state=approved`
- `ORCH_AGENT_MODE=remote`, `ORCH_AGENT_ENDPOINT=http://127.0.0.1:8787` -> `state=approved`
- `_workspace/strategy-memory.json`에 `experimentVariant/rerunCount/leadTimeMs` 누적 확인

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- autonomous 토론에서 role별 모델/프롬프트 적용 여부
- 메모리 만료/압축 시 요약 통계가 올바르게 유지되는지
- warmup 이후 A/B 가중치 자동 조정이 의도대로 작동하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
