### PR TITLE
feat(frontend): improve lecture playback UX and admin remap

### DIFF
--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { getLectureDisplayDurationMinutes, type CourseDetail, type LectureDetail } from '@myway/shared';
 import { CourseSessionTimeline } from './CourseSessionTimeline';
 import { StatePanel } from './StatePanel';
 import { buildProtectedVideoUrl } from '../../../lib/video-url';
+import { saveLectureVideoMappingDetailed } from '../../../lib/api-media';
 
 type CourseExploreDetailPanelProps = {
   course: CourseDetail | null;
@@ -173,6 +175,9 @@ export function CourseExploreDetailPanel({
   onTabChange,
   onNavigate,
 }: CourseExploreDetailPanelProps) {
+  const [remapAssetKey, setRemapAssetKey] = useState('');
+  const [remapBusy, setRemapBusy] = useState(false);
+  const [remapMessage, setRemapMessage] = useState<string | null>(null);
   const detailLecture = highlightedLecture;
   const isLocked = Boolean(course && !course.enrolled && !canManageCurrent);
   const protectedVideoUrl = buildProtectedVideoUrl(detailLecture?.video_url, sessionToken);
@@ -182,6 +187,22 @@ export function CourseExploreDetailPanel({
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
       void navigator.clipboard.writeText(fileName);
     }
+  };
+
+  const handleRemapAssetKey = async () => {
+    if (!detailLecture?.id || !remapAssetKey.trim()) {
+      setRemapMessage('asset key를 입력해 주세요.');
+      return;
+    }
+
+    setRemapBusy(true);
+    setRemapMessage(null);
+    const response = await saveLectureVideoMappingDetailed({
+      lecture_id: detailLecture.id,
+      asset_key: remapAssetKey.trim(),
+    }, sessionToken);
+    setRemapBusy(false);
+    setRemapMessage(response?.success ? '재매핑 저장 완료' : (response?.error?.message ?? '재매핑 실패'));
   };
 
   return (
@@ -351,6 +372,35 @@ export function CourseExploreDetailPanel({
                             />
                           </div>
                         )
+                      ) : viewMode === 'watch' ? (
+                        <div className="mt-4 rounded-2xl border border-slate-200 bg-white px-4 py-4">
+                          <div className="text-[12px] font-semibold text-slate-700">재생 가능한 영상이 없습니다.</div>
+                          <p className="mt-2 text-[12px] leading-6 text-slate-500">
+                            강의 영상 URL이 비어 있습니다. 관리자라면 아래에서 R2 asset key를 재매핑할 수 있습니다.
+                          </p>
+                          {canManageCurrent ? (
+                            <div className="mt-3">
+                              <div className="flex flex-wrap gap-2">
+                                <input
+                                  type="text"
+                                  value={remapAssetKey}
+                                  onChange={(event) => setRemapAssetKey(event.target.value)}
+                                  placeholder="media/crs_xxx/lec_xxx.mp4"
+                                  className="min-w-[260px] flex-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-[12px] text-slate-700 placeholder:text-slate-400 focus:border-cyan-300 focus:outline-none"
+                                />
+                                <button
+                                  type="button"
+                                  disabled={remapBusy}
+                                  onClick={() => void handleRemapAssetKey()}
+                                  className="rounded-xl border border-cyan-200 bg-cyan-50 px-3 py-2 text-[12px] font-semibold text-cyan-700 transition hover:bg-cyan-100 disabled:opacity-60"
+                                >
+                                  R2 재매핑
+                                </button>
+                              </div>
+                              {remapMessage ? <div className="mt-2 text-[11px] text-slate-500">{remapMessage}</div> : null}
+                            </div>
+                          ) : null}
+                        </div>
                       ) : null}
                       <div className="mt-4 flex flex-wrap gap-2">
                         {viewMode === 'watch' ? (

--- a/frontend/src/features/lms/pages/LectureWatchPage.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPage.tsx
@@ -3,7 +3,7 @@ import type { CourseCard, CourseDetail, LectureDetail, LectureTranscript } from 
 import { CourseSessionTimeline } from '../components/CourseSessionTimeline';
 import { LectureSideChatPanel } from '../components/LectureSideChatPanel';
 import { StatePanel } from '../components/StatePanel';
-import { loadLectureTranscriptDetailed } from '../../../lib/api-media';
+import { loadLectureTranscriptDetailed, saveLectureVideoMappingDetailed } from '../../../lib/api-media';
 import { buildProtectedVideoUrl } from '../../../lib/video-url';
 
 type LectureWatchPageProps = {
@@ -21,6 +21,7 @@ type LectureWatchPageProps = {
 
 type RightTab = 'sessions' | 'script' | 'chat';
 type ScriptTab = RightTab;
+type VideoPlaybackErrorKind = 'forbidden' | 'not_found' | 'unknown' | null;
 
 function formatDuration(minutes: number): string {
   if (minutes < 60) {
@@ -47,6 +48,12 @@ export function LectureWatchPage({
   const [activePanelTab, setActivePanelTab] = useState<ScriptTab>('sessions');
   const [transcript, setTranscript] = useState<LectureTranscript | null>(null);
   const [transcriptLoading, setTranscriptLoading] = useState(false);
+  const [videoErrorKind, setVideoErrorKind] = useState<VideoPlaybackErrorKind>(null);
+  const [videoErrorMessage, setVideoErrorMessage] = useState<string | null>(null);
+  const [videoChecking, setVideoChecking] = useState(false);
+  const [remapAssetKey, setRemapAssetKey] = useState('');
+  const [remapMessage, setRemapMessage] = useState<string | null>(null);
+  const [remapBusy, setRemapBusy] = useState(false);
   const isLocked = Boolean(selectedCourse && !selectedCourse.enrolled && !canManageCurrent);
   const currentLecture = useMemo(() => {
     if (!selectedCourse) {
@@ -55,6 +62,7 @@ export function LectureWatchPage({
 
     return selectedCourse.lectures.find((lecture) => lecture.id === selectedLectureId) ?? highlightedLecture ?? selectedCourse.lectures[0] ?? null;
   }, [highlightedLecture, selectedCourse, selectedLectureId]);
+  const protectedVideoUrl = buildProtectedVideoUrl(currentLecture?.video_url, sessionToken);
 
   const upcomingLectures = useMemo(() => {
     if (!selectedCourse || !currentLecture) {
@@ -92,6 +100,87 @@ export function LectureWatchPage({
       active = false;
     };
   }, [currentLecture?.id, isLocked, sessionToken]);
+
+  useEffect(() => {
+    let active = true;
+    setVideoErrorKind(null);
+    setVideoErrorMessage(null);
+    setVideoChecking(false);
+
+    if (isLocked || !currentLecture?.video_url || !protectedVideoUrl) {
+      return () => {
+        active = false;
+      };
+    }
+
+    const check = async () => {
+      setVideoChecking(true);
+      try {
+        const response = await fetch(protectedVideoUrl, {
+          method: 'GET',
+          headers: { Range: 'bytes=0-1' },
+        });
+        if (!active) {
+          return;
+        }
+        if (response.ok) {
+          setVideoErrorKind(null);
+          setVideoErrorMessage(null);
+          return;
+        }
+        if (response.status === 403) {
+          setVideoErrorKind('forbidden');
+          setVideoErrorMessage('영상 접근 권한이 없습니다. 토큰 또는 자산 권한을 확인해 주세요.');
+          return;
+        }
+        if (response.status === 404) {
+          setVideoErrorKind('not_found');
+          setVideoErrorMessage('영상 파일을 찾지 못했습니다. R2 키 매핑을 확인해 주세요.');
+          return;
+        }
+        setVideoErrorKind('unknown');
+        setVideoErrorMessage(`영상 재생 확인에 실패했습니다. (HTTP ${response.status})`);
+      } catch {
+        if (active) {
+          setVideoErrorKind('unknown');
+          setVideoErrorMessage('영상 재생 확인 중 네트워크 오류가 발생했습니다.');
+        }
+      } finally {
+        if (active) {
+          setVideoChecking(false);
+        }
+      }
+    };
+
+    void check();
+    return () => {
+      active = false;
+    };
+  }, [currentLecture?.video_url, isLocked, protectedVideoUrl]);
+
+  async function handleRemapAssetKey() {
+    if (!currentLecture?.id || !remapAssetKey.trim()) {
+      setRemapMessage('강의 ID와 asset key를 확인해 주세요.');
+      return;
+    }
+
+    setRemapBusy(true);
+    setRemapMessage(null);
+    const response = await saveLectureVideoMappingDetailed({
+      lecture_id: currentLecture.id,
+      asset_key: remapAssetKey.trim(),
+    }, sessionToken);
+    setRemapBusy(false);
+
+    if (response?.success) {
+      setRemapMessage('R2 재매핑을 저장했습니다. 잠시 후 다시 재생을 시도해 주세요.');
+      setVideoErrorKind(null);
+      setVideoErrorMessage(null);
+      return;
+    }
+
+    setRemapMessage(response?.error?.message ?? '재매핑 저장에 실패했습니다.');
+  }
 
   function formatTimecode(value: number): string {
     const totalSeconds = Math.max(0, Math.floor(value / 1000));
@@ -198,12 +287,37 @@ export function LectureWatchPage({
                   </div>
                 </div>
               ) : currentLecture?.video_url ? (
-                <video
-                  className="aspect-video w-full bg-black"
-                  controls
-                  preload="metadata"
-                  src={buildProtectedVideoUrl(currentLecture.video_url, sessionToken)}
-                />
+                <div className="relative">
+                  <video
+                    className="aspect-video w-full bg-black"
+                    controls
+                    preload="metadata"
+                    src={protectedVideoUrl}
+                    onError={() => {
+                      if (!videoErrorKind) {
+                        setVideoErrorKind('unknown');
+                        setVideoErrorMessage('브라우저 재생 중 오류가 발생했습니다.');
+                      }
+                    }}
+                  />
+                  {videoChecking ? (
+                    <div className="absolute left-3 top-3 rounded-full bg-black/65 px-3 py-1 text-[11px] font-semibold text-white/90">
+                      재생 상태 확인 중...
+                    </div>
+                  ) : null}
+                  {videoErrorKind ? (
+                    <div className="border-t border-white/10 bg-slate-950/90 px-4 py-3 text-[12px] text-white/90">
+                      <div className="font-semibold">
+                        {videoErrorKind === 'forbidden'
+                          ? '403 권한 오류'
+                          : videoErrorKind === 'not_found'
+                            ? '404 파일 없음'
+                            : '재생 오류'}
+                      </div>
+                      <div className="mt-1 text-white/70">{videoErrorMessage ?? '영상 상태를 확인해 주세요.'}</div>
+                    </div>
+                  ) : null}
+                </div>
               ) : (
                 <div className="flex aspect-video items-center justify-center bg-[linear-gradient(135deg,#020617_0%,#111827_50%,#1e293b_100%)] text-white">
                   <div className="text-center">
@@ -212,6 +326,32 @@ export function LectureWatchPage({
                     </div>
                     <div className="mt-4 text-[15px] font-semibold">재생 가능한 영상이 없습니다.</div>
                     <div className="mt-1 text-[12px] text-white/65">이 차시는 텍스트/자료 기반으로 확인할 수 있습니다.</div>
+                    {canManageCurrent ? (
+                      <div className="mx-auto mt-4 flex max-w-xl flex-col gap-2 text-left">
+                        <label htmlFor="lecture-remap-asset-key" className="text-[11px] font-semibold text-white/80">
+                          관리자: R2 asset key 재매핑
+                        </label>
+                        <div className="flex flex-wrap gap-2">
+                          <input
+                            id="lecture-remap-asset-key"
+                            type="text"
+                            value={remapAssetKey}
+                            onChange={(event) => setRemapAssetKey(event.target.value)}
+                            placeholder="media/crs_xxx/lec_xxx.mp4"
+                            className="min-w-[260px] flex-1 rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-[12px] text-white placeholder:text-white/45 focus:border-cyan-300 focus:outline-none"
+                          />
+                          <button
+                            type="button"
+                            disabled={remapBusy}
+                            onClick={() => void handleRemapAssetKey()}
+                            className="rounded-xl bg-cyan-500 px-4 py-2 text-[12px] font-semibold text-slate-950 transition hover:bg-cyan-400 disabled:opacity-60"
+                          >
+                            R2 재매핑
+                          </button>
+                        </div>
+                        {remapMessage ? <div className="text-[11px] text-white/70">{remapMessage}</div> : null}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               )}

--- a/frontend/src/lib/api-media.ts
+++ b/frontend/src/lib/api-media.ts
@@ -25,6 +25,18 @@ export type MediaExtractionResult = {
   pipeline: LecturePipeline;
 };
 
+export type LectureVideoMappingInput = {
+  lecture_id: string;
+  asset_key: string;
+  video_url?: string;
+};
+
+export type LectureVideoMappingResult = {
+  lecture_id: string;
+  asset_key: string;
+  video_url: string;
+};
+
 export async function uploadLectureVideoDetailed(
   lectureId: string,
   file: File,
@@ -112,4 +124,15 @@ export async function loadMediaProcessorHealth(sessionToken?: string | null): Pr
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
   const response = await request<MediaProcessorHealth>('/api/v1/media/processor-health', undefined, token);
   return response?.success && response.data ? response.data : null;
+}
+
+export async function saveLectureVideoMappingDetailed(
+  input: LectureVideoMappingInput,
+  sessionToken?: string | null,
+): Promise<ApiRequestResult<LectureVideoMappingResult> | null> {
+  const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
+  return await request<LectureVideoMappingResult>('/api/v1/media/lecture-video', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  }, token);
 }


### PR DESCRIPTION
# 변경 요약
강의 상세/시청 UX를 개선하여 영상 미연결 안내, 재생 오류 코드(403/404/기타) 분리 안내, 관리자 R2 재매핑 액션을 추가했습니다.

## 배경
R2 자산이 존재해도 강의의 `video_url`/매핑 누락으로 재생 실패가 발생할 때 원인 구분이 어려웠고, 관리자 재매핑을 화면에서 바로 수행할 수 없었습니다.

## 변경 내용
- `LectureWatchPage`
- `video_url` 없음 상태 안내 UI 추가
- 재생 사전 확인(fetch range)으로 403/404/기타 오류 메시지 분리
- 관리자용 `R2 재매핑` 입력/저장 버튼 추가 (`POST /api/v1/media/lecture-video`)
- `CourseExploreDetailPanel`
- 시청 모드에서 `video_url` 없음 상태 안내 UI 추가
- 관리자용 `R2 재매핑` 버튼 추가
- `api-media`
- `saveLectureVideoMappingDetailed` API 유틸 추가

## 연결 이슈
- 없음

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:frontend` 통과
- layer tests: 프론트 빌드 기준 타입/번들 검증 완료
- risk/rollback: UI/호출 추가 범위이며 롤백은 PR revert 1회로 가능

## ADR 링크
- ADR: 해당 없음
- 상태 변경: 해당 없음