### PR TITLE
refactor: validate shortform export callback request body

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/ApiValidationExceptionHandler.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ApiValidationExceptionHandler.java
@@ -43,6 +43,9 @@ public class ApiValidationExceptionHandler {
         if (isShortformLikeVideoViolation(exception)) {
             return ResponseEntity.badRequest().body(ApiResponse.failure("VIDEO_ID_REQUIRED", "video_id가 필요합니다."));
         }
+        if (isShortformCallbackIdViolation(exception)) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_ID_REQUIRED", "shortform_id가 필요합니다."));
+        }
         return ResponseEntity.badRequest().body(ApiResponse.failure("INVALID_BODY", "요청 본문이 올바르지 않습니다."));
     }
 
@@ -105,5 +108,9 @@ public class ApiValidationExceptionHandler {
 
     private boolean isShortformLikeVideoViolation(MethodArgumentNotValidException exception) {
         return hasNotBlankViolation(exception, "likeRequest", "video_id");
+    }
+
+    private boolean isShortformCallbackIdViolation(MethodArgumentNotValidException exception) {
+        return hasNotBlankViolation(exception, "exportCallbackRequest", "shortform_id");
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -7,6 +7,7 @@ import com.myway.backendspring.feature.shortform.ShortformService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -172,31 +173,23 @@ public class ShortformController {
     }
 
     public record ExportCallbackRequest(
-            String shortform_id,
+            @NotBlank String shortform_id,
             String video_id,
             String status,
             String video_url,
             String error_message,
-            Long event_version
+            @NotNull Long event_version
     ) {}
 
     @PostMapping("/export/callback")
     public ResponseEntity<ApiResponse<Map<String, Object>>> exportCallback(
             @RequestHeader(value = "X-Callback-Token", required = false) String token,
-            @RequestBody ExportCallbackRequest body
+            @Valid @RequestBody ExportCallbackRequest body
     ) {
         if (token == null || token.isBlank() || !token.equals(callbackToken)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "유효한 callback token이 필요합니다."));
         }
-        if (body == null) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("INVALID_BODY", "요청 본문이 올바르지 않습니다."));
-        }
-        String shortformId = body.shortform_id() != null && !body.shortform_id().isBlank()
-                ? body.shortform_id().trim()
-                : (body.video_id() != null ? body.video_id().trim() : "");
-        if (shortformId.isBlank()) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_ID_REQUIRED", "shortform_id가 필요합니다."));
-        }
+        String shortformId = body.shortform_id().trim();
 
         CallbackPolicyDecision decision = CallbackStateTransitionPolicy.decide(body);
         if (!decision.valid()) {
@@ -240,7 +233,7 @@ public class ShortformController {
 
     private static final class CallbackStateTransitionPolicy {
         private static CallbackPolicyDecision decide(ExportCallbackRequest body) {
-            long eventVersion = body.event_version() != null ? body.event_version() : 1L;
+            long eventVersion = body.event_version();
             if (eventVersion < 1L) {
                 return CallbackPolicyDecision.invalid("event_version은 1 이상이어야 합니다.");
             }


### PR DESCRIPTION
# 변경 요약
- PR #353 템플릿 정합성 보정
- 제목/본문 형식을 저장소 표준에 맞춰 정리

## 배경
- 276~400 구간 PR 본문/제목 형식이 저장소 템플릿과 일치하지 않는 항목을 정리하기 위해 갱신함

## 변경 내용
- 제목 템플릿 규칙 미준수 건 자동 보정
- PR 본문을 `.github/pull_request_template.md` 구조에 맞춰 표준화

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: historical PR metadata template normalization
- layer tests: n/a (metadata-only rewrite)
- risk/rollback: PR 메타데이터 변경만 수행, 코드 영향 없음

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 시 업데이트