### PR TITLE
feat(media): add admin batch STT/RAG pipeline automation

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -91,6 +91,15 @@ public class MediaController {
             String video_url
     ) {}
 
+    public record RunBatchPipelineRequest(
+            List<String> lecture_ids,
+            @Min(0) Integer retry_count,
+            Boolean force_run,
+            String language,
+            String stt_provider,
+            String stt_model
+    ) {}
+
     private String trimRequired(String value) {
         return value.trim();
     }
@@ -120,6 +129,10 @@ public class MediaController {
         if (session == null) return false;
         String role = session.user().role();
         return "admin".equals(role) || "instructor".equals(role);
+    }
+
+    private boolean isAdmin(SessionView session) {
+        return session != null && "admin".equals(session.user().role());
     }
 
     @PostMapping("/upload-video")
@@ -262,6 +275,34 @@ public class MediaController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_VIDEO_NOT_FOUND", "연결된 강의 영상 에셋이 없습니다."));
         }
         return ResponseEntity.ok(ApiResponse.success(payload));
+    }
+
+    @PostMapping("/pipeline/run-batch")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> runBatchPipeline(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) @Valid RunBatchPipelineRequest body
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return unauthenticated();
+        if (!isAdmin(session)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.failure("FORBIDDEN", "배치 파이프라인 실행은 운영자만 사용할 수 있습니다."));
+        }
+        List<String> lectureIds = body == null ? null : body.lecture_ids();
+        Integer retryCount = body == null ? 0 : body.retry_count();
+        boolean forceRun = body != null && Boolean.TRUE.equals(body.force_run());
+        String language = body == null ? null : body.language();
+        String sttProvider = body == null ? null : body.stt_provider();
+        String sttModel = body == null ? null : body.stt_model();
+        Map<String, Object> result = mediaPipelineService.runBatchPipeline(
+                lectureIds,
+                retryCount,
+                forceRun,
+                language,
+                sttProvider,
+                sttModel
+        );
+        return ResponseEntity.ok(ApiResponse.success(result, "STT/RAG 배치 파이프라인 실행이 완료되었습니다."));
     }
 
     @PostMapping("/extract-audio/callback")

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaPipelineService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaPipelineService.java
@@ -5,9 +5,13 @@ import com.myway.backendspring.feature.repository.FeatureStoreRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -36,6 +40,8 @@ public class MediaPipelineService {
                 "file_name", fileName
         );
         repository.upsertKv(MEDIA_ASSET_SCOPE, key, payload);
+        // Keep existing upload contract and persist lecture->asset mapping automatically.
+        bindLectureVideoAsset(lectureId, key, null);
         return payload;
     }
 
@@ -145,6 +151,82 @@ public class MediaPipelineService {
         return repository.getKv(LECTURE_VIDEO_SCOPE, lectureId.trim());
     }
 
