### PR TITLE
feat(ai): RAG 인덱스 관리 API 및 인덱스 우선 조회 추가

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
@@ -102,6 +102,46 @@ public class AiController {
         return ResponseEntity.ok(ApiResponse.success(data, "RAG 응답을 생성했습니다."));
     }
 
+    @GetMapping("/rag/index")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> ragIndex(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestParam(value = "lecture_id", required = false) String lectureId,
+            @RequestParam(value = "course_id", required = false) String courseId
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        Map<String, Object> data = featureStore.ragIndexOverview(
+                lectureId == null || lectureId.isBlank() ? null : lectureId.trim(),
+                courseId == null || courseId.isBlank() ? null : courseId.trim()
+        );
+        return ResponseEntity.ok(ApiResponse.success(data, "RAG 인덱스 현황을 조회했습니다."));
+    }
+
+    @PostMapping("/rag/index/rebuild")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> rebuildRagIndex(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody Map<String, Object> body
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String lectureId = text(body, "lecture_id");
+        String courseId = text(body, "course_id");
+        if (lectureId.isBlank() && courseId.isBlank()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_OR_COURSE_REQUIRED", "lecture_id 또는 course_id가 필요합니다."));
+        }
+        if (!lectureId.isBlank() && learningService.getLecture(lectureId) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        if (!courseId.isBlank() && learningService.getCourseLectures(courseId).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("COURSE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        Map<String, Object> data = featureStore.rebuildRagIndex(
+                lectureId.isBlank() ? null : lectureId,
+                courseId.isBlank() ? null : courseId
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(data, "RAG 인덱스를 재생성했습니다."));
+    }
+
     @PostMapping("/intent")
     public ResponseEntity<ApiResponse<Map<String, Object>>> intent(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
         SessionView session = require(auth);

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -41,6 +41,7 @@ public class FeatureStoreService {
     private static final String CUSTOM_COURSE_SCOPE = "custom_course";
     private static final String ADMIN_ASSIGNMENT_SCOPE = "admin_assignment";
     private static final String AI_USAGE_SCOPE = "ai_usage_daily";
+    private static final String RAG_INDEX_SCOPE = "rag_chunk_index";
     private static final String DEV_AI_PROVIDER = "ollama";
     private static final String NON_DEV_AI_PROVIDER = "gemini";
     private static final String DEV_AI_MODEL = "llama3.1:8b";
@@ -356,7 +357,7 @@ public class FeatureStoreService {
         int resolvedLimit = Math.max(1, Math.min(6, limit == null ? 4 : limit));
         String normalizedQuery = normalizeText(query);
         List<String> targetLectureIds = targetLectureIds(lectureId, courseId);
-        List<Map<String, Object>> corpus = buildRagCorpus(targetLectureIds);
+        List<Map<String, Object>> corpus = indexedRagCorpus(targetLectureIds);
 
         List<Map<String, Object>> rankedChunks = corpus.stream()
                 .map(chunk -> {
@@ -420,6 +421,40 @@ public class FeatureStoreService {
         payload.put("provider", providerPayload);
         payload.put("limit", resolvedLimit);
         return payload;
+    }
+
+    public Map<String, Object> ragIndexOverview(String lectureId, String courseId) {
+        List<String> lectureIds = targetLectureIds(lectureId, courseId);
+        List<Map<String, Object>> chunks = indexedRagCorpus(lectureIds);
+        Set<String> indexedLectures = chunks.stream()
+                .map(chunk -> String.valueOf(chunk.getOrDefault("lecture_id", "")))
+                .filter(id -> !id.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        return Map.of(
+                "scope", RAG_INDEX_SCOPE,
+                "lecture_ids", indexedLectures,
+                "chunk_count", chunks.size(),
+                "indexed_at", Instant.now().toString()
+        );
+    }
+
+    public Map<String, Object> rebuildRagIndex(String lectureId, String courseId) {
+        List<String> lectureIds = targetLectureIds(lectureId, courseId);
+        List<Map<String, Object>> chunks = buildRagCorpus(lectureIds);
+        String key = ragIndexKey(lectureId, courseId);
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("id", key);
+        payload.put("lecture_id", lectureId);
+        payload.put("course_id", courseId);
+        payload.put("chunk_count", chunks.size());
+        payload.put("chunks", chunks);
+        payload.put("updated_at", Instant.now().toString());
+        store.upsertKv(RAG_INDEX_SCOPE, key, payload);
+        return Map.of(
+                "index_id", key,
+                "chunk_count", chunks.size(),
+                "updated_at", payload.get("updated_at")
+        );
     }
 
     private Instant parseInstantOrNull(Object raw) {
@@ -1370,6 +1405,33 @@ public class FeatureStoreService {
             }
         }
         return chunks;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> indexedRagCorpus(List<String> lectureIds) {
+        if (lectureIds.isEmpty()) return List.of();
+        List<Map<String, Object>> indexed = new ArrayList<>();
+        for (String lectureId : lectureIds) {
+            Map<String, Object> saved = store.getKv(RAG_INDEX_SCOPE, ragIndexKey(lectureId, null));
+            if (saved == null || !(saved.get("chunks") instanceof List<?> rows)) continue;
+            for (Object row : rows) {
+                if (!(row instanceof Map<?, ?> map)) continue;
+                Map<String, Object> chunk = new HashMap<>();
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    if (entry.getKey() != null) {
+                        chunk.put(String.valueOf(entry.getKey()), entry.getValue());
+                    }
+                }
+                indexed.add(chunk);
+            }
+        }
+        return indexed.isEmpty() ? buildRagCorpus(lectureIds) : indexed;
+    }
+
+    private String ragIndexKey(String lectureId, String courseId) {
+        if (lectureId != null && !lectureId.isBlank()) return "lecture:" + lectureId;
+        if (courseId != null && !courseId.isBlank()) return "course:" + courseId;
+        return "global:all";
     }
 
     private Map<String, Object> buildChunk(


### PR DESCRIPTION
# 변경 요약
RAG 인덱스 관리 API를 추가하고, 검색 시 저장된 인덱스를 우선 사용하는 경로를 연결했습니다.

## 배경
기존 RAG는 요청 시마다 코퍼스를 재구성하는 형태여서 운영 시 재현성과 성능 관리가 어려웠습니다.

## 변경 내용
- `AiController`
  - `GET /api/v1/ai/rag/index` 추가: 인덱스 현황 조회
  - `POST /api/v1/ai/rag/index/rebuild` 추가: lecture/course 단위 인덱스 재생성
- `FeatureStoreService`
  - 신규 scope: `rag_chunk_index`
  - `rebuildRagIndex(...)` 구현
  - `ragIndexOverview(...)` 구현
  - `ragOverview(...)`에서 인덱스 데이터 우선 사용, 없으면 기존 코퍼스 빌드로 fallback

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

실행 검증:
- `npm run test:backend`
- 결과: `Tests run: 33, Failures: 0, Errors: 0, Skipped: 0`

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- 인덱스 미존재 시 기존 fallback이 정상 동작하는지
- 인덱스 재생성 후 `rag` 응답의 chunk 일관성이 유지되는지
- lecture/course 키 스킴(`lecture:*`, `course:*`) 충돌 가능성 없는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
