### PR TITLE
refactor: align media lecture id validation with bean constraints

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/ApiValidationExceptionHandler.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ApiValidationExceptionHandler.java
@@ -52,6 +52,9 @@ public class ApiValidationExceptionHandler {
         if (isShortformCallbackIdViolation(exception)) {
             return ResponseEntity.badRequest().body(ApiResponse.failure("SHORTFORM_ID_REQUIRED", "shortform_id가 필요합니다."));
         }
+        if (isMediaLectureIdViolation(exception)) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
+        }
         return ResponseEntity.badRequest().body(ApiResponse.failure("INVALID_BODY", "요청 본문이 올바르지 않습니다."));
     }
 
@@ -126,6 +129,12 @@ public class ApiValidationExceptionHandler {
 
     private boolean isShortformCallbackIdViolation(MethodArgumentNotValidException exception) {
         return hasNotBlankViolation(exception, "exportCallbackRequest", "shortform_id");
+    }
+
+    private boolean isMediaLectureIdViolation(MethodArgumentNotValidException exception) {
+        return hasNotBlankViolation(exception, "extractAudioRequest", "lecture_id")
+                || hasNotBlankViolation(exception, "transcribeRequest", "lecture_id")
+                || hasNotBlankViolation(exception, "summarizeRequest", "lecture_id");
     }
 
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -100,9 +100,8 @@ public class MediaController {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
         if (!canManageMedia(session)) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "오디오 추출은 강사와 운영자만 사용할 수 있습니다."));
-        String lectureId = body.lecture_id() == null ? "" : body.lecture_id().trim();
+        String lectureId = body.lecture_id().trim();
         String audioUrl = body.audio_url() == null ? "" : body.audio_url().trim();
-        if (lectureId.isEmpty()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
         Map<String, Object> extraction = mediaPipelineService.createExtraction(lectureId, audioUrl.isBlank() ? null : audioUrl);
         Map<String, Object> dispatched = mediaPipelineService.dispatchExtractionJob(String.valueOf(extraction.get("id")), audioUrl.isBlank() ? null : audioUrl);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(dispatched != null ? dispatched : extraction, "오디오 추출 job이 생성되었습니다."));
@@ -111,8 +110,7 @@ public class MediaController {
     @PostMapping("/transcribe")
     public ResponseEntity<ApiResponse<Map<String, Object>>> transcribe(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody TranscribeRequest body) {
         if (require(auth) == null) return unauthenticated();
-        String lectureId = body.lecture_id() == null ? "" : body.lecture_id().trim();
-        if (lectureId.isEmpty()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
+        String lectureId = body.lecture_id().trim();
         if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
         String language = body.language() == null || body.language().isBlank() ? "ko" : body.language().trim();
         Integer durationMs = body.duration_ms();
@@ -128,8 +126,7 @@ public class MediaController {
     @PostMapping("/summarize")
     public ResponseEntity<ApiResponse<Map<String, Object>>> summarize(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody SummarizeRequest body) {
         if (require(auth) == null) return unauthenticated();
-        String lectureId = body.lecture_id() == null ? "" : body.lecture_id().trim();
-        if (lectureId.isEmpty()) return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_ID_REQUIRED", "lecture_id가 필요합니다."));
+        String lectureId = body.lecture_id().trim();
         if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
         String style = body.style() == null || body.style().isBlank() ? "brief" : body.style().trim();
         String language = body.language() == null || body.language().isBlank() ? "ko" : body.language().trim();

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -142,6 +142,32 @@ class MediaContractTest {
     }
 
     @Test
+    void mediaWriteEndpoints_shouldKeepLectureIdRequiredErrorCode_whenLectureIdBlank() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andReturn(), "LECTURE_ID_REQUIRED");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/transcribe")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andReturn(), "LECTURE_ID_REQUIRED");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/summarize")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andReturn(), "LECTURE_ID_REQUIRED");
+    }
+
+    @Test
     void transcribe_shouldCapDurationToPublicPolicyLimit() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
 


### PR DESCRIPTION
# 변경 요약
- PR #360 템플릿 정합성 보정
- 제목/본문 형식을 저장소 표준에 맞춰 정리

## 배경
- 276~400 구간 PR 본문/제목 형식이 저장소 템플릿과 일치하지 않는 항목을 정리하기 위해 갱신함

## 변경 내용
- 제목 템플릿 규칙 미준수 건 자동 보정
- PR 본문을 `.github/pull_request_template.md` 구조에 맞춰 표준화

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: historical PR metadata template normalization
- layer tests: n/a (metadata-only rewrite)
- risk/rollback: PR 메타데이터 변경만 수행, 코드 영향 없음

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 시 업데이트