### PR TITLE
refactor: apply dto wrapper to legacy shortform bridge payloads

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
@@ -375,22 +375,24 @@ public class NotImplementedController {
     @PostMapping("/legacy/shortform/generate")
     public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformGenerate(
             @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody Map<String, Object> body
+            @RequestBody(required = false) LegacyBody body
     ) {
+        Map<String, Object> payload = payloadOf(body);
         return shortformController.generate(auth, new ShortformController.GenerateRequest(
-                text(body, "course_id"),
-                text(body, "mode")
+                text(payload, "course_id"),
+                text(payload, "mode")
         ));
     }
 
     @PutMapping("/legacy/shortform/candidates/select")
     public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformSelect(
             @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody Map<String, Object> body
+            @RequestBody(required = false) LegacyBody body
     ) {
+        Map<String, Object> payload = payloadOf(body);
         return shortformController.select(auth, new ShortformController.SelectCandidatesRequest(
-                text(body, "extraction_id"),
-                listOfString(body, "candidate_ids")
+                text(payload, "extraction_id"),
+                listOfString(payload, "candidate_ids")
         ));
     }
 
@@ -405,12 +407,13 @@ public class NotImplementedController {
     @PostMapping("/legacy/shortform/compose")
     public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformCompose(
             @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody Map<String, Object> body
+            @RequestBody(required = false) LegacyBody body
     ) {
+        Map<String, Object> payload = payloadOf(body);
         return shortformController.compose(auth, new ShortformController.ComposeRequest(
-                text(body, "title"),
-                text(body, "description"),
-                text(body, "course_id")
+                text(payload, "title"),
+                text(payload, "description"),
+                text(payload, "course_id")
         ));
     }
 
@@ -425,35 +428,38 @@ public class NotImplementedController {
     @PostMapping("/legacy/shortform/share")
     public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformShare(
             @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody Map<String, Object> body
+            @RequestBody(required = false) LegacyBody body
     ) {
+        Map<String, Object> payload = payloadOf(body);
         return shortformController.share(auth, new ShortformController.ShareRequest(
-                text(body, "video_id"),
-                text(body, "course_id"),
-                text(body, "visibility"),
-                text(body, "message")
+                text(payload, "video_id"),
+                text(payload, "course_id"),
+                text(payload, "visibility"),
+                text(payload, "message")
         ));
     }
 
     @PostMapping("/legacy/shortform/save")
     public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformSave(
             @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody Map<String, Object> body
+            @RequestBody(required = false) LegacyBody body
     ) {
+        Map<String, Object> payload = payloadOf(body);
         return shortformController.save(auth, new ShortformController.SaveRequest(
-                text(body, "video_id"),
-                text(body, "note"),
-                text(body, "folder")
+                text(payload, "video_id"),
+                text(payload, "note"),
+                text(payload, "folder")
         ));
     }
 
     @PostMapping("/legacy/shortform/like")
     public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformLike(
             @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody Map<String, Object> body
+            @RequestBody(required = false) LegacyBody body
     ) {
+        Map<String, Object> payload = payloadOf(body);
         return shortformController.like(auth, new ShortformController.LikeRequest(
-                text(body, "video_id")
+                text(payload, "video_id")
         ));
     }
 


### PR DESCRIPTION
# 변경 요약
- PR #345 템플릿 정합성 보정
- 제목/본문 형식을 저장소 표준에 맞춰 정리

## 배경
- 276~400 구간 PR 본문/제목 형식이 저장소 템플릿과 일치하지 않는 항목을 정리하기 위해 갱신함

## 변경 내용
- 제목 템플릿 규칙 미준수 건 자동 보정
- PR 본문을 `.github/pull_request_template.md` 구조에 맞춰 표준화

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: historical PR metadata template normalization
- layer tests: n/a (metadata-only rewrite)
- risk/rollback: PR 메타데이터 변경만 수행, 코드 영향 없음

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 시 업데이트