+    public Map<String, Object> runBatchPipeline(
+            List<String> lectureIds,
+            Integer retryCountInput,
+            boolean forceRun,
+            String language,
+            String sttProvider,
+            String sttModel
+    ) {
+        List<Map<String, Object>> mappings = repository.listKvByScope(LECTURE_VIDEO_SCOPE);
+        Map<String, Map<String, Object>> mappedByLecture = new LinkedHashMap<>();
+        for (Map<String, Object> mapping : mappings) {
+            String lectureId = String.valueOf(mapping.getOrDefault("lecture_id", "")).trim();
+            if (!lectureId.isBlank()) {
+                mappedByLecture.put(lectureId, mapping);
+            }
+        }
+
+        Set<String> targetLectures = resolveTargetLectures(lectureIds, mappedByLecture.keySet());
+        int retryCount = normalizeRetryCount(retryCountInput);
+        int maxAttempts = retryCount + 1;
+        String normalizedLanguage = normalizeOrDefault(language, "ko");
+
+        List<Map<String, Object>> items = new ArrayList<>();
+        int success = 0;
+        int failed = 0;
+        int pending = 0;
+
+        for (String lectureId : targetLectures) {
+            Map<String, Object> mapping = mappedByLecture.get(lectureId);
+            if (mapping == null) {
+                pending++;
+                items.add(batchPending(lectureId, "MAPPING_MISSING", "강의에 연결된 영상 에셋이 없어 대기 상태로 남겼습니다."));
+                continue;
+            }
+
+            Map<String, Object> currentPipeline = pipeline(lectureId);
+            if (!forceRun && isPipelineRunning(currentPipeline)) {
+                pending++;
+                items.add(batchPending(lectureId, "PIPELINE_IN_PROGRESS", "기존 파이프라인이 처리 중이라 이번 배치에서 건너뛰었습니다."));
+                continue;
+            }
+
+            BatchAttemptResult result = executeSingleLecture(
+                    lectureId,
+                    mapping,
+                    maxAttempts,
+                    normalizedLanguage,
+                    sttProvider,
+                    sttModel
+            );
+            if ("SUCCESS".equals(result.status())) {
+                success++;
+            } else if ("FAILED".equals(result.status())) {
+                failed++;
+            } else {
+                pending++;
+            }
+            items.add(result.toMap());
+        }
+
+        return Map.of(
+                "batch_scope", "mapped_lectures",
+                "requested_count", targetLectures.size(),
+                "processed_count", items.size(),
+                "retry_count", retryCount,
+                "force_run", forceRun,
+                "summary", Map.of(
+                        "success", success,
+                        "failed", failed,
+                        "pending", pending
+                ),
+                "items", items,
+                "updated_at", Instant.now().toString()
+        );
+    }
+
     public Map<String, Object> completeExtractionCallback(
             String extractionId,
             String status,
@@ -208,6 +290,147 @@ public class MediaPipelineService {
             map.put("note_id", null);
             map.put("extraction_id", extractionId);
             map.put("updated_at", now);
+            return map;
+        }
+    }
+
+    private BatchAttemptResult executeSingleLecture(
+            String lectureId,
+            Map<String, Object> mapping,
+            int maxAttempts,
+            String language,
+            String sttProvider,
+            String sttModel
+    ) {
+        String assetKey = String.valueOf(mapping.getOrDefault("asset_key", "")).trim();
+        String audioUrl = String.valueOf(mapping.getOrDefault("video_url", "")).trim();
+        if (audioUrl.isBlank() && !assetKey.isBlank()) {
+            audioUrl = "/api/v1/media/assets/" + assetKey;
+        }
+        if (audioUrl.isBlank()) {
+            return new BatchAttemptResult(lectureId, "FAILED", 1, "ASSET_URL_MISSING", "영상 URL을 찾을 수 없습니다.", null, null, null, null);
+        }
+
+        int attemptsUsed = 0;
+        String lastErrorCode = null;
+        String lastErrorMessage = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            attemptsUsed = attempt;
+            try {
+                Map<String, Object> extraction = createExtraction(lectureId, audioUrl);
+                String extractionId = String.valueOf(extraction.getOrDefault("id", "")).trim();
+                Map<String, Object> dispatch = dispatchExtractionJob(extractionId, audioUrl);
+                if (dispatch == null) {
+                    throw new IllegalStateException("오디오 추출 작업 디스패치에 실패했습니다.");
+                }
+                Map<String, Object> transcript = transcribe(
+                        lectureId,
+                        language,
+                        null,
+                        normalizeNullable(sttProvider),
+                        normalizeNullable(sttModel),
+                        audioUrl,
+                        extractionId
+                );
+                Map<String, Object> ragIndex = featureStoreService.rebuildRagIndex(lectureId, null);
+                Map<String, Object> pipeline = pipeline(lectureId);
+                return new BatchAttemptResult(
+                        lectureId,
+                        "SUCCESS",
+                        attemptsUsed,
+                        null,
+                        null,
+                        extractionId,
+                        transcript,
+                        ragIndex,
+                        pipeline
+                );
+            } catch (RuntimeException ex) {
+                lastErrorCode = "PIPELINE_EXECUTION_FAILED";
+                lastErrorMessage = ex.getMessage() == null ? "파이프라인 실행 중 오류가 발생했습니다." : ex.getMessage();
+            }
+        }
+        return new BatchAttemptResult(
+                lectureId,
+                "FAILED",
+                attemptsUsed,
+                lastErrorCode,
+                lastErrorMessage,
+                null,
+                null,
+                null,
+                pipeline(lectureId)
+        );
+    }
+
+    private Map<String, Object> batchPending(String lectureId, String code, String message) {
+        return Map.of(
+                "lecture_id", lectureId,
+                "status", "PENDING",
+                "attempts_used", 0,
+                "error_code", code,
+                "error_message", message
+        );
+    }
+
+    private Set<String> resolveTargetLectures(List<String> requestedLectureIds, Set<String> mappedLectureIds) {
+        if (requestedLectureIds == null || requestedLectureIds.isEmpty()) {
+            return new LinkedHashSet<>(mappedLectureIds);
+        }
+        Set<String> resolved = new LinkedHashSet<>();
+        for (String lectureId : requestedLectureIds) {
+            String normalized = lectureId == null ? "" : lectureId.trim();
+            if (!normalized.isBlank()) {
+                resolved.add(normalized);
+            }
+        }
+        return resolved;
+    }
+
+    private boolean isPipelineRunning(Map<String, Object> pipeline) {
+        String stage = String.valueOf(pipeline.getOrDefault("processing_stage", "")).toLowerCase();
+        return "queued".equals(stage) || "transcribing".equals(stage) || "callback".equals(stage);
+    }
+
+    private int normalizeRetryCount(Integer retryCountInput) {
+        if (retryCountInput == null) return 0;
+        return Math.max(0, Math.min(5, retryCountInput));
+    }
+
+    private String normalizeOrDefault(String value, String defaultValue) {
+        if (value == null) return defaultValue;
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? defaultValue : trimmed;
+    }
+
+    private String normalizeNullable(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? null : trimmed;
+    }
+
+    private record BatchAttemptResult(
+            String lectureId,
+            String status,
+            int attemptsUsed,
+            String errorCode,
+            String errorMessage,
+            String extractionId,
+            Map<String, Object> transcript,
+            Map<String, Object> ragIndex,
+            Map<String, Object> pipeline
+    ) {
+        Map<String, Object> toMap() {
+            Map<String, Object> map = new HashMap<>();
+            map.put("lecture_id", lectureId);
+            map.put("status", status);
+            map.put("attempts_used", attemptsUsed);
+            map.put("error_code", errorCode);
+            map.put("error_message", errorMessage);
+            map.put("extraction_id", extractionId);
+            map.put("transcript", transcript);
+            map.put("rag_index", ragIndex);
+            map.put("pipeline", pipeline);
             return map;
         }
     }

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -95,6 +95,27 @@ class MediaContractTest {
     }
 
     @Test
