### PR TITLE
refactor: shortform request DTO boundaries

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
@@ -355,7 +355,10 @@ public class NotImplementedController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody Map<String, Object> body
     ) {
-        return shortformController.generate(auth, body);
+        return shortformController.generate(auth, new ShortformController.GenerateRequest(
+                text(body, "course_id"),
+                text(body, "mode")
+        ));
     }
 
     @PutMapping("/legacy/shortform/candidates/select")
@@ -363,7 +366,10 @@ public class NotImplementedController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody Map<String, Object> body
     ) {
-        return shortformController.select(auth, body);
+        return shortformController.select(auth, new ShortformController.SelectCandidatesRequest(
+                text(body, "extraction_id"),
+                listOfString(body, "candidate_ids")
+        ));
     }
 
     @GetMapping("/legacy/shortform/extraction/{id}")
@@ -379,7 +385,11 @@ public class NotImplementedController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody Map<String, Object> body
     ) {
-        return shortformController.compose(auth, body);
+        return shortformController.compose(auth, new ShortformController.ComposeRequest(
+                text(body, "title"),
+                text(body, "description"),
+                text(body, "course_id")
+        ));
     }
 
     @GetMapping("/legacy/shortform/video/{id}")
@@ -395,7 +405,12 @@ public class NotImplementedController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody Map<String, Object> body
     ) {
-        return shortformController.share(auth, body);
+        return shortformController.share(auth, new ShortformController.ShareRequest(
+                text(body, "video_id"),
+                text(body, "course_id"),
+                text(body, "visibility"),
+                text(body, "message")
+        ));
     }
 
     @PostMapping("/legacy/shortform/save")
@@ -403,7 +418,11 @@ public class NotImplementedController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody Map<String, Object> body
     ) {
-        return shortformController.save(auth, body);
+        return shortformController.save(auth, new ShortformController.SaveRequest(
+                text(body, "video_id"),
+                text(body, "note"),
+                text(body, "folder")
+        ));
     }
 
     @PostMapping("/legacy/shortform/like")
@@ -411,7 +430,9 @@ public class NotImplementedController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody Map<String, Object> body
     ) {
-        return shortformController.like(auth, body);
+        return shortformController.like(auth, new ShortformController.LikeRequest(
+                text(body, "video_id")
+        ));
     }
 
     @PostMapping("/legacy/shortform/{shortformId}/export/retry")
@@ -534,5 +555,16 @@ public class NotImplementedController {
         } catch (NumberFormatException ignored) {
             return null;
         }
