### PR TITLE
feat: RAG 질의 튜닝(min_score/debug) 및 인덱스 초기화 API 추가

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
@@ -97,7 +97,16 @@ public class AiController {
         }
 
         Integer limit = intOrNull(body, "limit");
-        Map<String, Object> data = featureStore.ragOverview(query, lectureId.isBlank() ? null : lectureId, courseId.isBlank() ? null : courseId, limit);
+        Double minScore = doubleOrNull(body, "min_score");
+        boolean includeDebug = booleanOrDefault(body, "include_debug", false);
+        Map<String, Object> data = featureStore.ragOverview(
+                query,
+                lectureId.isBlank() ? null : lectureId,
+                courseId.isBlank() ? null : courseId,
+                limit,
+                minScore,
+                includeDebug
+        );
         featureStore.recordAiUsage(session.user().id(), "rag", true, query);
         return ResponseEntity.ok(ApiResponse.success(data, "RAG 응답을 생성했습니다."));
     }
@@ -140,6 +149,31 @@ public class AiController {
                 courseId.isBlank() ? null : courseId
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(data, "RAG 인덱스를 재생성했습니다."));
+    }
+
+    @PostMapping("/rag/index/clear")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> clearRagIndex(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody Map<String, Object> body
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        String lectureId = text(body, "lecture_id");
+        String courseId = text(body, "course_id");
+        if (lectureId.isBlank() && courseId.isBlank()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_OR_COURSE_REQUIRED", "lecture_id 또는 course_id가 필요합니다."));
+        }
+        if (!lectureId.isBlank() && learningService.getLecture(lectureId) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        if (!courseId.isBlank() && learningService.getCourseLectures(courseId).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("COURSE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        Map<String, Object> data = featureStore.clearRagIndex(
+                lectureId.isBlank() ? null : lectureId,
+                courseId.isBlank() ? null : courseId
+        );
+        return ResponseEntity.ok(ApiResponse.success(data, "RAG 인덱스를 초기화했습니다."));
     }
 
     @PostMapping("/intent")
@@ -265,5 +299,38 @@ public class AiController {
         } catch (NumberFormatException ignored) {
             return null;
         }
+    }
+
+    private Double doubleOrNull(Map<String, Object> body, String key) {
+        String value = text(body, key);
+        if (value.isBlank()) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private boolean booleanOrDefault(Map<String, Object> body, String key, boolean defaultValue) {
+        if (body == null || !body.containsKey(key)) {
+            return defaultValue;
+        }
+        Object raw = body.get(key);
+        if (raw instanceof Boolean bool) {
+            return bool;
+        }
+        String value = String.valueOf(raw).trim().toLowerCase();
+        if (value.isBlank()) {
+            return defaultValue;
+        }
+        if ("true".equals(value) || "1".equals(value) || "y".equals(value) || "yes".equals(value)) {
+            return true;
+        }
+        if ("false".equals(value) || "0".equals(value) || "n".equals(value) || "no".equals(value)) {
+            return false;
+        }
+        return defaultValue;
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -355,10 +355,22 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> ragOverview(String query, String lectureId, String courseId, Integer limit) {
+        return ragOverview(query, lectureId, courseId, limit, null, false);
+    }
+
+    public Map<String, Object> ragOverview(
+            String query,
+            String lectureId,
+            String courseId,
+            Integer limit,
+            Double minScore,
+            boolean includeDebug
+    ) {
         int resolvedLimit = Math.max(1, Math.min(6, limit == null ? 4 : limit));
         String normalizedQuery = normalizeText(query);
         List<String> targetLectureIds = targetLectureIds(lectureId, courseId);
         List<Map<String, Object>> corpus = indexedRagCorpus(targetLectureIds);
+        double threshold = minScore == null ? 0.0 : Math.max(0.0, Math.min(1.0, minScore));
 
         List<Map<String, Object>> rankedChunks = corpus.stream()
                 .map(chunk -> {
@@ -366,6 +378,7 @@ public class FeatureStoreService {
                     mutable.put("similarity", scoreChunk(normalizedQuery, mutable));
                     return mutable;
                 })
+                .filter(item -> asDouble(item.get("similarity")) >= threshold)
                 .sorted(Comparator
                         .comparingDouble((Map<String, Object> item) -> asDouble(item.get("similarity"))).reversed()
                         .thenComparing(item -> String.valueOf(item.getOrDefault("title", ""))))
@@ -421,6 +434,16 @@ public class FeatureStoreService {
         payload.put("answer_payload", answerPayload);
         payload.put("provider", providerPayload);
         payload.put("limit", resolvedLimit);
+        payload.put("min_score", threshold);
+        if (includeDebug) {
+            double avgSimilarity = rankedChunks.stream().mapToDouble(item -> asDouble(item.get("similarity"))).average().orElse(0.0);
+            payload.put("debug", Map.of(
+                    "query_tokens", tokenize(normalizedQuery),
+                    "corpus_size", corpus.size(),
+                    "filtered_count", rankedChunks.size(),
+                    "avg_similarity", Math.round(avgSimilarity * 1000.0) / 1000.0
+            ));
+        }
         return payload;
     }
 
@@ -454,6 +477,24 @@ public class FeatureStoreService {
         return Map.of(
                 "index_id", key,
                 "chunk_count", chunks.size(),
+                "updated_at", payload.get("updated_at")
+        );
+    }
+
+    public Map<String, Object> clearRagIndex(String lectureId, String courseId) {
+        String key = ragIndexKey(lectureId, courseId);
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("id", key);
+        payload.put("lecture_id", lectureId);
+        payload.put("course_id", courseId);
+        payload.put("chunk_count", 0);
+        payload.put("chunks", List.of());
+        payload.put("updated_at", Instant.now().toString());
+        payload.put("cleared", true);
+        store.upsertKv(RAG_INDEX_SCOPE, key, payload);
+        return Map.of(
+                "index_id", key,
+                "cleared", true,
                 "updated_at", payload.get("updated_at")
         );
     }


### PR DESCRIPTION
## 작업 내용\n- RAG 질의 API에 min_score, include_debug 파라미터 추가\n- 유사도 임계치 필터링 및 디버그 메타데이터 응답 지원\n- RAG 인덱스 초기화 API(POST /api/v1/ai/rag/index/clear) 추가\n- 강의/코스 유효성 검증 로직 반영\n\n## 변경 파일\n- backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java\n- backend-spring/src/main/java/com/myway/backendspring/api/AiController.java\n\n## 검증\n- 
pm run test:backend\n- 결과: 33 passed, 0 failed\n\n## 기대 효과\n- 검색 노이즈를 줄이기 위한 임계치 제어 가능\n- 디버그 옵션으로 질의 품질 점검 용이\n- 인덱스 운영 시 재생성 전 초기화 루틴 제공