### PR TITLE
refactor: split media and shortform services

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -4,7 +4,7 @@ import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.domain.DemoLearningService;
-import com.myway.backendspring.feature.FeatureStoreService;
+import com.myway.backendspring.feature.media.MediaPipelineService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,18 +19,18 @@ import java.util.Map;
 @RequestMapping("/api/v1/media")
 public class MediaController {
     private final SessionService sessionService;
-    private final FeatureStoreService featureStore;
+    private final MediaPipelineService mediaPipelineService;
     private final DemoLearningService learningService;
     private final String callbackToken;
 
     public MediaController(
             SessionService sessionService,
-            FeatureStoreService featureStore,
+            MediaPipelineService mediaPipelineService,
             DemoLearningService learningService,
             @Value("${myway.media.callback.token:dev-media-callback-token}") String callbackToken
     ) {
         this.sessionService = sessionService;
-        this.featureStore = featureStore;
+        this.mediaPipelineService = mediaPipelineService;
         this.learningService = learningService;
         this.callbackToken = callbackToken;
     }
@@ -64,7 +64,7 @@ public class MediaController {
         if (!canManageMedia(session)) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "영상 업로드는 강사와 운영자만 사용할 수 있습니다."));
         if (lectureId == null || lectureId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
         String fileName = file != null ? file.getOriginalFilename() : "uploaded.mp4";
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.mediaUpload(lectureId.trim(), fileName), "강의 영상이 업로드되었습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(mediaPipelineService.mediaUpload(lectureId.trim(), fileName), "강의 영상이 업로드되었습니다."));
     }
 
     @PostMapping("/extract-audio")
@@ -76,8 +76,8 @@ public class MediaController {
         String lectureId = text(body, "lecture_id");
         String audioUrl = text(body, "audio_url");
         if (lectureId.isEmpty()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
-        Map<String, Object> extraction = featureStore.createExtraction(lectureId, audioUrl.isBlank() ? null : audioUrl);
-        Map<String, Object> dispatched = featureStore.dispatchExtractionJob(String.valueOf(extraction.get("id")), audioUrl.isBlank() ? null : audioUrl);
+        Map<String, Object> extraction = mediaPipelineService.createExtraction(lectureId, audioUrl.isBlank() ? null : audioUrl);
+        Map<String, Object> dispatched = mediaPipelineService.dispatchExtractionJob(String.valueOf(extraction.get("id")), audioUrl.isBlank() ? null : audioUrl);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(dispatched != null ? dispatched : extraction, "오디오 추출 job이 생성되었습니다."));
     }
 
@@ -104,7 +104,7 @@ public class MediaController {
         String sttModel = text(body, "stt_model");
         String audioUrl = text(body, "audio_url");
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(
-                featureStore.transcribe(lectureId, language, durationMs, sttProvider.isBlank() ? null : sttProvider, sttModel.isBlank() ? null : sttModel, audioUrl.isBlank() ? null : audioUrl),
+                mediaPipelineService.transcribe(lectureId, language, durationMs, sttProvider.isBlank() ? null : sttProvider, sttModel.isBlank() ? null : sttModel, audioUrl.isBlank() ? null : audioUrl),
                 "트랜스크립트가 생성되었습니다."
         ));
     }
@@ -118,7 +118,7 @@ public class MediaController {
         if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
         String style = text(body, "style").isBlank() ? "brief" : text(body, "style");
         String language = text(body, "language").isBlank() ? "ko" : text(body, "language");
-        Map<String, Object> note = featureStore.summarizeLecture(lectureId, style, language);
+        Map<String, Object> note = mediaPipelineService.summarizeLecture(lectureId, style, language);
         Map<String, Object> response = Map.of(
                 "note_id", note.get("id"),
                 "lecture_id", note.get("lecture_id"),
@@ -128,7 +128,7 @@ public class MediaController {
                 "keywords", note.get("keywords"),
                 "timestamps", note.get("timestamps"),
                 "style", style,
-                "pipeline", featureStore.pipeline(lectureId)
+                "pipeline", mediaPipelineService.pipeline(lectureId)
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "요약이 생성되었습니다."));
     }
@@ -136,37 +136,37 @@ public class MediaController {
     @GetMapping("/pipeline/{lectureId}")
     public ResponseEntity<ApiResponse<Map<String, Object>>> pipeline(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String lectureId) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.pipeline(lectureId)));