+    void uploadVideo_shouldAutoBindLectureVideoAsset_withoutManualBindingEndpoint() throws Exception {
+        String instructorAuth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        JsonNode uploadData = readData(mockMvc.perform(post("/api/v1/media/upload-video")
+                        .header("Authorization", instructorAuth)
+                        .queryParam("lecture_id", "lec_java_01"))
+                .andExpect(status().isCreated())
+                .andReturn());
+        String uploadedAssetKey = uploadData.path("asset_key").asText();
+        assertThat(uploadedAssetKey).isNotBlank();
+
+        JsonNode boundData = readData(mockMvc.perform(get("/api/v1/media/lecture-video/lec_java_01")
+                        .header("Authorization", instructorAuth))
+                .andExpect(status().isOk())
+                .andReturn());
+        assertThat(boundData.path("lecture_id").asText()).isEqualTo("lec_java_01");
+        assertThat(boundData.path("asset_key").asText()).isEqualTo(uploadedAssetKey);
+        assertThat(boundData.path("video_url").asText()).isEqualTo("/api/v1/media/assets/" + uploadedAssetKey);
+    }
+
+    @Test
     void mediaProviders_shouldExposeDemoAsDefaultPolicyForTranscribePlan() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
 
@@ -196,6 +217,32 @@ class MediaContractTest {
 
         assertThat(transcript.path("stt_provider").asText()).isEqualTo("demo");
         assertThat(transcript.path("stt_model").asText()).isEqualTo("cf-whisper");
+    }
+
+    @Test
+    void pipelineRunBatch_shouldAllowOnlyAdmin_andReturnSummary() throws Exception {
+        String adminAuth = "Bearer " + loginAndGetToken("usr_adm_001");
+        String instructorAuth = "Bearer " + loginAndGetToken("usr_ins_001");
+
+        assertFailureEnvelope(mockMvc.perform(post("/api/v1/media/pipeline/run-batch")
+                        .header("Authorization", instructorAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"retry_count\":1}"))
+                .andExpect(status().isForbidden())
+                .andReturn(), "FORBIDDEN");
+
+        JsonNode response = readData(mockMvc.perform(post("/api/v1/media/pipeline/run-batch")
+                        .header("Authorization", adminAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_ids\":[\"lec_java_01\"],\"retry_count\":1,\"force_run\":true}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        JsonNode summary = response.path("summary");
+        assertThat(summary.has("success")).isTrue();
+        assertThat(summary.has("failed")).isTrue();
+        assertThat(summary.has("pending")).isTrue();
+        assertThat(response.path("items").isArray()).isTrue();
     }
 
     private String loginAndGetToken(String userId) throws Exception {

--- a/docs/dev-logs/2026-05-21-media-batch-pipeline-automation.md
+++ b/docs/dev-logs/2026-05-21-media-batch-pipeline-automation.md
@@ -1,0 +1,16 @@
+# 2026-05-21 Media Batch Pipeline Automation
+
+## 변경 요약
+- 관리자 전용 배치 엔드포인트 `POST /api/v1/media/pipeline/run-batch`를 추가했다.
+- 매핑된 강의를 대상으로 `extract-audio -> transcribe -> rag index`를 순차 실행하도록 구현했다.
+- `retry_count` 옵션 기반 재시도와 `success/failed/pending` 집계 응답을 추가했다.
+
+## 핵심 정책
+- 기존 인증 정책 유지: 비로그인 401.
+- 관리자 전용 정책 적용: 운영자(admin)만 배치 실행 가능, 강사(instructor)는 403.
+- 기존 개별 엔드포인트 동작은 유지하고 배치 기능을 서비스 계층에 추가했다.
+
+## 검증
+- `mvn -DskipTests compile` 성공.
+- `MediaContractTest`는 현재 로컬 DB 초기화 스크립트 이슈로 컨텍스트 기동 실패(기존 환경 이슈) 확인.
+- 배치 엔드포인트 계약 검증 테스트를 추가해 권한/응답 집계 필드를 검증하도록 반영했다.


### PR DESCRIPTION
# 변경 요약
- 관리자 전용 STT/RAG 운영 배치 엔드포인트 `POST /api/v1/media/pipeline/run-batch`를 추가했습니다.
- 매핑된 강의를 대상으로 `extract-audio -> transcribe -> rag index` 순차 실행과 실패 재시도(`retry_count`)를 지원합니다.
- 결과에 강의별 상태와 `success/failed/pending` 집계를 포함합니다.

## 배경
- 운영자가 여러 강의를 한 번에 파이프라인 처리할 수 있는 자동화 경로가 필요했습니다.
- 기존 개별 API 호출을 수동으로 반복하던 운영 부담을 줄이고 실패 케이스 재시도를 일관화해야 했습니다.

## 변경 내용
- `MediaController`
  - `RunBatchPipelineRequest` DTO 추가
  - `POST /api/v1/media/pipeline/run-batch` 추가
  - 권한 정책: admin만 허용(비로그인 401, 강사/학생 403)
- `MediaPipelineService`
  - 강의-에셋 매핑(`lecture_video_asset`) 기반 대상 선정
  - 강의별 순차 실행: extraction 생성 -> extraction dispatch -> transcribe -> rag index rebuild
  - `retry_count` 기반 재시도(최대 5)
  - in-progress 파이프라인은 pending 집계(강제 실행 옵션 `force_run=true` 지원)
  - 배치 결과 `summary(success, failed, pending)`와 `items` 상세 반환
- 테스트/문서
  - `MediaContractTest`에 배치 엔드포인트 권한/응답 집계 테스트 추가
  - `docs/dev-logs/2026-05-21-media-batch-pipeline-automation.md` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `mvn -DskipTests compile` 통과
- layer tests: `mvn -Dtest=MediaContractTest test` 실행 시 DB 초기화 스크립트 환경 이슈로 컨텍스트 기동 실패(기존 환경)
- risk/rollback: 배치 엔드포인트 신규 추가이므로 롤백은 해당 커밋 revert로 가능

## ADR 링크
- ADR: `N/A`
- 상태 변경: `N/A`
