### PR TITLE
fix(ci): orchestration gate decision path refresh

### DIFF
--- a/.github/workflows/orchestration-gate.yml
+++ b/.github/workflows/orchestration-gate.yml
@@ -64,6 +64,22 @@ jobs:
           ORCH_PROFILE: strict
           ORCH_TARGET_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
 
+      - name: Refresh decision path after gate run
+        run: |
+          set -euo pipefail
+          candidates=(
+            "${PROJECT_DIR}/_workspace/decision.json"
+            "_workspace/decision.json"
+            "decision.json"
+          )
+          for p in "${candidates[@]}"; do
+            if [ -f "$p" ]; then
+              echo "DECISION_PATH=$p" >> "$GITHUB_ENV"
+              exit 0
+            fi
+          done
+          echo "DECISION_PATH=" >> "$GITHUB_ENV"
+
       - name: Ensure decision artifact exists
         run: |
           set -euo pipefail


### PR DESCRIPTION
orchestration-gate에서 orch:run 이후 생성된 decision artifact 경로를 재탐색하도록 수정했습니다.\n\n원인: DECISION_PATH를 gate 실행 전에만 계산해 빈 값으로 남아 'decision artifact missing' 실패 발생.