+        return ResponseEntity.ok(ApiResponse.success(mediaPipelineService.pipeline(lectureId)));
     }
 
     @GetMapping("/audio-extractions/{lectureId}")
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> audioExtractions(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String lectureId) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.extractions(lectureId)));
+        return ResponseEntity.ok(ApiResponse.success(mediaPipelineService.extractions(lectureId)));
     }
 
     @GetMapping("/transcript/{lectureId}")
     public ResponseEntity<ApiResponse<Map<String, Object>>> transcript(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String lectureId) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.transcript(lectureId)));
+        return ResponseEntity.ok(ApiResponse.success(mediaPipelineService.transcript(lectureId)));
     }
 
     @GetMapping("/notes/{lectureId}")
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> notes(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String lectureId) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.notes(lectureId)));
+        return ResponseEntity.ok(ApiResponse.success(mediaPipelineService.notes(lectureId)));
     }
 
     @GetMapping("/providers")
     public ResponseEntity<ApiResponse<Map<String, Object>>> providers(@RequestHeader(value = "Authorization", required = false) String auth) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.sttProviders()));
+        return ResponseEntity.ok(ApiResponse.success(mediaPipelineService.sttProviders()));
     }
 
     @GetMapping("/processor-health")
     public ResponseEntity<ApiResponse<Map<String, Object>>> processorHealth(@RequestHeader(value = "Authorization", required = false) String auth) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.processorHealth()));
+        return ResponseEntity.ok(ApiResponse.success(mediaPipelineService.processorHealth()));
     }
 
     @GetMapping("/assets/**")
@@ -184,7 +184,7 @@ public class MediaController {
         if (processorToken == null || !processorToken.equals(callbackToken)) {
             if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
         }
-        Map<String, Object> asset = featureStore.mediaAsset(assetKey);
+        Map<String, Object> asset = mediaPipelineService.mediaAsset(assetKey);
         if (asset == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("ASSET_NOT_FOUND", "미디어 파일을 찾을 수 없습니다."));
         return ResponseEntity.ok(ApiResponse.success(asset));
     }
