### PR TITLE
feat(media): STT 품질 메트릭 및 전사 후 RAG 자동 인덱싱

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -53,6 +53,7 @@ public class FeatureStoreService {
     private static final int FALLBACK_SEGMENT_MIN_MS = 1_000;
     private static final int RAG_CHUNK_MAX_WORDS = 90;
     private static final int RAG_CHUNK_OVERLAP_WORDS = 20;
+    private static final int STT_TARGET_SEGMENT_WORDS = 20;
     private final FeatureJdbcStore store;
     private final DemoLearningService learningService;
     private final int shortformMaxRetry;
@@ -633,6 +634,7 @@ public class FeatureStoreService {
         List<Map<String, Object>> segments = splitIntoSegments(baseText, durationMs);
         String transcriptId = String.valueOf(extraction.getOrDefault("id", UUID.randomUUID().toString()));
         int wordCount = countWords(baseText);
+        Map<String, Object> sttQuality = sttQualityMetrics(segments, durationMs);
 
         Map<String, Object> transcriptPayload = new HashMap<>();
         transcriptPayload.put("id", transcriptId);
@@ -644,6 +646,7 @@ public class FeatureStoreService {
         transcriptPayload.put("duration_ms", durationMs);
         transcriptPayload.put("stt_provider", resolvedProvider);
         transcriptPayload.put("stt_model", resolvedModel);
+        transcriptPayload.put("quality", sttQuality);
         transcriptPayload.put("created_at", Instant.now().toString());
         store.upsertKv(TRANSCRIPT_SCOPE, lectureId, transcriptPayload);
 
@@ -677,7 +680,10 @@ public class FeatureStoreService {
         extractionPayload.put("processing_step", "stt_completed");
         extractionPayload.put("processing_error_code", null);
         extractionPayload.put("processing_error", null);
+        extractionPayload.put("stt_quality", sttQuality);
         store.upsertKv(EXTRACTION_SCOPE, String.valueOf(extraction.getOrDefault("id", transcriptId)), extractionPayload);
+
+        Map<String, Object> ragIndex = rebuildRagIndex(lectureId, null);
 
         Map<String, Object> response = new HashMap<>();
         response.put("transcript_id", transcriptId);
@@ -690,6 +696,8 @@ public class FeatureStoreService {
         response.put("audio_url", audioUrl);
         response.put("pipeline", pipeline(lectureId));
         response.put("language", normalizedLanguage);
+        response.put("quality", sttQuality);
+        response.put("rag_index", ragIndex);
         return response;
     }
 
@@ -1556,6 +1564,42 @@ public class FeatureStoreService {
             segments.add(segment);
         }
         return segments;
+    }
+
+    private Map<String, Object> sttQualityMetrics(List<Map<String, Object>> segments, int durationMs) {
+        if (segments == null || segments.isEmpty()) {
+            return Map.of(
+                    "segment_count", 0,
+                    "avg_words_per_segment", 0,
+                    "min_segment_ms", 0,
+                    "max_segment_ms", 0,
+                    "target_segment_words", STT_TARGET_SEGMENT_WORDS,
+                    "quality_score", 0.0
+            );
+        }
+        int totalWords = 0;
+        int minMs = Integer.MAX_VALUE;
+        int maxMs = 0;
+        for (Map<String, Object> segment : segments) {
+            int start = asInt(segment.get("start_ms"));
+            int end = asInt(segment.get("end_ms"));
+            int ms = Math.max(0, end - start);
+            minMs = Math.min(minMs, ms);
+            maxMs = Math.max(maxMs, ms);
+            totalWords += countWords(String.valueOf(segment.getOrDefault("text", "")));
+        }
+        double avgWords = totalWords / (double) Math.max(1, segments.size());
+        double wordFit = 1.0 - Math.min(1.0, Math.abs(avgWords - STT_TARGET_SEGMENT_WORDS) / STT_TARGET_SEGMENT_WORDS);
+        double durationFit = 1.0 - Math.min(1.0, Math.abs(durationMs - (segments.size() * 20_000.0)) / Math.max(1.0, durationMs));
+        double score = Math.max(0.0, Math.min(1.0, (wordFit * 0.7) + (durationFit * 0.3)));
+        return Map.of(
+                "segment_count", segments.size(),
+                "avg_words_per_segment", Math.round(avgWords * 100.0) / 100.0,
+                "min_segment_ms", minMs == Integer.MAX_VALUE ? 0 : minMs,
+                "max_segment_ms", maxMs,
+                "target_segment_words", STT_TARGET_SEGMENT_WORDS,
+                "quality_score", Math.round(score * 1000.0) / 1000.0
+        );
     }
 
     private int countWords(String text) {


### PR DESCRIPTION
# 변경 요약
STT 전사 결과에 품질 메타데이터를 추가하고, 전사 완료 시 RAG 인덱스를 자동 재생성하도록 개선했습니다.

## 배경
전사 파이프라인은 동작하지만 품질 지표가 없어 운영 판단이 어려웠고, 전사 후 RAG 인덱스 최신화가 수동이었습니다.

## 변경 내용
- `FeatureStoreService.transcribe(...)`
  - `quality` 메트릭 추가
    - `segment_count`
    - `avg_words_per_segment`
    - `min_segment_ms` / `max_segment_ms`
    - `target_segment_words`
    - `quality_score`
  - 전사 완료 시 `rebuildRagIndex(lectureId, null)` 자동 호출
  - 응답에 `quality`, `rag_index` 포함
  - extraction KV에도 `stt_quality` 저장

## 연결 이슈
- Closes #N/A
- Fixes #N/A

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

실행 검증:
- `npm run test:backend`
- 결과: `Tests run: 33, Failures: 0, Errors: 0, Skipped: 0`

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- `quality_score` 산식이 운영 기준에 맞는지
- 전사 완료 시 인덱스 재생성이 성능 병목 없이 동작하는지
- transcript/extraction 응답 스키마 확장이 프론트와 충돌 없는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
