### PR TITLE
feat(orchestration): portable-orchestrator 스킬 및 주입 스크립트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "orch:run": "tsx tools/orchestrator/run.ts",
     "orch:checks": "tsx tools/orchestrator/checks.ts",
     "orch:report": "tsx tools/orchestrator/report.ts",
+    "orch:portable:init": "node tools/orchestrator/portable/install.mjs",
     "agent-runtime:start": "tsx tools/agent-runtime/server.ts",
     "lint": "npm --workspace @myway/backend run build && npm --workspace @myway/frontend run build",
     "perf:smoke": "npm run build:frontend"

--- a/skills/portable-orchestrator/SKILL.md
+++ b/skills/portable-orchestrator/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: portable-orchestrator
+description: "현재 레포의 오케스트레이션 자동화(ops/workflow, orchestrator runtime, CI gate)를 다른 프로젝트에 재사용 가능한 형태로 설치/주입한다."
+---
+
+# Portable Orchestrator
+
+## 목적
+- 현재 프로젝트의 오케스트레이션 체계를 다른 레포로 이식한다.
+- 설치 후 대상 레포에서 바로 `orch:run`, `orchestration-gate`를 사용할 수 있게 만든다.
+
+## 사용 조건
+- 사용자가 "다른 프로젝트에도 같은 자동화 붙여줘", "portable로 뽑아줘", "템플릿 주입해줘" 같은 요청을 했을 때 실행한다.
+
+## 실행 절차
+1. 설치 스크립트 실행
+- `node tools/orchestrator/portable/install.mjs --target <대상레포절대경로>`
+
+2. 설정 파일 생성/주입 확인
+- 대상 레포에 `orchestration.config.yaml`이 생성된다.
+- 기본값을 프로젝트에 맞게 수정한다.
+
+3. 대상 레포 package script 점검
+- `orch:run`, `orch:checks`, `orch:report`, `agent-runtime:start` 추가 여부 확인
+
+4. CI 연결 점검
+- 대상 레포의 `.github/workflows/orchestration-gate.yml` 존재 확인
+- 브랜치 보호 규칙에서 `orchestration-gate / gate` required check 설정 확인
+
+## 산출물
+- `ops/workflow/*`
+- `tools/orchestrator/*`
+- `tools/agent-runtime/server.ts`
+- `.github/workflows/orchestration-gate.yml`
+- `orchestration.config.yaml`
+
+## 주의
+- `_workspace/` 산출물 파일은 이식 대상에 커밋하지 않는다.
+- 대상 레포의 기존 워크플로우/스크립트와 충돌 시 `--force` 없이 먼저 diff를 검토한다.