@@ -210,7 +210,7 @@ public class MediaController {
         String status = body.status() == null ? "COMPLETED" : body.status();
         String errorMessage = body.error_message();
         String audioUrl = body.audio_url() == null ? null : body.audio_url().trim();
-        Map<String, Object> result = featureStore.completeExtractionCallback(
+        Map<String, Object> result = mediaPipelineService.completeExtractionCallback(
                 extractionId,
                 status,
                 errorMessage,
@@ -228,7 +228,7 @@ public class MediaController {
         }
         if (Boolean.TRUE.equals(result.get("callback_ignored"))) {
             return ResponseEntity.ok(ApiResponse.success(
-                    Map.of("extraction", result, "pipeline", featureStore.pipeline(String.valueOf(result.getOrDefault("lecture_id", "")))),
+                    Map.of("extraction", result, "pipeline", mediaPipelineService.pipeline(String.valueOf(result.getOrDefault("lecture_id", "")))),
                     "오래된 callback 이벤트를 무시했습니다."
             ));
         }
@@ -237,7 +237,7 @@ public class MediaController {
         boolean shouldStartStt = "COMPLETED".equalsIgnoreCase(status)
                 || "transcribing".equalsIgnoreCase(String.valueOf(result.getOrDefault("processing_stage", "")));
         if (shouldStartStt && !lectureId.isBlank()) {
-            transcribeResult = featureStore.transcribe(
+            transcribeResult = mediaPipelineService.transcribe(
                     lectureId,
                     "ko",
                     null,
@@ -249,13 +249,13 @@ public class MediaController {
         }
 
         if (transcribeResult == null) {
-            return ResponseEntity.ok(ApiResponse.success(Map.of("extraction", result, "pipeline", featureStore.pipeline(lectureId)), "오디오 추출 callback이 반영되었습니다."));
+            return ResponseEntity.ok(ApiResponse.success(Map.of("extraction", result, "pipeline", mediaPipelineService.pipeline(lectureId)), "오디오 추출 callback이 반영되었습니다."));
         }
 
         return ResponseEntity.ok(ApiResponse.success(
                 Map.of(
                         "extraction", result,
-                        "pipeline", featureStore.pipeline(lectureId),
+                        "pipeline", mediaPipelineService.pipeline(lectureId),
                         "transcript", transcribeResult
                 ),
                 "오디오 추출 callback이 반영되어 STT가 자동 시작되었습니다."

--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -3,7 +3,7 @@ package com.myway.backendspring.api;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
-import com.myway.backendspring.feature.FeatureStoreService;
+import com.myway.backendspring.feature.shortform.ShortformService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,16 +16,16 @@ import java.util.Map;
 @RequestMapping("/api/v1/shortform")
 public class ShortformController {
     private final SessionService sessionService;
-    private final FeatureStoreService featureStore;
+    private final ShortformService shortformService;
     private final String callbackToken;
 
     public ShortformController(
             SessionService sessionService,
-            FeatureStoreService featureStore,
+            ShortformService shortformService,
             @Value("${myway.shortform.callback.token:dev-shortform-callback-token}") String callbackToken
     ) {
         this.sessionService = sessionService;
-        this.featureStore = featureStore;
+        this.shortformService = shortformService;
         this.callbackToken = callbackToken;
     }
 
@@ -35,20 +35,20 @@ public class ShortformController {
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> library(@RequestHeader(value = "Authorization", required = false) String auth) {
         SessionView s = require(auth);
         if (s == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformLibrary(s.user().id())));
+        return ResponseEntity.ok(ApiResponse.success(shortformService.shortformLibrary(s.user().id())));
     }
 
     @GetMapping("/community")
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> community(@RequestHeader(value = "Authorization", required = false) String auth, @RequestParam(value = "course_id", required = false) String courseId) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformCommunity(courseId)));
+        return ResponseEntity.ok(ApiResponse.success(shortformService.shortformCommunity(courseId)));
     }
 
     @PostMapping("/generate")
     public ResponseEntity<ApiResponse<Map<String, Object>>> generate(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
         SessionView s = require(auth);
         if (s == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.createShortformExtraction(s.user().id(), body), "숏폼 후보가 생성되었습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.createShortformExtraction(s.user().id(), body), "숏폼 후보가 생성되었습니다."));
     }
 
     @PutMapping("/candidates/select")
@@ -61,7 +61,7 @@ public class ShortformController {
             return ResponseEntity.badRequest().body(ApiResponse.failure("CANDIDATE_IDS_REQUIRED", "candidate_ids가 필요합니다."));
         }
         List<String> candidateIds = candidateIdsList.stream().map(String::valueOf).toList();
-        Map<String, Object> updated = featureStore.selectShortformCandidates(extractionId, candidateIds);
+        Map<String, Object> updated = shortformService.selectShortformCandidates(extractionId, candidateIds);
         if (updated == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "추출 결과를 찾을 수 없습니다."));
         return ResponseEntity.ok(ApiResponse.success(updated, "후보 선택이 반영되었습니다."));
     }
@@ -69,7 +69,7 @@ public class ShortformController {
     @GetMapping("/extraction/{id}")
     public ResponseEntity<ApiResponse<Map<String, Object>>> extraction(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String id) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        Map<String, Object> row = featureStore.getShortformExtraction(id);
+        Map<String, Object> row = shortformService.getShortformExtraction(id);
         if (row == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "추출 결과를 찾을 수 없습니다."));
         return ResponseEntity.ok(ApiResponse.success(row));
     }
@@ -78,13 +78,13 @@ public class ShortformController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> compose(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
         SessionView s = require(auth);
         if (s == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(featureStore.composeShortform(s.user().id(), body), "숏폼이 생성되었습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.composeShortform(s.user().id(), body), "숏폼이 생성되었습니다."));
     }
 
     @GetMapping("/video/{id}")
     public ResponseEntity<ApiResponse<Map<String, Object>>> video(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String id) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        Map<String, Object> row = featureStore.shortformVideo(id);
+        Map<String, Object> row = shortformService.shortformVideo(id);
         if (row == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("SHORTFORM_NOT_FOUND", "숏폼을 찾을 수 없습니다."));
         return ResponseEntity.ok(ApiResponse.success(row));
     }
@@ -93,14 +93,14 @@ public class ShortformController {
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> videos(@RequestHeader(value = "Authorization", required = false) String auth) {
         SessionView session = require(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformVideos(session.user().id())));
+        return ResponseEntity.ok(ApiResponse.success(shortformService.shortformVideos(session.user().id())));
     }
 
     @PostMapping("/share")
     public ResponseEntity<ApiResponse<Map<String, Object>>> share(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
         SessionView session = require(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        Map<String, Object> row = featureStore.shareShortform(session.user().id(), body);
+        Map<String, Object> row = shortformService.shareShortform(session.user().id(), body);
         if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_SHARE_FAILED", "숏폼을 공유할 수 없습니다."));
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(row, "숏폼이 공유되었습니다."));
     }
@@ -109,7 +109,7 @@ public class ShortformController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> save(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
         SessionView session = require(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        Map<String, Object> row = featureStore.saveShortform(session.user().id(), body);
+        Map<String, Object> row = shortformService.saveShortform(session.user().id(), body);
         if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_SAVE_FAILED", "숏폼을 담아갈 수 없습니다."));
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(row, "숏폼이 담아가기 되었습니다."));
     }
@@ -120,7 +120,7 @@ public class ShortformController {
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
         String videoId = String.valueOf(body.getOrDefault("video_id", "")).trim();
         if (videoId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("VIDEO_ID_REQUIRED", "video_id가 필요합니다."));
-        Map<String, Object> row = featureStore.toggleShortformLike(session.user().id(), videoId);
+        Map<String, Object> row = shortformService.toggleShortformLike(session.user().id(), videoId);
         if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_LIKE_FAILED", "좋아요를 처리할 수 없습니다."));
         return ResponseEntity.ok(ApiResponse.success(row, "좋아요 상태가 반영되었습니다."));
     }
@@ -130,7 +130,7 @@ public class ShortformController {
         SessionView s = require(auth);
         if (s == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
 
-        Map<String, Object> updated = featureStore.retryShortformExport(s.user().id(), shortformId);
+        Map<String, Object> updated = shortformService.retryShortformExport(s.user().id(), shortformId);
         if (updated == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("SHORTFORM_NOT_FOUND", "숏폼을 찾을 수 없습니다."));
         }
@@ -175,7 +175,7 @@ public class ShortformController {
         long eventVersion = body.event_version() != null ? body.event_version() : 1L;
         String status = body.status() != null ? body.status() : "COMPLETED";
 
-        Map<String, Object> updated = featureStore.applyShortformExportCallback(
+        Map<String, Object> updated = shortformService.applyShortformExportCallback(
                 shortformId,
                 status,
                 eventVersion,

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaPipelineService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaPipelineService.java
@@ -1,0 +1,96 @@
+package com.myway.backendspring.feature.media;
+
+import com.myway.backendspring.feature.FeatureStoreService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MediaPipelineService {
+    private final FeatureStoreService featureStoreService;
+
+    public MediaPipelineService(FeatureStoreService featureStoreService) {
+        this.featureStoreService = featureStoreService;
+    }
+
+    public Map<String, Object> mediaUpload(String lectureId, String fileName) {
+        return featureStoreService.mediaUpload(lectureId, fileName);
+    }
+
+    public Map<String, Object> createExtraction(String lectureId, String audioUrl) {
+        return featureStoreService.createExtraction(lectureId, audioUrl);
+    }
+
+    public Map<String, Object> dispatchExtractionJob(String extractionId, String audioUrl) {
+        return featureStoreService.dispatchExtractionJob(extractionId, audioUrl);
+    }
+
+    public Map<String, Object> transcribe(String lectureId, String language, Integer durationMs, String sttProvider, String sttModel, String audioUrl) {
+        return featureStoreService.transcribe(lectureId, language, durationMs, sttProvider, sttModel, audioUrl);
+    }
+
+    public Map<String, Object> transcribe(String lectureId, String language, Integer durationMs, String sttProvider, String sttModel, String audioUrl, String extractionId) {
+        return featureStoreService.transcribe(lectureId, language, durationMs, sttProvider, sttModel, audioUrl, extractionId);
+    }
+
+    public Map<String, Object> summarizeLecture(String lectureId, String style, String language) {
+        return featureStoreService.summarizeLecture(lectureId, style, language);
+    }
+
+    public Map<String, Object> pipeline(String lectureId) {
+        return featureStoreService.pipeline(lectureId);
+    }
+
+    public List<Map<String, Object>> extractions(String lectureId) {
+        return featureStoreService.extractions(lectureId);
+    }
+
+    public Map<String, Object> transcript(String lectureId) {
+        return featureStoreService.transcript(lectureId);
+    }
+
+    public List<Map<String, Object>> notes(String lectureId) {
+        return featureStoreService.notes(lectureId);
+    }
+
+    public Map<String, Object> sttProviders() {
+        return featureStoreService.sttProviders();
+    }
+
+    public Map<String, Object> processorHealth() {
+        return featureStoreService.processorHealth();
+    }
+
+    public Map<String, Object> mediaAsset(String assetKey) {
+        return featureStoreService.mediaAsset(assetKey);
+    }
+
+    public Map<String, Object> completeExtractionCallback(
+            String extractionId,
+            String status,
+            String errorMessage,
+            long eventVersion,
+            String audioUrl,
+            String processingJobId,
+            String processingStage,
+            String processingStep,
+            String audioFormat,
+            Integer sampleRate,
+            Integer channels
+    ) {
+        return featureStoreService.completeExtractionCallback(
+                extractionId,
+                status,
+                errorMessage,
+                eventVersion,
+                audioUrl,
+                processingJobId,
+                processingStage,
+                processingStep,
+                audioFormat,
+                sampleRate,
+                channels
+        );
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
@@ -1,0 +1,32 @@
+package com.myway.backendspring.feature.shortform;
+
+import com.myway.backendspring.feature.FeatureStoreService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ShortformService {
+    private final FeatureStoreService featureStoreService;
+
+    public ShortformService(FeatureStoreService featureStoreService) {
+        this.featureStoreService = featureStoreService;
+    }
+
+    public List<Map<String, Object>> shortformLibrary(String userId) { return featureStoreService.shortformLibrary(userId); }
+    public List<Map<String, Object>> shortformCommunity(String courseId) { return featureStoreService.shortformCommunity(courseId); }
+    public Map<String, Object> createShortformExtraction(String userId, Map<String, Object> payload) { return featureStoreService.createShortformExtraction(userId, payload); }
+    public Map<String, Object> selectShortformCandidates(String extractionId, List<String> candidateIds) { return featureStoreService.selectShortformCandidates(extractionId, candidateIds); }
+    public Map<String, Object> getShortformExtraction(String id) { return featureStoreService.getShortformExtraction(id); }
+    public Map<String, Object> composeShortform(String userId, Map<String, Object> payload) { return featureStoreService.composeShortform(userId, payload); }
+    public Map<String, Object> shortformVideo(String id) { return featureStoreService.shortformVideo(id); }
+    public List<Map<String, Object>> shortformVideos(String userId) { return featureStoreService.shortformVideos(userId); }
+    public Map<String, Object> shareShortform(String userId, Map<String, Object> payload) { return featureStoreService.shareShortform(userId, payload); }
+    public Map<String, Object> saveShortform(String userId, Map<String, Object> payload) { return featureStoreService.saveShortform(userId, payload); }
+    public Map<String, Object> toggleShortformLike(String userId, String videoId) { return featureStoreService.toggleShortformLike(userId, videoId); }
+    public Map<String, Object> retryShortformExport(String userId, String shortformId) { return featureStoreService.retryShortformExport(userId, shortformId); }
+    public Map<String, Object> applyShortformExportCallback(String shortformId, String status, long eventVersion, String videoUrl, String errorMessage) {
+        return featureStoreService.applyShortformExportCallback(shortformId, status, eventVersion, videoUrl, errorMessage);
+    }
+}


### PR DESCRIPTION
# 변경 요약
- PR #291 템플릿 정합성 보정
- 제목/본문 형식을 저장소 표준에 맞춰 정리

## 배경
- 276~400 구간 PR 본문/제목 형식이 저장소 템플릿과 일치하지 않는 항목을 정리하기 위해 갱신함

## 변경 내용
- 제목 템플릿 규칙 미준수 건 자동 보정
- PR 본문을 `.github/pull_request_template.md` 구조에 맞춰 표준화

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: historical PR metadata template normalization
- layer tests: n/a (metadata-only rewrite)
- risk/rollback: PR 메타데이터 변경만 수행, 코드 영향 없음

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 시 업데이트