### PR TITLE
fix(batch): resolve failed lecture course title from course detail

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaBatchService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaBatchService.java
@@ -1,6 +1,7 @@
 package com.myway.backendspring.feature.media;
 
 import com.myway.backendspring.domain.DemoLearningService;
+import com.myway.backendspring.domain.CourseDetail;
 import com.myway.backendspring.domain.LectureItem;
 import org.springframework.stereotype.Service;
 
@@ -164,9 +165,18 @@ public class MediaBatchService {
     private Map<String, Object> failedLectureItem(LectureItem lecture, String reason, String failedAt) {
         Map<String, Object> item = new HashMap<>();
         String lectureId = lecture == null ? "" : lecture.id();
+        String courseTitle = null;
+        if (lecture != null && lecture.course_id() != null && !lecture.course_id().isBlank()) {
+            CourseDetail course = learningService.getCourseDetail(lecture.course_id(), "");
+            if (course != null && course.title() != null && !course.title().isBlank()) {
+                courseTitle = course.title();
+            } else {
+                courseTitle = lecture.course_id();
+            }
+        }
         item.put("lecture_id", lectureId);
         item.put("lecture_title", lecture == null ? lectureId : lecture.title());
-        item.put("course_title", lecture == null ? null : lecture.course_id());
+        item.put("course_title", courseTitle);
         item.put("failed_reason", reason);
         item.put("failed_at", failedAt);
         return item;

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AdminMediaBatchIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AdminMediaBatchIntegrationTest.java
@@ -72,6 +72,7 @@ class AdminMediaBatchIntegrationTest {
             assertThat(firstFailed.path("lecture_id").asText()).isNotBlank();
             assertThat(firstFailed.has("failed_reason")).isTrue();
             assertThat(firstFailed.has("failed_at")).isTrue();
+            assertThat(firstFailed.path("course_title").asText()).isNotBlank();
         }
     }
 

--- a/docs/dev-logs/2026-05-22-batch-failed-course-title-fix.md
+++ b/docs/dev-logs/2026-05-22-batch-failed-course-title-fix.md
@@ -1,0 +1,17 @@
+# 2026-05-22 Batch Failed Lecture Course Title Fix
+
+## Summary
+- Fixed admin media batch failure metadata so `course_title` now resolves to the actual course title instead of the course id.
+- Kept fallback behavior to course id when course detail title is unavailable.
+- Added integration assertion to ensure failed lecture metadata includes non-blank `course_title`.
+
+## Files
+- `backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaBatchService.java`
+- `backend-spring/src/test/java/com/myway/backendspring/integration/AdminMediaBatchIntegrationTest.java`
+
+## Verification
+- `npm run test:backend:clean` passed (59 tests, 0 failures)
+
+## Risk / Rollback
+- Risk: low. Metadata enrichment only; no API contract shape change.
+- Rollback: revert commit `aa6712d` (and follow-up docs commit in this branch if needed).


### PR DESCRIPTION
# 변경 요약
admin 배치 실패 강의 메타데이터의 `course_title`이 코스 ID로 내려가던 문제를 수정해 실제 코스명을 우선 노출하도록 보완했습니다.

## 배경
관리자 배치 현황에서 실패 강의 목록을 볼 때 코스명이 아닌 ID가 표시되어 운영 가시성이 떨어졌습니다.

## 변경 내용
- `MediaBatchService.failedLectureItem`에서 `learningService.getCourseDetail`로 코스명을 조회해 `course_title`에 주입
- 코스명 조회 불가 시 기존처럼 `course_id`로 폴백
- `AdminMediaBatchIntegrationTest`에 `course_title` non-blank 검증 추가
- `docs/dev-logs/2026-05-22-batch-failed-course-title-fix.md` 기록 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트
- 실패 강의 메타데이터 `course_title`이 실제 코스명으로 내려오는지
- 코스 상세 조회 실패 시 `course_id` 폴백 동작이 안전한지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run test:backend:clean` 통과
- layer tests: 백엔드 테스트 59/59 통과
- risk/rollback: 리스크 낮음(표시 메타데이터 보강). 문제 시 본 PR 커밋 revert.

## ADR 링크
- ADR: `N/A (설계/아키텍처 변경 없음)`
- 상태 변경: `N/A`
