### PR TITLE
feat: add failed lecture metadata to admin media batch status

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaBatchService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaBatchService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,19 +50,21 @@ public class MediaBatchService {
             int success = 0;
             int failure = 0;
             int pending = 0;
-            List<String> failedLectures = new ArrayList<>();
+            List<Map<String, Object>> failedLectures = new ArrayList<>();
+            String failedAt = Instant.now().toString();
 
             for (String lectureId : targets) {
+                LectureItem lecture = learningService.getLecture(lectureId);
                 Map<String, Object> mapping = mediaPipelineService.lectureVideoAssetMapping(lectureId);
                 if (mapping == null) {
                     pending++;
-                    failedLectures.add(lectureId);
+                    failedLectures.add(failedLectureItem(lecture, "MAPPING_MISSING", failedAt));
                     continue;
                 }
                 String assetKey = String.valueOf(mapping.getOrDefault("asset_key", "")).trim();
                 if (assetKey.isBlank()) {
                     pending++;
-                    failedLectures.add(lectureId);
+                    failedLectures.add(failedLectureItem(lecture, "ASSET_KEY_MISSING", failedAt));
                     continue;
                 }
 
@@ -72,7 +75,7 @@ public class MediaBatchService {
                 String status = String.valueOf(dispatched == null ? "" : dispatched.getOrDefault("status", "")).toUpperCase();
                 if ("FAILED".equals(status)) {
                     failure++;
-                    failedLectures.add(lectureId);
+                    failedLectures.add(failedLectureItem(lecture, "DISPATCH_FAILED", failedAt));
                 } else if ("PROCESSING".equals(status) || "PENDING".equals(status) || status.isBlank()) {
                     pending++;
                 } else {
@@ -135,6 +138,14 @@ public class MediaBatchService {
             return learningService.listAllLectures().stream().map(LectureItem::id).toList();
         }
 
+        Map<String, Object> previousStatus = mediaPipelineService.batchStatus();
+        if (previousStatus != null) {
+            List<String> fromPrevious = extractFailedLectureIds(previousStatus.get("failed_lectures"));
+            if (!fromPrevious.isEmpty()) {
+                return fromPrevious;
+            }
+        }
+
         List<String> failed = new ArrayList<>();
         for (LectureItem lecture : learningService.listAllLectures()) {
             Map<String, Object> pipeline = mediaPipelineService.pipeline(lecture.id());
@@ -148,5 +159,39 @@ public class MediaBatchService {
             }
         }
         return failed;
+    }
+
+    private Map<String, Object> failedLectureItem(LectureItem lecture, String reason, String failedAt) {
+        Map<String, Object> item = new HashMap<>();
+        String lectureId = lecture == null ? "" : lecture.id();
+        item.put("lecture_id", lectureId);
+        item.put("lecture_title", lecture == null ? lectureId : lecture.title());
+        item.put("course_title", lecture == null ? null : lecture.course_id());
+        item.put("failed_reason", reason);
+        item.put("failed_at", failedAt);
+        return item;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractFailedLectureIds(Object rawFailedLectures) {
+        if (!(rawFailedLectures instanceof List<?> list)) {
+            return List.of();
+        }
+
+        List<String> ids = new ArrayList<>();
+        for (Object row : list) {
+            if (row instanceof String s && !s.isBlank()) {
+                ids.add(s.trim());
+                continue;
+            }
+            if (row instanceof Map<?, ?> map) {
+                Object lectureIdRaw = map.containsKey("lecture_id") ? map.get("lecture_id") : "";
+                String lectureId = String.valueOf(lectureIdRaw).trim();
+                if (!lectureId.isBlank()) {
+                    ids.add(lectureId);
+                }
+            }
+        }
+        return ids;
     }
 }

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AdminMediaBatchIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AdminMediaBatchIntegrationTest.java
@@ -56,6 +56,7 @@ class AdminMediaBatchIntegrationTest {
         JsonNode runData = objectMapper.readTree(run).path("data");
         assertThat(runData.path("last_run_at").asText()).isNotBlank();
         assertThat(runData.path("target_count").asInt()).isGreaterThan(0);
+        assertThat(runData.path("failed_lectures").isArray()).isTrue();
 
         String statusRes = mockMvc.perform(get("/api/v1/admin/media/batch/status")
                         .header("Authorization", adminAuth))
@@ -66,6 +67,12 @@ class AdminMediaBatchIntegrationTest {
         JsonNode statusData = objectMapper.readTree(statusRes).path("data");
         assertThat(statusData.path("last_run_at").asText()).isNotBlank();
         assertThat(statusData.path("mode").asText()).isIn("all", "failed-only");
+        if (statusData.path("failed_lectures").isArray() && statusData.path("failed_lectures").size() > 0) {
+            JsonNode firstFailed = statusData.path("failed_lectures").get(0);
+            assertThat(firstFailed.path("lecture_id").asText()).isNotBlank();
+            assertThat(firstFailed.has("failed_reason")).isTrue();
+            assertThat(firstFailed.has("failed_at")).isTrue();
+        }
     }
 
     @Test


### PR DESCRIPTION
# 변경 요약
관리자 배치 상태의 `failed_lectures`를 문자열 목록에서 구조화 메타데이터(강의/사유/시각)로 확장했습니다.

## 배경
- 관리자 화면에서 실패 강의 목록을 클릭/재실행할 때 사유와 시각이 필요했지만, 백엔드는 ID 문자열만 저장하고 있었습니다.

## 변경 내용
- `MediaBatchService`
  - `failed_lectures`를 객체 배열로 저장
    - `lecture_id`, `lecture_title`, `course_title`, `failed_reason`, `failed_at`
  - `failed-only` 모드 타깃 선정 시 직전 배치의 `failed_lectures`를 우선 사용
  - 이전 포맷(문자열 배열)과의 호환을 위해 파싱 로직 유지
- `AdminMediaBatchIntegrationTest`
  - 배치 상태 응답에서 `failed_lectures` 구조 필드 검증 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run test:backend:clean` 통과
- layer tests: `AdminMediaBatchIntegrationTest` 포함 전체 backend test pass
- risk/rollback: 응답 형식 확장(하위호환 유지), 문제 시 `failed_lectures` 포맷 변경만 롤백 가능

## ADR 링크
- ADR: `없음`
- 상태 변경: `해당 없음`