### PR TITLE
feat: legacy media read endpoints compatibility

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
@@ -106,6 +106,33 @@ public class NotImplementedController {
         return ResponseEntity.ok(ApiResponse.success(featureStore.aiLogs(userId), "legacy ai logs 응답을 /api/v1/ai/logs와 동일하게 반환했습니다."));
     }
 
+    @GetMapping("/legacy/media/providers")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaProviders(@RequestHeader(value = "Authorization", required = false) String auth) {
+        if (sessionService.me(auth) == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.success(featureStore.sttProviders(), "legacy media providers 응답을 /api/v1/media/providers와 동일하게 반환했습니다."));
+    }
+
+    @GetMapping("/legacy/media/processor-health")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaProcessorHealth(@RequestHeader(value = "Authorization", required = false) String auth) {
+        if (sessionService.me(auth) == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.success(featureStore.processorHealth(), "legacy media processor health 응답을 /api/v1/media/processor-health와 동일하게 반환했습니다."));
+    }
+
+    @GetMapping("/legacy/media/pipeline/{lectureId}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaPipeline(
+            @PathVariable String lectureId,
+            @RequestHeader(value = "Authorization", required = false) String auth
+    ) {
+        if (sessionService.me(auth) == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.success(featureStore.pipeline(lectureId), "legacy media pipeline 응답을 /api/v1/media/pipeline/{lectureId}와 동일하게 반환했습니다."));
+    }
+
     @GetMapping("/legacy/mappings")
     public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMappings() {
         return ResponseEntity.ok(ApiResponse.success(Map.of(
@@ -120,7 +147,10 @@ public class NotImplementedController {
                         Map.of("legacy", "/api/v1/legacy/ai/recommendations", "replacement", "/api/v1/ai/recommendations", "status", "available"),
                         Map.of("legacy", "/api/v1/legacy/ai/logs", "replacement", "/api/v1/ai/logs", "status", "available"),
                         Map.of("legacy", "/api/v1/legacy/ai/*", "replacement", "/api/v1/ai/*", "status", "migration_in_progress"),
-                        Map.of("legacy", "/api/v1/legacy/media/*", "replacement", "/api/v1/media/*"),
+                        Map.of("legacy", "/api/v1/legacy/media/providers", "replacement", "/api/v1/media/providers", "status", "available"),
+                        Map.of("legacy", "/api/v1/legacy/media/processor-health", "replacement", "/api/v1/media/processor-health", "status", "available"),
+                        Map.of("legacy", "/api/v1/legacy/media/pipeline/{lectureId}", "replacement", "/api/v1/media/pipeline/{lectureId}", "status", "available"),
+                        Map.of("legacy", "/api/v1/legacy/media/*", "replacement", "/api/v1/media/*", "status", "migration_in_progress"),
                         Map.of("legacy", "/api/v1/legacy/shortform/*", "replacement", "/api/v1/shortform/*")
                 )
         ), "legacy API 매핑 정보를 반환했습니다."));

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/LegacyEndpointMigrationIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/LegacyEndpointMigrationIntegrationTest.java
@@ -45,14 +45,19 @@ class LegacyEndpointMigrationIntegrationTest {
         assertThat(courseMapping.path("status").asText()).isEqualTo("available");
 
         JsonNode aiSettingsMapping = null;
+        JsonNode mediaProvidersMapping = null;
         for (JsonNode node : mappings) {
             if ("/api/v1/legacy/ai/settings".equals(node.path("legacy").asText())) {
                 aiSettingsMapping = node;
-                break;
+            }
+            if ("/api/v1/legacy/media/providers".equals(node.path("legacy").asText())) {
+                mediaProvidersMapping = node;
             }
         }
         assertThat(aiSettingsMapping).isNotNull();
         assertThat(aiSettingsMapping.path("status").asText()).isEqualTo("available");
+        assertThat(mediaProvidersMapping).isNotNull();
+        assertThat(mediaProvidersMapping.path("status").asText()).isEqualTo("available");
     }
 
     @Test
@@ -88,6 +93,29 @@ class LegacyEndpointMigrationIntegrationTest {
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         assertThat(objectMapper.readTree(logs).path("success").asBoolean()).isTrue();
+    }
+
+    @Test
+    void legacyMediaReadEndpoints_shouldReturnModernCompatibleData() throws Exception {
+        String auth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        String providers = mockMvc.perform(get("/api/v1/legacy/media/providers")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(providers).path("success").asBoolean()).isTrue();
+
+        String health = mockMvc.perform(get("/api/v1/legacy/media/processor-health")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(health).path("success").asBoolean()).isTrue();
+
+        String pipeline = mockMvc.perform(get("/api/v1/legacy/media/pipeline/lec_java_01")
+                        .header("Authorization", auth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(pipeline).path("success").asBoolean()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
# 변경 요약
- PR #282 템플릿 정합성 보정
- 제목/본문 형식을 저장소 표준에 맞춰 정리

## 배경
- 276~400 구간 PR 본문/제목 형식이 저장소 템플릿과 일치하지 않는 항목을 정리하기 위해 갱신함

## 변경 내용
- 제목 템플릿 규칙 미준수 건 자동 보정
- PR 본문을 `.github/pull_request_template.md` 구조에 맞춰 표준화

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: historical PR metadata template normalization
- layer tests: n/a (metadata-only rewrite)
- risk/rollback: PR 메타데이터 변경만 수행, 코드 영향 없음

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 시 업데이트