+    }
+
+    private List<String> listOfString(Map<String, Object> body, String key) {
+        if (body == null) {
+            return List.of();
+        }
+        Object raw = body.get(key);
+        if (!(raw instanceof List<?> items)) {
+            return List.of();
+        }
+        return items.stream().map(String::valueOf).toList();
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -15,6 +15,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/shortform")
 public class ShortformController {
+    public record GenerateRequest(String course_id, String mode) {}
+    public record SelectCandidatesRequest(String extraction_id, List<String> candidate_ids) {}
+    public record ComposeRequest(String title, String description, String course_id) {}
+    public record ShareRequest(String video_id, String course_id, String visibility, String message) {}
+    public record SaveRequest(String video_id, String note, String folder) {}
+    public record LikeRequest(String video_id) {}
+
     private final SessionService sessionService;
     private final ShortformService shortformService;
     private final String callbackToken;
@@ -45,22 +52,25 @@ public class ShortformController {
     }
 
     @PostMapping("/generate")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> generate(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> generate(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody GenerateRequest body) {
         SessionView s = require(auth);
         if (s == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.createShortformExtraction(s.user().id(), body), "숏폼 후보가 생성되었습니다."));
+        Map<String, Object> payload = Map.of(
+                "course_id", body != null && body.course_id() != null ? body.course_id() : "",
+                "mode", body != null && body.mode() != null ? body.mode() : ""
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.createShortformExtraction(s.user().id(), payload), "숏폼 후보가 생성되었습니다."));
     }
 
     @PutMapping("/candidates/select")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> select(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> select(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody SelectCandidatesRequest body) {
         if (require(auth) == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        String extractionId = String.valueOf(body.getOrDefault("extraction_id", "")).trim();
+        String extractionId = body == null || body.extraction_id() == null ? "" : body.extraction_id().trim();
         if (extractionId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("EXTRACTION_ID_REQUIRED", "extraction_id가 필요합니다."));
-        Object candidateIdsRaw = body.get("candidate_ids");
-        if (!(candidateIdsRaw instanceof List<?> candidateIdsList) || candidateIdsList.isEmpty()) {
+        List<String> candidateIds = body == null || body.candidate_ids() == null ? List.of() : body.candidate_ids().stream().map(String::valueOf).toList();
+        if (candidateIds.isEmpty()) {
             return ResponseEntity.badRequest().body(ApiResponse.failure("CANDIDATE_IDS_REQUIRED", "candidate_ids가 필요합니다."));
         }
-        List<String> candidateIds = candidateIdsList.stream().map(String::valueOf).toList();
         Map<String, Object> updated = shortformService.selectShortformCandidates(extractionId, candidateIds);
         if (updated == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "추출 결과를 찾을 수 없습니다."));
         return ResponseEntity.ok(ApiResponse.success(updated, "후보 선택이 반영되었습니다."));
@@ -75,10 +85,15 @@ public class ShortformController {
     }
 
     @PostMapping("/compose")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> compose(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> compose(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody ComposeRequest body) {
         SessionView s = require(auth);
         if (s == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.composeShortform(s.user().id(), body), "숏폼이 생성되었습니다."));
+        Map<String, Object> payload = Map.of(
+                "title", body != null && body.title() != null ? body.title() : "",
+                "description", body != null && body.description() != null ? body.description() : "",
+                "course_id", body != null && body.course_id() != null ? body.course_id() : ""
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.composeShortform(s.user().id(), payload), "숏폼이 생성되었습니다."));
     }
 
     @GetMapping("/video/{id}")
@@ -97,28 +112,39 @@ public class ShortformController {
     }
 
     @PostMapping("/share")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> share(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> share(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody ShareRequest body) {
         SessionView session = require(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        Map<String, Object> row = shortformService.shareShortform(session.user().id(), body);
+        Map<String, Object> payload = Map.of(
+                "video_id", body != null && body.video_id() != null ? body.video_id() : "",
+                "course_id", body != null && body.course_id() != null ? body.course_id() : "",
+                "visibility", body != null && body.visibility() != null ? body.visibility() : "",
+                "message", body != null && body.message() != null ? body.message() : ""
+        );
+        Map<String, Object> row = shortformService.shareShortform(session.user().id(), payload);
         if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_SHARE_FAILED", "숏폼을 공유할 수 없습니다."));
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(row, "숏폼이 공유되었습니다."));
     }
 
     @PostMapping("/save")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> save(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> save(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody SaveRequest body) {
         SessionView session = require(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        Map<String, Object> row = shortformService.saveShortform(session.user().id(), body);
+        Map<String, Object> payload = Map.of(
+                "video_id", body != null && body.video_id() != null ? body.video_id() : "",
+                "note", body != null && body.note() != null ? body.note() : "",
+                "folder", body != null && body.folder() != null ? body.folder() : ""
+        );
+        Map<String, Object> row = shortformService.saveShortform(session.user().id(), payload);
         if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_SAVE_FAILED", "숏폼을 담아갈 수 없습니다."));
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(row, "숏폼이 담아가기 되었습니다."));
     }
 
     @PostMapping("/like")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> like(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> like(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody LikeRequest body) {
         SessionView session = require(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        String videoId = String.valueOf(body.getOrDefault("video_id", "")).trim();
+        String videoId = body == null || body.video_id() == null ? "" : body.video_id().trim();
         if (videoId.isBlank()) return ResponseEntity.badRequest().body(ApiResponse.failure("VIDEO_ID_REQUIRED", "video_id가 필요합니다."));
         Map<String, Object> row = shortformService.toggleShortformLike(session.user().id(), videoId);
         if (row == null) return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_LIKE_FAILED", "좋아요를 처리할 수 없습니다."));


### PR DESCRIPTION
# 변경 요약
- PR #305 템플릿 정합성 보정
- 제목/본문 형식을 저장소 표준에 맞춰 정리

## 배경
- 276~400 구간 PR 본문/제목 형식이 저장소 템플릿과 일치하지 않는 항목을 정리하기 위해 갱신함

## 변경 내용
- 제목 템플릿 규칙 미준수 건 자동 보정
- PR 본문을 `.github/pull_request_template.md` 구조에 맞춰 표준화

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: historical PR metadata template normalization
- layer tests: n/a (metadata-only rewrite)
- risk/rollback: PR 메타데이터 변경만 수행, 코드 영향 없음

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 시 업데이트