### PR TITLE
feat(batch): support auto-run mode all or failed-only

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaBatchScheduler.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaBatchScheduler.java
@@ -9,13 +9,16 @@ public class MediaBatchScheduler {
 
     private final MediaBatchService mediaBatchService;
     private final boolean enabled;
+    private final String autoMode;
 
     public MediaBatchScheduler(
             MediaBatchService mediaBatchService,
-            @Value("${myway.media.batch.auto.enabled:true}") boolean enabled
+            @Value("${myway.media.batch.auto.enabled:true}") boolean enabled,
+            @Value("${myway.media.batch.auto.mode:all}") String autoMode
     ) {
         this.mediaBatchService = mediaBatchService;
         this.enabled = enabled;
+        this.autoMode = normalizeMode(autoMode);
     }
 
     @Scheduled(fixedDelayString = "${myway.media.batch.auto.interval-ms:43200000}", initialDelayString = "${myway.media.batch.auto.initial-delay-ms:60000}")
@@ -23,6 +26,13 @@ public class MediaBatchScheduler {
         if (!enabled) {
             return;
         }
-        mediaBatchService.runBatch("all", true);
+        mediaBatchService.runBatch(autoMode, true);
+    }
+
+    private String normalizeMode(String mode) {
+        if (mode == null) {
+            return "all";
+        }
+        return "failed-only".equalsIgnoreCase(mode.trim()) ? "failed-only" : "all";
     }
 }

--- a/docs/dev-logs/2026-05-21-admin-media-batch-ops.md
+++ b/docs/dev-logs/2026-05-21-admin-media-batch-ops.md
@@ -20,7 +20,10 @@
 
 ## 운영
 - 수동 일괄 매핑: `scripts/backend-r2-bulk-map.ps1`
-- 배치 스케줄 튜닝: `myway.media.batch.schedule-ms`
+- 배치 스케줄 튜닝:
+  - `myway.media.batch.auto.enabled`
+  - `myway.media.batch.auto.interval-ms`
+  - `myway.media.batch.auto.initial-delay-ms`
 
 ## 검증
 - `backend-spring`: `.\mvnw.cmd -q "-Dtest=MediaContractTest,AdminMediaBatchIntegrationTest" test` 통과

--- a/docs/dev-logs/2026-05-22-media-batch-auto-mode-config.md
+++ b/docs/dev-logs/2026-05-22-media-batch-auto-mode-config.md
@@ -1,0 +1,14 @@
+# 2026-05-22 Media Batch Auto Mode Config
+
+## Summary
+- Added scheduler mode config for media batch auto-run.
+- `MediaBatchScheduler` now supports:
+  - `myway.media.batch.auto.mode=all` (default)
+  - `myway.media.batch.auto.mode=failed-only`
+- Invalid mode values are normalized to `all`.
+
+## Why
+- 운영에서 배치 자동 실행을 전체 처리와 실패건 재시도로 분리 운용할 수 있도록 제어 포인트를 추가했다.
+
+## Verification
+- `npm run test:backend:clean` passed.


### PR DESCRIPTION
# 변경 요약
미디어 배치 자동 스케줄러가 `all` 고정으로만 실행되던 부분을 설정값으로 `all`/`failed-only` 모드 선택 가능하도록 확장했습니다.

## 배경
운영에서 자동 배치를 하루 1~2회 돌릴 때, 전체 처리와 실패건 재시도를 분리해 제어할 필요가 있었습니다.

## 변경 내용
- `MediaBatchScheduler`
  - 신규 설정: `myway.media.batch.auto.mode` (`all` 기본, `failed-only` 지원)
  - 잘못된 값은 `all`로 정규화
  - `runBatch("all", true)` 고정 호출을 `runBatch(autoMode, true)`로 변경
- 문서 정리
  - `docs/dev-logs/2026-05-21-admin-media-batch-ops.md`의 오래된 설정 키(`schedule-ms`)를 현재 키로 정정
  - `docs/dev-logs/2026-05-22-media-batch-auto-mode-config.md` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트
- `myway.media.batch.auto.mode=failed-only`에서 자동 스케줄이 실패건 재시도 모드로 실행되는지
- 비정상 값 주입 시 `all` 폴백이 의도대로 동작하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run test:backend:clean` 통과
- layer tests: 백엔드 59 tests pass
- risk/rollback: scheduler 설정 경로 변경. 문제 시 커밋 revert + `myway.media.batch.auto.mode=all`로 즉시 복귀 가능.

## ADR 링크
- ADR: `N/A (아키텍처 변경 없음)`
- 상태 변경: `N/A`