--- a/tools/orchestrator/portable/install.mjs
+++ b/tools/orchestrator/portable/install.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const args = { target: "", force: false, projectName: "" };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--target") args.target = argv[i + 1] || "";
+    if (token === "--force") args.force = true;
+    if (token === "--project-name") args.projectName = argv[i + 1] || "";
+  }
+  return args;
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function copyFileWithGuard(src, dst, force) {
+  ensureDir(path.dirname(dst));
+  if (fs.existsSync(dst) && !force) {
+    throw new Error(`target exists (use --force): ${dst}`);
+  }
+  fs.copyFileSync(src, dst);
+}
+
+function copyDirRecursive(srcDir, dstDir, force) {
+  ensureDir(dstDir);
+  const entries = fs.readdirSync(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = path.join(srcDir, entry.name);
+    const dst = path.join(dstDir, entry.name);
+    if (entry.isDirectory()) copyDirRecursive(src, dst, force);
+    else copyFileWithGuard(src, dst, force);
+  }
+}
+
+function readJsonSafe(file) {
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, JSON.stringify(value, null, 2) + "\n", "utf-8");
+}
+
+function injectConfig(templatePath, targetPath, projectName, force) {
+  if (fs.existsSync(targetPath) && !force) {
+    throw new Error(`target exists (use --force): ${targetPath}`);
+  }
+  const raw = fs.readFileSync(templatePath, "utf-8");
+  const rendered = raw.replace(/__PROJECT_NAME__/g, projectName);
+  fs.writeFileSync(targetPath, rendered, "utf-8");
+}
+
+function ensurePackageScripts(targetRoot) {
+  const pkgPath = path.join(targetRoot, "package.json");
+  const pkg = readJsonSafe(pkgPath);
+  if (!pkg) return { updated: false, reason: "package.json not found or invalid" };
+  pkg.scripts = pkg.scripts || {};
+  const desired = {
+    "orch:run": "tsx tools/orchestrator/run.ts",
+    "orch:checks": "tsx tools/orchestrator/checks.ts",
+    "orch:report": "tsx tools/orchestrator/report.ts",
+    "agent-runtime:start": "tsx tools/agent-runtime/server.ts"
+  };
+  let changed = false;
+  for (const [k, v] of Object.entries(desired)) {
+    if (!pkg.scripts[k]) {
+      pkg.scripts[k] = v;
+      changed = true;
+    }
+  }
+  if (changed) writeJson(pkgPath, pkg);
+  return { updated: changed, reason: changed ? "scripts added" : "scripts already present" };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!args.target) {
+    process.stderr.write("usage: node tools/orchestrator/portable/install.mjs --target <absolute-path> [--project-name <name>] [--force]\n");
+    process.exit(1);
+  }
+
+  const sourceRoot = process.cwd();
+  const targetRoot = path.resolve(args.target);
+  const projectName = args.projectName || path.basename(targetRoot);
+  ensureDir(targetRoot);
+
+  const copyPlan = [
+    { src: "ops/workflow", dst: "ops/workflow", type: "dir" },
+    { src: "tools/orchestrator", dst: "tools/orchestrator", type: "dir" },
+    { src: "tools/agent-runtime/server.ts", dst: "tools/agent-runtime/server.ts", type: "file" },
+    { src: ".github/workflows/orchestration-gate.yml", dst: ".github/workflows/orchestration-gate.yml", type: "file" }
+  ];
+
+  for (const item of copyPlan) {
+    const absSrc = path.join(sourceRoot, item.src);
+    const absDst = path.join(targetRoot, item.dst);
+    if (!fs.existsSync(absSrc)) continue;
+    if (item.type === "dir") copyDirRecursive(absSrc, absDst, args.force);
+    else copyFileWithGuard(absSrc, absDst, args.force);
+  }
+
+  const templatePath = path.join(sourceRoot, "tools/orchestrator/portable/orchestration.config.template.yaml");
+  const configPath = path.join(targetRoot, "orchestration.config.yaml");
+  injectConfig(templatePath, configPath, projectName, args.force);
+  const scriptResult = ensurePackageScripts(targetRoot);
+
+  process.stdout.write(
+    JSON.stringify(
+      {
+        ok: true,
+        targetRoot,
+        projectName,
+        force: args.force,
+        created: ["ops/workflow/*", "tools/orchestrator/*", "tools/agent-runtime/server.ts", ".github/workflows/orchestration-gate.yml", "orchestration.config.yaml"],
+        packageScripts: scriptResult
+      },
+      null,
+      2
+    ) + "\n"
+  );
+}
+
+main();

--- a/tools/orchestrator/portable/orchestration.config.template.yaml
+++ b/tools/orchestrator/portable/orchestration.config.template.yaml
@@ -1,0 +1,18 @@
+version: 1
+project:
+  name: "__PROJECT_NAME__"
+  target_branch: "dev"
+runtime:
+  mode: "local"
+  endpoint: ""
+  api_key_env: "ORCH_AGENT_API_KEY"
+debate:
+  autonomous_enabled: false
+  autonomous_rounds: 2
+learning:
+  enabled: true
+  history_limit: 100
+  ttl_days: 30
+experiments:
+  enabled: true
+  variant_ratio: 0.5


### PR DESCRIPTION
# 변경 요약
다른 프로젝트에서도 재사용 가능한 `portable-orchestrator` 스킬과 오케스트레이션 주입 설치 스크립트를 추가했습니다.

## 배경
현재 오케스트레이션 자동화는 이 레포 기준으로 완성됐지만, 다른 프로젝트로 옮길 때 수작업 복제가 필요했습니다.

## 변경 내용
- `skills/portable-orchestrator/SKILL.md` 추가
  - 재사용 목적/적용 절차/주의사항 정의
- `tools/orchestrator/portable/install.mjs` 추가
  - 대상 레포로 오케스트레이션 핵심 파일 세트 자동 주입
  - `orchestration.config.yaml` 자동 생성
  - 대상 `package.json`에 `orch:*`/`agent-runtime:start` 스크립트 자동 추가
  - 안전 옵션: 기본 충돌 시 실패, `--force` 시 덮어쓰기
- `tools/orchestrator/portable/orchestration.config.template.yaml` 추가
  - 프로젝트명 치환 가능한 기본 설정 템플릿
- `package.json`
  - `orch:portable:init` 스크립트 추가

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

실행 검증:
- `npm run -s orch:portable:init -- --target C:\Users\ggg99\Desktop\tmp-portable-orch-smoke --project-name smoke-portable`
- 결과 확인:
  - `ops/workflow/*`, `tools/orchestrator/*`, `tools/agent-runtime/server.ts`, `.github/workflows/orchestration-gate.yml` 생성
  - `orchestration.config.yaml` 생성
  - 대상 `package.json.scripts` 주입 확인

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- 기존 파일 충돌 시 `--force` 없이 안전하게 실패하는지
- 대상 `package.json`이 없는 레포에서의 동작(안내 메시지) 적절성
- 주입 파일 범위가 과도하지 않고 필요한 최소 세트인지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
