### PR TITLE
refactor: validate course payloads with bean validation

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/ApiValidationExceptionHandler.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ApiValidationExceptionHandler.java
@@ -13,11 +13,32 @@ public class ApiValidationExceptionHandler {
         if (hasUserIdNotBlankViolation(exception)) {
             return ResponseEntity.badRequest().body(ApiResponse.failure("USER_ID_REQUIRED", "로그인할 사용자 식별자가 필요합니다."));
         }
+        if (isCourseCreateInputViolation(exception)) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("COURSE_CREATE_FIELDS_REQUIRED", "강의 제목, 설명, 카테고리, 난이도가 필요합니다."));
+        }
+        if (isMaterialInputViolation(exception)) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("MATERIAL_FIELDS_REQUIRED", "자료 제목, 요약, 파일명이 필요합니다."));
+        }
+        if (isNoticeInputViolation(exception)) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("NOTICE_FIELDS_REQUIRED", "공지 제목과 내용이 필요합니다."));
+        }
         return ResponseEntity.badRequest().body(ApiResponse.failure("INVALID_BODY", "요청 본문이 올바르지 않습니다."));
     }
 
     private boolean hasUserIdNotBlankViolation(MethodArgumentNotValidException exception) {
         return exception.getBindingResult().getFieldErrors().stream()
                 .anyMatch(error -> "userId".equals(error.getField()) && "NotBlank".equals(error.getCode()));
+    }
+
+    private boolean isCourseCreateInputViolation(MethodArgumentNotValidException exception) {
+        return "courseCreateInput".equals(exception.getBindingResult().getObjectName());
+    }
+
+    private boolean isMaterialInputViolation(MethodArgumentNotValidException exception) {
+        return "materialInput".equals(exception.getBindingResult().getObjectName());
+    }
+
+    private boolean isNoticeInputViolation(MethodArgumentNotValidException exception) {
+        return "noticeInput".equals(exception.getBindingResult().getObjectName());
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/CoursesController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/CoursesController.java
@@ -9,6 +9,8 @@ import com.myway.backendspring.domain.learning.application.LearningApplicationSe
 import com.myway.backendspring.domain.learning.model.CourseCard;
 import com.myway.backendspring.domain.learning.model.CourseDetail;
 import com.myway.backendspring.domain.learning.model.LectureItem;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,23 +29,30 @@ public class CoursesController {
         this.learningService = learningService;
     }
 
-    public record MaterialInput(String title, String summary, String file_name) {}
-    public record NoticeInput(String title, String content, Boolean pinned) {}
-    public record CourseCreateInput(String title, String description, String category, String difficulty, List<String> lecture_titles) {}
+    public record MaterialInput(
+            @NotBlank String title,
+            @NotBlank String summary,
+            @NotBlank String file_name
+    ) {}
+    public record NoticeInput(@NotBlank String title, @NotBlank String content, Boolean pinned) {}
+    public record CourseCreateInput(
+            @NotBlank String title,
+            @NotBlank String description,
+            @NotBlank String category,
+            @NotBlank String difficulty,
+            List<String> lecture_titles
+    ) {}
 
     @PostMapping
-    public ResponseEntity<ApiResponse<CourseDetail>> create(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody CourseCreateInput body) {
+    public ResponseEntity<ApiResponse<CourseDetail>> create(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody CourseCreateInput body) {
         SessionView session = sessionService.me(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
         if (!canManageCourses(session.user().role())) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "강의를 개설할 권한이 없습니다."));
-        if (body == null || isBlank(body.title()) || isBlank(body.description()) || isBlank(body.category()) || isBlank(body.difficulty())) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("COURSE_CREATE_FIELDS_REQUIRED", "강의 제목, 설명, 카테고리, 난이도가 필요합니다."));
-        }
 
         List<String> lectureTitles = new ArrayList<>();
         if (body.lecture_titles() != null) {
             for (String lectureTitle : body.lecture_titles()) {
-                if (!isBlank(lectureTitle)) {
+                if (lectureTitle != null && !lectureTitle.trim().isEmpty()) {
                     lectureTitles.add(lectureTitle.trim());
                 }
             }
@@ -87,12 +96,9 @@ public class CoursesController {
     }
 
     @PostMapping("/{courseId}/materials")
-    public ResponseEntity<ApiResponse<MaterialItem>> addMaterial(@PathVariable String courseId, @RequestHeader(value = "Authorization", required = false) String auth, @RequestBody MaterialInput body) {
+    public ResponseEntity<ApiResponse<MaterialItem>> addMaterial(@PathVariable String courseId, @RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody MaterialInput body) {
         SessionView session = sessionService.me(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        if (body == null || isBlank(body.title()) || isBlank(body.summary()) || isBlank(body.file_name())) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("MATERIAL_FIELDS_REQUIRED", "자료 제목, 요약, 파일명이 필요합니다."));
-        }
         MaterialItem item = learningService.addMaterial(session.user().id(), courseId, body.title().trim(), body.summary().trim(), body.file_name().trim());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(item, "자료가 등록되었습니다."));
     }
@@ -103,18 +109,11 @@ public class CoursesController {
     }
 
     @PostMapping("/{courseId}/notices")
-    public ResponseEntity<ApiResponse<NoticeItem>> addNotice(@PathVariable String courseId, @RequestHeader(value = "Authorization", required = false) String auth, @RequestBody NoticeInput body) {
+    public ResponseEntity<ApiResponse<NoticeItem>> addNotice(@PathVariable String courseId, @RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody NoticeInput body) {
         SessionView session = sessionService.me(auth);
         if (session == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-        if (body == null || isBlank(body.title()) || isBlank(body.content())) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("NOTICE_FIELDS_REQUIRED", "공지 제목과 내용이 필요합니다."));
-        }
         NoticeItem item = learningService.addNotice(session.user().id(), courseId, body.title().trim(), body.content().trim(), Boolean.TRUE.equals(body.pinned()));
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(item, "공지가 등록되었습니다."));
-    }
-
-    private boolean isBlank(String value) {
-        return value == null || value.trim().isEmpty();
     }
 
     private boolean canManageCourses(String role) {


### PR DESCRIPTION
# 변경 요약
- PR #335 템플릿 정합성 보정
- 제목/본문 형식을 저장소 표준에 맞춰 정리

## 배경
- 276~400 구간 PR 본문/제목 형식이 저장소 템플릿과 일치하지 않는 항목을 정리하기 위해 갱신함

## 변경 내용
- 제목 템플릿 규칙 미준수 건 자동 보정
- PR 본문을 `.github/pull_request_template.md` 구조에 맞춰 표준화

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: historical PR metadata template normalization
- layer tests: n/a (metadata-only rewrite)
- risk/rollback: PR 메타데이터 변경만 수행, 코드 영향 없음

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 시 업데이트