### PR TITLE
feat(backend): RAG/STT 품질 및 학습데이터 영속성 고도화

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
@@ -3,16 +3,40 @@ package com.myway.backendspring.api;
 import com.myway.backendspring.common.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1")
 public class NotImplementedController {
 
+    @GetMapping("/legacy/mappings")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMappings() {
+        return ResponseEntity.ok(ApiResponse.success(Map.of(
+                "status", "migration_in_progress",
+                "mappings", List.of(
+                        Map.of("legacy", "/api/v1/legacy/courses", "replacement", "/api/v1/courses"),
+                        Map.of("legacy", "/api/v1/legacy/ai/*", "replacement", "/api/v1/ai/*"),
+                        Map.of("legacy", "/api/v1/legacy/media/*", "replacement", "/api/v1/media/*"),
+                        Map.of("legacy", "/api/v1/legacy/shortform/*", "replacement", "/api/v1/shortform/*")
+                )
+        ), "legacy API 매핑 정보를 반환했습니다."));
+    }
+
+    @GetMapping("/legacy/{domain}")
+    public ResponseEntity<ApiResponse<Object>> legacyDomain(@PathVariable String domain) {
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
+                .body(ApiResponse.failure("NOT_IMPLEMENTED", "legacy/" + domain + " API는 이관 중입니다. /api/v1/legacy/mappings를 확인하세요."));
+    }
+
     @RequestMapping(value = {"/legacy", "/legacy/**"})
     public ResponseEntity<ApiResponse<Object>> notImplemented() {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-                .body(ApiResponse.failure("NOT_IMPLEMENTED", "Spring 백엔드 마이그레이션 중인 API입니다."));
+                .body(ApiResponse.failure("NOT_IMPLEMENTED", "Spring 백엔드 마이그레이션 중인 API입니다. /api/v1/legacy/mappings를 확인하세요."));
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -11,6 +11,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DemoLearningService {
     private static final String ENROLLMENT_SCOPE = "learning_enrollment";
     private static final String LECTURE_COMPLETION_SCOPE = "learning_lecture_completion";
+    private static final String COURSE_SCOPE = "learning_course";
+    private static final String MATERIAL_SCOPE = "learning_material";
+    private static final String NOTICE_SCOPE = "learning_notice";
     private final Map<String, CourseDetail> courses = new LinkedHashMap<>();
     private final Map<String, List<MaterialItem>> materialsByCourse = new ConcurrentHashMap<>();
     private final Map<String, List<NoticeItem>> noticesByCourse = new ConcurrentHashMap<>();
@@ -33,6 +36,10 @@ public class DemoLearningService {
     }
 
     private void initSeedData() {
+        if (useStore()) {
+            seedStoreDataIfMissing();
+            return;
+        }
         List<LectureItem> javaLectures = List.of(
                 new LectureItem("lec_java_01", "crs_java_01", "Spring Boot 시작", 25),
                 new LectureItem("lec_java_02", "crs_java_01", "REST API 설계", 35)
@@ -54,11 +61,11 @@ public class DemoLearningService {
     }
 
     public List<CourseCard> listCourseCards(String userId) {
-        return courses.values().stream().map(c -> new CourseCard(c.id(), c.title(), c.instructor_id(), progressPercent(userId, c.id()))).toList();
+        return listAllCourses().stream().map(c -> new CourseCard(c.id(), c.title(), c.instructor_id(), progressPercent(userId, c.id()))).toList();
     }
 
     public List<CourseCard> listManagedCourseCards(String userId, String role) {
-        return courses.values().stream()
+        return listAllCourses().stream()
                 .filter(c -> "admin".equals(role) || c.instructor_id().equals(userId))
                 .map(c -> new CourseCard(c.id(), c.title(), c.instructor_id(), progressPercent(userId, c.id())))
                 .toList();
@@ -72,23 +79,27 @@ public class DemoLearningService {
             lectures.add(new LectureItem("lec_" + UUID.randomUUID(), courseId, titles.get(i), 25 + (i * 5)));
         }
         CourseDetail detail = new CourseDetail(courseId, title, instructorId, List.copyOf(lectures), 0);
-        courses.put(courseId, detail);
+        if (useStore()) {
+            store.upsertKv(COURSE_SCOPE, courseId, toCoursePayload(detail));
+        } else {
+            courses.put(courseId, detail);
+        }
         return detail;
     }
 
     public CourseDetail getCourseDetail(String courseId, String userId) {
-        CourseDetail base = courses.get(courseId);
+        CourseDetail base = findCourse(courseId);
         if (base == null) return null;
         return new CourseDetail(base.id(), base.title(), base.instructor_id(), base.lectures(), progressPercent(userId, base.id()));
     }
 
     public List<LectureItem> getCourseLectures(String courseId) {
-        CourseDetail detail = courses.get(courseId);
+        CourseDetail detail = findCourse(courseId);
         return detail == null ? List.of() : detail.lectures();
     }
 
     public LectureItem getLecture(String lectureId) {
-        return courses.values().stream().flatMap(c -> c.lectures().stream()).filter(l -> l.id().equals(lectureId)).findFirst().orElse(null);
+        return listAllCourses().stream().flatMap(c -> c.lectures().stream()).filter(l -> l.id().equals(lectureId)).findFirst().orElse(null);
     }
 
     public LectureItem getCourseLecture(String courseId, String lectureId) {
@@ -103,22 +114,44 @@ public class DemoLearningService {
     }
 
     public List<MaterialItem> getMaterials(String courseId) {
+        if (useStore()) {
+            return store.listKvByScope(MATERIAL_SCOPE).stream()
+                    .map(this::fromMaterialPayload)
+                    .filter(Objects::nonNull)
+                    .filter(m -> courseId.equals(m.course_id()))
+                    .toList();
+        }
         return materialsByCourse.getOrDefault(courseId, List.of());
     }
 
     public List<NoticeItem> getNotices(String courseId) {
+        if (useStore()) {
+            return store.listKvByScope(NOTICE_SCOPE).stream()
+                    .map(this::fromNoticePayload)
+                    .filter(Objects::nonNull)
+                    .filter(n -> courseId.equals(n.course_id()))
+                    .toList();
+        }
         return noticesByCourse.getOrDefault(courseId, List.of());
     }
 
     public MaterialItem addMaterial(String userId, String courseId, String title, String summary, String fileName) {
         MaterialItem created = new MaterialItem(UUID.randomUUID().toString(), courseId, title, summary, fileName);
-        materialsByCourse.computeIfAbsent(courseId, k -> new ArrayList<>()).add(created);
+        if (useStore()) {
+            store.upsertKv(MATERIAL_SCOPE, created.id(), toMaterialPayload(created));
+        } else {
+            materialsByCourse.computeIfAbsent(courseId, k -> new ArrayList<>()).add(created);
+        }
         return created;
     }
 
     public NoticeItem addNotice(String userId, String courseId, String title, String content, boolean pinned) {
         NoticeItem created = new NoticeItem(UUID.randomUUID().toString(), courseId, title, content, pinned);
-        noticesByCourse.computeIfAbsent(courseId, k -> new ArrayList<>()).add(created);
+        if (useStore()) {
+            store.upsertKv(NOTICE_SCOPE, created.id(), toNoticePayload(created));
+        } else {
+            noticesByCourse.computeIfAbsent(courseId, k -> new ArrayList<>()).add(created);
+        }
         return created;
     }
 
@@ -251,6 +284,151 @@ public class DemoLearningService {
 
     private boolean useStore() {
         return store != null;
+    }
+
+    private void seedStoreDataIfMissing() {
+        if (!store.listKvByScope(COURSE_SCOPE).isEmpty()) {
+            return;
+        }
+        List<LectureItem> javaLectures = List.of(
+                new LectureItem("lec_java_01", "crs_java_01", "Spring Boot 시작", 25),
+                new LectureItem("lec_java_02", "crs_java_01", "REST API 설계", 35)
+        );
+        List<LectureItem> reactLectures = List.of(
+                new LectureItem("lec_react_01", "crs_react_01", "React 상태관리", 30),
+                new LectureItem("lec_react_02", "crs_react_01", "API 연동", 28)
+        );
+        CourseDetail java = new CourseDetail("crs_java_01", "Java Spring 백엔드", "usr_ins_001", javaLectures, 0);
+        CourseDetail react = new CourseDetail("crs_react_01", "React 프론트엔드", "usr_ins_001", reactLectures, 0);
+        store.upsertKv(COURSE_SCOPE, java.id(), toCoursePayload(java));
+        store.upsertKv(COURSE_SCOPE, react.id(), toCoursePayload(react));
+        store.upsertKv(MATERIAL_SCOPE, "mat_java_01", Map.of(
+                "id", "mat_java_01",
+                "course_id", "crs_java_01",
+                "title", "강의 자료집",
+                "summary", "Spring 핵심 요약",
+                "file_name", "spring-handbook.pdf"
+        ));
+        store.upsertKv(NOTICE_SCOPE, "not_java_01", Map.of(
+                "id", "not_java_01",
+                "course_id", "crs_java_01",
+                "title", "과제 공지",
+                "content", "1주차 과제를 제출하세요.",
+                "pinned", true
+        ));
+    }
+
+    private List<CourseDetail> listAllCourses() {
+        if (!useStore()) return new ArrayList<>(courses.values());
+        return store.listKvByScope(COURSE_SCOPE).stream()
+                .map(this::fromCoursePayload)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private CourseDetail findCourse(String courseId) {
+        if (!useStore()) return courses.get(courseId);
+        return fromCoursePayload(store.getKv(COURSE_SCOPE, courseId));
+    }
+
+    private Map<String, Object> toCoursePayload(CourseDetail detail) {
+        List<Map<String, Object>> lectures = detail.lectures().stream()
+                .map(l -> {
+                    Map<String, Object> row = new HashMap<>();
+                    row.put("id", l.id());
+                    row.put("course_id", l.course_id());
+                    row.put("title", l.title());
+                    row.put("duration_minutes", l.duration_minutes());
+                    return row;
+                })
+                .toList();
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("id", detail.id());
+        payload.put("title", detail.title());
+        payload.put("instructor_id", detail.instructor_id());
+        payload.put("lectures", lectures);
+        return payload;
+    }
+
+    @SuppressWarnings("unchecked")
+    private CourseDetail fromCoursePayload(Map<String, Object> payload) {
+        if (payload == null) return null;
+        String id = String.valueOf(payload.getOrDefault("id", "")).trim();
+        if (id.isBlank()) return null;
+        String title = String.valueOf(payload.getOrDefault("title", "")).trim();
+        String instructorId = String.valueOf(payload.getOrDefault("instructor_id", "")).trim();
+        List<LectureItem> lectures = new ArrayList<>();
+        Object rawLectures = payload.get("lectures");
+        if (rawLectures instanceof List<?> list) {
+            for (Object row : list) {
+                if (!(row instanceof Map<?, ?> map)) continue;
+                String lectureId = String.valueOf(map.containsKey("id") ? map.get("id") : "").trim();
+                String courseId = String.valueOf(map.containsKey("course_id") ? map.get("course_id") : id).trim();
+                String lectureTitle = String.valueOf(map.containsKey("title") ? map.get("title") : "").trim();
+                int duration = parseInt(map.get("duration_minutes"), 0);
+                if (!lectureId.isBlank() && !lectureTitle.isBlank()) {
+                    lectures.add(new LectureItem(lectureId, courseId, lectureTitle, duration));
+                }
+            }
+        }
+        return new CourseDetail(id, title, instructorId, lectures, 0);
+    }
+
+    private Map<String, Object> toMaterialPayload(MaterialItem item) {
+        return Map.of(
+                "id", item.id(),
+                "course_id", item.course_id(),
+                "title", item.title(),
+                "summary", item.summary(),
+                "file_name", item.file_name()
+        );
+    }
+
+    private MaterialItem fromMaterialPayload(Map<String, Object> payload) {
+        if (payload == null) return null;
+        String id = String.valueOf(payload.getOrDefault("id", "")).trim();
+        String courseId = String.valueOf(payload.getOrDefault("course_id", "")).trim();
+        if (id.isBlank() || courseId.isBlank()) return null;
+        return new MaterialItem(
+                id,
+                courseId,
+                String.valueOf(payload.getOrDefault("title", "")),
+                String.valueOf(payload.getOrDefault("summary", "")),
+                String.valueOf(payload.getOrDefault("file_name", ""))
+        );
+    }
+
+    private Map<String, Object> toNoticePayload(NoticeItem item) {
+        return Map.of(
+                "id", item.id(),
+                "course_id", item.course_id(),
+                "title", item.title(),
+                "content", item.content(),
+                "pinned", item.pinned()
+        );
+    }
+
+    private NoticeItem fromNoticePayload(Map<String, Object> payload) {
+        if (payload == null) return null;
+        String id = String.valueOf(payload.getOrDefault("id", "")).trim();
+        String courseId = String.valueOf(payload.getOrDefault("course_id", "")).trim();
+        if (id.isBlank() || courseId.isBlank()) return null;
+        return new NoticeItem(
+                id,
+                courseId,
+                String.valueOf(payload.getOrDefault("title", "")),
+                String.valueOf(payload.getOrDefault("content", "")),
+                Boolean.parseBoolean(String.valueOf(payload.getOrDefault("pinned", false)))
+        );
+    }
+
+    private int parseInt(Object value, int fallback) {
+        if (value instanceof Number n) return n.intValue();
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (Exception ignored) {
+            return fallback;
+        }
     }
 
     private void appendActivity(String userId, String type, String resourceType, String resourceId, Map<String, Object> metadata) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -50,6 +50,8 @@ public class FeatureStoreService {
     private static final int PUBLIC_STT_MAX_DURATION_MS = 180_000;
     private static final int FALLBACK_TRANSCRIPT_DURATION_MS = 120_000;
     private static final int FALLBACK_SEGMENT_MIN_MS = 1_000;
+    private static final int RAG_CHUNK_MAX_WORDS = 90;
+    private static final int RAG_CHUNK_OVERLAP_WORDS = 20;
     private final FeatureJdbcStore store;
     private final DemoLearningService learningService;
     private final int shortformMaxRetry;
@@ -1406,10 +1408,12 @@ public class FeatureStoreService {
         Set<String> haystack = new LinkedHashSet<>(tokenize(title + " " + content));
         long overlap = queryTokens.stream().filter(haystack::contains).count();
         double coverage = overlap / (double) Math.max(3, queryTokens.size());
-        double exact = content.contains(query) ? 0.14 : 0;
-        double titleBoost = title.contains(query) ? 0.06 : 0;
+        double exact = content.contains(query) ? 0.16 : 0;
+        double titleBoost = title.contains(query) ? 0.08 : 0;
+        double orderBoost = phraseOrderBoost(queryTokens, tokenize(content));
+        double diversityPenalty = repeatedTokenPenalty(tokenize(content));
         double scopeBoost = "transcript".equals(chunk.get("source_scope")) ? 0.05 : ("note".equals(chunk.get("source_scope")) ? 0.03 : 0.01);
-        return Math.min(0.99, coverage + exact + titleBoost + scopeBoost);
+        return Math.min(0.99, Math.max(0.0, coverage + exact + titleBoost + orderBoost + scopeBoost - diversityPenalty));
     }
 
     private String inferIntent(String query) {
@@ -1439,17 +1443,19 @@ public class FeatureStoreService {
     }
 
     private List<String> splitForRag(String text, int maxChunks) {
-        List<String> sentences = List.of(text.split("(?<=[.!?])\\s+"));
-        List<String> cleaned = sentences.stream().map(this::normalizeText).filter(s -> !s.isBlank()).toList();
-        if (cleaned.isEmpty()) {
-            return List.of(text);
-        }
-        int chunkSize = Math.max(1, (int) Math.ceil(cleaned.size() / (double) maxChunks));
+        List<String> words = tokenizeForChunking(text);
+        if (words.isEmpty()) return List.of(text);
+        int maxWords = Math.max(30, RAG_CHUNK_MAX_WORDS);
+        int overlap = Math.max(0, Math.min(RAG_CHUNK_OVERLAP_WORDS, maxWords / 2));
         List<String> parts = new ArrayList<>();
-        for (int i = 0; i < cleaned.size(); i += chunkSize) {
-            parts.add(String.join(" ", cleaned.subList(i, Math.min(cleaned.size(), i + chunkSize))));
+        int cursor = 0;
+        while (cursor < words.size() && parts.size() < Math.max(1, maxChunks * 2)) {
+            int end = Math.min(words.size(), cursor + maxWords);
+            parts.add(String.join(" ", words.subList(cursor, end)));
+            if (end >= words.size()) break;
+            cursor = Math.max(cursor + 1, end - overlap);
         }
-        return parts;
+        return parts.isEmpty() ? List.of(text) : parts;
     }
 
     private String buildLectureNarrative(String lectureId) {
@@ -1462,11 +1468,11 @@ public class FeatureStoreService {
     }
 
     private List<Map<String, Object>> splitIntoSegments(String text, int durationMs) {
-        List<String> words = List.of(normalizeText(text).split("\\s+")).stream().filter(word -> !word.isBlank()).toList();
+        List<String> words = tokenizeForChunking(text);
         if (words.isEmpty()) {
             return List.of();
         }
-        int segmentCount = Math.min(6, Math.max(3, (int) Math.ceil(words.size() / 10.0)));
+        int segmentCount = Math.min(8, Math.max(3, (int) Math.ceil(words.size() / 20.0)));
         int wordsPerSegment = Math.max(1, (int) Math.ceil(words.size() / (double) segmentCount));
         List<Map<String, Object>> segments = new ArrayList<>();
         for (int i = 0; i < segmentCount; i++) {
@@ -1500,6 +1506,39 @@ public class FeatureStoreService {
                 .map(String::trim)
                 .filter(token -> token.length() > 1)
                 .toList();
+    }
+
+    private List<String> tokenizeForChunking(String text) {
+        return List.of(normalizeText(text).split("\\s+")).stream()
+                .map(String::trim)
+                .filter(token -> !token.isBlank())
+                .toList();
+    }
+
+    private double phraseOrderBoost(List<String> queryTokens, List<String> contentTokens) {
+        if (queryTokens.size() < 2 || contentTokens.size() < 2) return 0.0;
+        int matchedPairs = 0;
+        for (int i = 0; i < queryTokens.size() - 1; i++) {
+            String first = queryTokens.get(i);
+            String second = queryTokens.get(i + 1);
+            for (int j = 0; j < contentTokens.size() - 1; j++) {
+                if (first.equals(contentTokens.get(j)) && second.equals(contentTokens.get(j + 1))) {
+                    matchedPairs++;
+                    break;
+                }
+            }
+        }
+        return Math.min(0.08, matchedPairs * 0.02);
+    }
+
+    private double repeatedTokenPenalty(List<String> tokens) {
+        if (tokens.isEmpty()) return 0.0;
+        Map<String, Integer> countByToken = new HashMap<>();
+        for (String token : tokens) {
+            countByToken.put(token, countByToken.getOrDefault(token, 0) + 1);
+        }
+        long repeatedKinds = countByToken.values().stream().filter(v -> v >= 4).count();
+        return Math.min(0.06, repeatedKinds * 0.01);
     }
 
     private String normalizeText(String text) {


### PR DESCRIPTION
# 변경 요약
AI/RAG 검색 품질, STT 청킹 품질, 도메인 데이터 영속성(코스/자료/공지), legacy 이관 안내를 백엔드 기준으로 1차 고도화했습니다.

## 배경
현재 백엔드는 기능 뼈대는 갖춰졌지만, RAG 스코어링/청킹 품질과 DemoLearning 데이터 영속성, legacy 경로 안내 체계가 운영 기준에 맞게 보강될 필요가 있었습니다.

## 변경 내용
- `FeatureStoreService`
  - RAG 점수 계산 고도화
    - 기존 단순 토큰 오버랩 + exact 매칭에서
    - `phrase order boost`, `repeated token penalty`를 추가한 하이브리드 점수로 개선
  - RAG 청킹 고도화
    - 고정 문장 분할 중심 -> 단어 기반 `max_words + overlap` 청킹으로 변경
    - 긴 문서에서도 컨텍스트 단절을 줄이도록 청크 오버랩 적용
  - STT fallback 세그먼트 분할 튜닝
    - 세그먼트 개수/밀도 기준을 조정해 과도한 단편 분할을 완화

- `DemoLearningService`
  - 코스/자료/공지를 KV store 기반으로 영속화
    - 신규 scope: `learning_course`, `learning_material`, `learning_notice`
  - store 사용 시 초기 seed를 KV에 기록하고 이후 조회는 store 기준으로 동작
  - 코스 생성/자료 등록/공지 등록도 store upsert 반영
  - 기존 in-memory fallback 경로는 store 미사용 시 유지

- `NotImplementedController`
  - `GET /api/v1/legacy/mappings` 추가
    - legacy -> replacement 매핑을 구조화된 형태로 제공
  - legacy 미이관 응답 메시지에 mappings 확인 경로를 포함해 마이그레이션 가이드 강화

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

실행 검증:
- `npm run test:backend`
- 결과: `Tests run: 33, Failures: 0, Errors: 0, Skipped: 0` / BUILD SUCCESS

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- RAG 점수 개선이 기존 검색 결과와 역행하지 않는지
- KV 기반 코스/자료/공지 영속화가 기존 시나리오(생성/조회/등록)와 호환되는지
- legacy mappings 응답 형식이 운영 가이드에 충분한지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
