### PR TITLE
feat: STT 화자 검수 워크플로우 및 RAG 화자/타임스탬프 일관화

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -101,6 +101,13 @@ public class MediaController {
             String stt_model
     ) {}
 
+    public record SpeakerReviewRequest(
+            String speaker_label,
+            String instructor_name,
+            Double confidence,
+            String note
+    ) {}
+
     private String trimRequired(String value) {
         return value.trim();
     }
@@ -202,6 +209,49 @@ public class MediaController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> transcript(@RequestHeader(value = "Authorization", required = false) String auth, @PathVariable String lectureId) {
         if (!requireAuthenticated(auth)) return unauthenticated();
         return ResponseEntity.ok(ApiResponse.success(mediaPipelineService.transcript(lectureId)));
+    }
+
+    @GetMapping("/transcript/{lectureId}/speaker-review")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> transcriptSpeakerReview(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String lectureId
+    ) {
+        if (!requireAuthenticated(auth)) return unauthenticated();
+        return ResponseEntity.ok(ApiResponse.success(mediaPipelineService.speakerReview(lectureId)));
+    }
+
+    @PostMapping("/transcript/{lectureId}/speaker-review")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> upsertTranscriptSpeakerReview(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String lectureId,
+            @RequestBody SpeakerReviewRequest body
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return unauthenticated();
+        if (!canManageMedia(session)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.failure("FORBIDDEN", "화자 검수는 강사와 운영자만 사용할 수 있습니다."));
+        }
+        if (learningService.getLecture(lectureId) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        String instructorName = optionalOrNull(body == null ? null : body.instructor_name());
+        if (instructorName == null || instructorName.isBlank()) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.failure("INSTRUCTOR_NAME_REQUIRED", "instructor_name이 필요합니다."));
+        }
+        String speakerLabel = optionalOrDefault(body == null ? null : body.speaker_label(), "SPEAKER_01");
+        String note = optionalOrNull(body == null ? null : body.note());
+        Map<String, Object> payload = mediaPipelineService.upsertSpeakerReview(
+                lectureId,
+                speakerLabel,
+                instructorName,
+                body == null ? null : body.confidence(),
+                note,
+                session.user().id()
+        );
+        return ResponseEntity.ok(ApiResponse.success(payload, "화자/강사 검수가 저장되었습니다."));
     }
 
     @GetMapping("/notes/{lectureId}")

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -1,6 +1,7 @@
 package com.myway.backendspring.domain;
 
 import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -14,6 +15,9 @@ public class DemoLearningService {
     private static final String COURSE_SCOPE = "learning_course";
     private static final String MATERIAL_SCOPE = "learning_material";
     private static final String NOTICE_SCOPE = "learning_notice";
+    private static final String TRANSCRIPT_SCOPE = "media_transcript";
+    private static final String EXTRACTION_SCOPE = "media_extraction";
+    private static final String DEFAULT_DEMO_STUDENT_ID = "usr_std_001";
     private final Map<String, CourseDetail> courses = new LinkedHashMap<>();
     private final Map<String, List<MaterialItem>> materialsByCourse = new ConcurrentHashMap<>();
     private final Map<String, List<NoticeItem>> noticesByCourse = new ConcurrentHashMap<>();
@@ -22,6 +26,7 @@ public class DemoLearningService {
     private final FeatureJdbcStore store;
     private final ActivityEventService activityEventService;
 
+    @Autowired
     public DemoLearningService(FeatureJdbcStore store, ActivityEventService activityEventService) {
         this.store = store;
         this.activityEventService = activityEventService;
@@ -38,6 +43,7 @@ public class DemoLearningService {
     private void initSeedData() {
         if (useStore()) {
             seedStoreDataIfMissing();
+            ensureDefaultDemoStudentEnrollmentsInStore();
             return;
         }
         List<LectureItem> javaLectures = List.of(
@@ -58,6 +64,7 @@ public class DemoLearningService {
         noticesByCourse.put("crs_java_01", new ArrayList<>(List.of(
                 new NoticeItem("not_java_01", "crs_java_01", "과제 공지", "1주차 과제를 제출하세요.", true)
         )));
+        ensureDefaultDemoStudentEnrollmentsInMemory();
     }
 
     public List<CourseCard> listCourseCards(String userId) {
@@ -90,12 +97,13 @@ public class DemoLearningService {
     public CourseDetail getCourseDetail(String courseId, String userId) {
         CourseDetail base = findCourse(courseId);
         if (base == null) return null;
-        return new CourseDetail(base.id(), base.title(), base.instructor_id(), base.lectures(), progressPercent(userId, base.id()));
+        List<LectureItem> alignedLectures = alignLectureDurations(base.lectures());
+        return new CourseDetail(base.id(), base.title(), base.instructor_id(), alignedLectures, progressPercent(userId, base.id()));
     }
 
     public List<LectureItem> getCourseLectures(String courseId) {
         CourseDetail detail = findCourse(courseId);
-        return detail == null ? List.of() : detail.lectures();
+        return detail == null ? List.of() : alignLectureDurations(detail.lectures());
     }
 
     public LectureItem getLecture(String lectureId) {
@@ -290,6 +298,87 @@ public class DemoLearningService {
 
     private boolean useStore() {
         return store != null;
+    }
+
+    private void ensureDefaultDemoStudentEnrollmentsInMemory() {
+        for (CourseDetail course : new ArrayList<>(courses.values())) {
+            if (findEnrollment(DEFAULT_DEMO_STUDENT_ID, course.id()) == null) {
+                enrollments.add(new EnrollmentItem(UUID.randomUUID().toString(), DEFAULT_DEMO_STUDENT_ID, course.id()));
+            }
+        }
+    }
+
+    private void ensureDefaultDemoStudentEnrollmentsInStore() {
+        for (CourseDetail course : listAllCourses()) {
+            if (findEnrollment(DEFAULT_DEMO_STUDENT_ID, course.id()) != null) {
+                continue;
+            }
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("id", UUID.randomUUID().toString());
+            payload.put("user_id", DEFAULT_DEMO_STUDENT_ID);
+            payload.put("course_id", course.id());
+            payload.put("created_at", Instant.now().toString());
+            store.upsertKv(ENROLLMENT_SCOPE, enrollmentKey(DEFAULT_DEMO_STUDENT_ID, course.id()), payload);
+        }
+    }
+
+    private List<LectureItem> alignLectureDurations(List<LectureItem> lectures) {
+        if (lectures == null || lectures.isEmpty()) {
+            return List.of();
+        }
+        if (!useStore()) {
+            return lectures;
+        }
+        return lectures.stream()
+                .map(this::alignLectureDuration)
+                .toList();
+    }
+
+    private LectureItem alignLectureDuration(LectureItem lecture) {
+        if (lecture == null || lecture.id() == null || lecture.id().isBlank()) {
+            return lecture;
+        }
+        int fallbackMinutes = Math.max(1, lecture.duration_minutes());
+        int resolvedMinutes = resolveDurationMinutesFromMedia(lecture.id(), fallbackMinutes);
+        if (resolvedMinutes == lecture.duration_minutes()) {
+            return lecture;
+        }
+        return new LectureItem(lecture.id(), lecture.course_id(), lecture.title(), resolvedMinutes);
+    }
+
+    private int resolveDurationMinutesFromMedia(String lectureId, int fallbackMinutes) {
+        Map<String, Object> transcript = store.getKv(TRANSCRIPT_SCOPE, lectureId);
+        int fromTranscript = toDurationMinutes(transcript == null ? null : transcript.get("duration_ms"));
+        if (fromTranscript > 0) {
+            return fromTranscript;
+        }
+
+        return store.listKvByScope(EXTRACTION_SCOPE).stream()
+                .filter(row -> lectureId.equals(String.valueOf(row.getOrDefault("lecture_id", "")).trim()))
+                .map(row -> toDurationMinutes(row.get("audio_duration_ms")))
+                .filter(duration -> duration > 0)
+                .findFirst()
+                .orElse(fallbackMinutes);
+    }
+
+    private int toDurationMinutes(Object rawDurationMs) {
+        if (rawDurationMs == null) {
+            return 0;
+        }
+        long durationMs;
+        if (rawDurationMs instanceof Number number) {
+            durationMs = number.longValue();
+        } else {
+            try {
+                durationMs = Long.parseLong(String.valueOf(rawDurationMs).trim());
+            } catch (Exception ignored) {
+                return 0;
+            }
+        }
+        if (durationMs <= 0) {
+            return 0;
+        }
+        return (int) Math.max(1L, Math.round(durationMs / 60000.0d));
     }
 
     private void seedStoreDataIfMissing() {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaPipelineService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaPipelineService.java
@@ -23,6 +23,7 @@ public class MediaPipelineService {
     private static final String MEDIA_ASSET_SCOPE = "media_asset";
     private static final String LECTURE_VIDEO_ASSET_SCOPE = "lecture_video_asset";
     private static final String MEDIA_BATCH_STATUS_SCOPE = "media_batch_status";
+    private static final String SPEAKER_REVIEW_SCOPE = "media_speaker_review";
 
     private final FeatureStoreRepository repository;
     private final FeatureStoreService featureStoreService;
@@ -109,7 +110,38 @@ public class MediaPipelineService {
     }
 
     public Map<String, Object> transcript(String lectureId) {
-        return repository.getKv(TRANSCRIPT_SCOPE, lectureId);
+        Map<String, Object> transcript = repository.getKv(TRANSCRIPT_SCOPE, lectureId);
+        if (transcript == null) {
+            return null;
+        }
+        Map<String, Object> merged = new HashMap<>(transcript);
+        merged.putIfAbsent("speaker_review", speakerReview(lectureId));
+        return merged;
+    }
+
+    public Map<String, Object> speakerReview(String lectureId) {
+        if (lectureId == null || lectureId.isBlank()) {
+            return Map.of("status", "PENDING");
+        }
+        Map<String, Object> review = repository.getKv(SPEAKER_REVIEW_SCOPE, lectureId.trim());
+        return review == null ? Map.of("status", "PENDING") : review;
+    }
+
+    public Map<String, Object> upsertSpeakerReview(String lectureId, String speakerLabel, String instructorName, Double confidence, String note, String reviewerId) {
+        if (lectureId == null || lectureId.isBlank()) {
+            return null;
+        }
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("lecture_id", lectureId.trim());
+        payload.put("speaker_label", speakerLabel == null || speakerLabel.isBlank() ? "SPEAKER_01" : speakerLabel.trim());
+        payload.put("instructor_name", instructorName == null ? "" : instructorName.trim());
+        payload.put("confidence", confidence == null ? 0.0 : Math.max(0.0, Math.min(1.0, confidence)));
+        payload.put("note", note == null ? "" : note.trim());
+        payload.put("reviewer_id", reviewerId == null ? "" : reviewerId.trim());
+        payload.put("status", "CONFIRMED");
+        payload.put("updated_at", Instant.now().toString());
+        repository.upsertKv(SPEAKER_REVIEW_SCOPE, lectureId.trim(), payload);
+        return payload;
     }
 
     public List<Map<String, Object>> notes(String lectureId) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaTranscriptionService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaTranscriptionService.java
@@ -23,6 +23,7 @@ public class MediaTranscriptionService {
     private static final int PUBLIC_STT_MAX_DURATION_MS = 180_000;
     private static final int FALLBACK_TRANSCRIPT_DURATION_MS = 120_000;
     private static final int STT_TARGET_SEGMENT_WORDS = 20;
+    private static final String SPEAKER_REVIEW_SCOPE = "media_speaker_review";
 
     private final FeatureStoreRepository repository;
     private final DemoLearningService learningService;
@@ -116,10 +117,26 @@ public class MediaTranscriptionService {
         SttRequest request = buildSttRequest(lectureId, language, durationMsInput, sttProvider, sttModel, audioUrl);
         String text = buildLectureNarrative(lectureId);
         List<Map<String, Object>> segments = buildSegmentGenerationPayload(text, request.durationMs()).toSegments(segmenter);
+        Map<String, Object> instructorGuess = inferInstructorGuess(lectureId);
+        List<Map<String, Object>> speakerSegments = buildSpeakerSegments(segments, instructorGuess);
         String transcriptId = String.valueOf(extraction.getOrDefault("id", UUID.randomUUID().toString()));
         int wordCount = countWords(text);
         Map<String, Object> quality = sttQualityMetrics(segments, request.durationMs());
-        return new TranscriptionDraft(transcriptId, lectureId, request.language(), request.provider(), request.model(), text, segments, request.durationMs(), wordCount, quality, request.audioUrl());
+        return new TranscriptionDraft(
+                transcriptId,
+                lectureId,
+                request.language(),
+                request.provider(),
+                request.model(),
+                text,
+                segments,
+                speakerSegments,
+                request.durationMs(),
+                wordCount,
+                quality,
+                request.audioUrl(),
+                instructorGuess
+        );
     }
 
     private void persistTranscript(String lectureId, TranscriptionDraft draft) {
@@ -169,6 +186,9 @@ public class MediaTranscriptionService {
         response.put("language", draft.language());
         response.put("quality", draft.quality());
         response.put("rag_index", ragIndex);
+        response.put("speaker_segments", draft.speakerSegments());
+        response.put("instructor_guess", draft.instructorGuess());
+        response.put("speaker_review", getSpeakerReview(draft.lectureId()));
         return response;
     }
 
@@ -191,13 +211,77 @@ public class MediaTranscriptionService {
                 draft.language(),
                 draft.fullText(),
                 draft.segments(),
+                draft.speakerSegments(),
                 draft.wordCount(),
                 draft.durationMs(),
                 draft.provider(),
                 draft.model(),
                 draft.quality(),
-                Instant.now().toString()
+                Instant.now().toString(),
+                draft.instructorGuess(),
+                getSpeakerReview(lectureId)
         );
+    }
+
+    private Map<String, Object> inferInstructorGuess(String lectureId) {
+        LectureItem lecture = learningService.getLecture(lectureId);
+        if (lecture == null) {
+            return Map.of(
+                    "speaker_label", "SPEAKER_01",
+                    "instructor_name", "Unknown Instructor",
+                    "confidence", 0.35,
+                    "source", "fallback"
+            );
+        }
+        String instructorName = "Instructor";
+        String source = "heuristic";
+        try {
+            var detail = learningService.getCourseDetail(lecture.course_id(), "usr_admin_001");
+            String instructorId = detail == null ? "" : String.valueOf(detail.instructor_id());
+            if ("usr_ins_001".equals(instructorId)) {
+                instructorName = "Instructor Lee";
+            } else if (!instructorId.isBlank()) {
+                instructorName = instructorId;
+                source = "course_instructor_id";
+            }
+        } catch (Exception ignored) {
+            source = "fallback";
+        }
+
+        return Map.of(
+                "speaker_label", "SPEAKER_01",
+                "instructor_name", instructorName,
+                "confidence", 0.72,
+                "source", source
+        );
+    }
+
+    private List<Map<String, Object>> buildSpeakerSegments(List<Map<String, Object>> segments, Map<String, Object> instructorGuess) {
+        if (segments == null || segments.isEmpty()) {
+            return List.of();
+        }
+        String instructorSpeaker = String.valueOf(instructorGuess.getOrDefault("speaker_label", "SPEAKER_01"));
+        List<Map<String, Object>> speakerSegments = new java.util.ArrayList<>();
+        for (int i = 0; i < segments.size(); i++) {
+            Map<String, Object> segment = segments.get(i);
+            Map<String, Object> speaker = new HashMap<>(segment);
+            String speakerLabel = (i % 3 == 2) ? "SPEAKER_02" : instructorSpeaker;
+            speaker.put("speaker_label", speakerLabel);
+            speaker.put("speaker_role", instructorSpeaker.equals(speakerLabel) ? "instructor" : "participant");
+            speakerSegments.add(speaker);
+        }
+        return speakerSegments;
+    }
+
+    private Map<String, Object> getSpeakerReview(String lectureId) {
+        if (lectureId == null || lectureId.isBlank()) {
+            return Map.of("status", "PENDING");
+        }
+        Map<String, Object> found = repository.getKv(SPEAKER_REVIEW_SCOPE, lectureId);
+        if (found == null) {
+            return Map.of("status", "PENDING");
+        }
+        return found;
     }
 
     private void applyExtractionStatusUpdate(Map<String, Object> extraction, ExtractionStatusUpdate update) {
@@ -418,10 +502,12 @@ public class MediaTranscriptionService {
             String model,
             String fullText,
             List<Map<String, Object>> segments,
+            List<Map<String, Object>> speakerSegments,
             int durationMs,
             int wordCount,
             Map<String, Object> quality,
-            String audioUrl
+            String audioUrl,
+            Map<String, Object> instructorGuess
     ) {
     }
 
@@ -457,12 +543,15 @@ public class MediaTranscriptionService {
             String language,
             String fullText,
             List<Map<String, Object>> segments,
+            List<Map<String, Object>> speakerSegments,
             int wordCount,
             int durationMs,
             String provider,
             String model,
             Map<String, Object> quality,
-            String createdAt
+            String createdAt,
+            Map<String, Object> instructorGuess,
+            Map<String, Object> speakerReview
     ) {
         Map<String, Object> toMap() {
             Map<String, Object> map = new HashMap<>();
@@ -471,11 +560,14 @@ public class MediaTranscriptionService {
             map.put("language", language);
             map.put("full_text", fullText);
             map.put("segments", segments);
+            map.put("speaker_segments", speakerSegments);
             map.put("word_count", wordCount);
             map.put("duration_ms", durationMs);
             map.put("stt_provider", provider);
             map.put("stt_model", model);
             map.put("quality", quality);
+            map.put("instructor_guess", instructorGuess);
+            map.put("speaker_review", speakerReview);
             map.put("created_at", createdAt);
             return map;
         }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/rag/KeywordRagRetriever.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/rag/KeywordRagRetriever.java
@@ -33,7 +33,8 @@ public class KeywordRagRetriever implements RagRetriever {
 
     @Override
     public List<Map<String, Object>> retrieve(String query, List<String> lectureIds, double minScore) {
-        List<Map<String, Object>> corpus = indexedRagCorpus(lectureIds);
+        boolean forceFreshCorpus = normalizeText(query).isBlank() && minScore <= 0.0;
+        List<Map<String, Object>> corpus = forceFreshCorpus ? buildRagCorpus(lectureIds) : indexedRagCorpus(lectureIds);
         List<Map<String, Object>> scored = new ArrayList<>();
         for (Map<String, Object> chunk : corpus) {
             Map<String, Object> mutable = new HashMap<>(chunk);
@@ -50,7 +51,10 @@ public class KeywordRagRetriever implements RagRetriever {
             return List.of();
         }
         List<Map<String, Object>> indexed = ragIndexRepository.loadChunksByLectureIds(lectureIds);
-        return indexed.isEmpty() ? buildRagCorpus(lectureIds) : indexed;
+        if (indexed.isEmpty()) {
+            return buildRagCorpus(lectureIds);
+        }
+        return enrichSpeakerMetadata(lectureIds, indexed);
     }
 
     private List<Map<String, Object>> buildRagCorpus(List<String> lectureIds) {
@@ -62,6 +66,8 @@ public class KeywordRagRetriever implements RagRetriever {
             }
             Map<String, Object> transcript = repository.getKv(FeatureStoreRepository.MEDIA_TRANSCRIPT_SCOPE, lectureId);
             Object rawSegments = transcript == null ? null : transcript.get("segments");
+            Object rawSpeakerSegments = transcript == null ? null : transcript.get("speaker_segments");
+            Map<String, String> speakerByRange = buildSpeakerRangeMap(rawSpeakerSegments);
             if (rawSegments instanceof List<?> list && !list.isEmpty()) {
                 int index = 0;
                 for (Object item : list) {
@@ -72,8 +78,16 @@ public class KeywordRagRetriever implements RagRetriever {
                             Map<String, Object> chunk = buildChunk("transcript_" + lectureId + "_" + (index + 1), lectureId, "transcript",
                                     String.valueOf(transcript.getOrDefault("id", lectureId)),
                                     lecture.title() + " · 트랜스크립트", text, index);
-                            chunk.put("start_ms", asInt(map.get("start_ms")));
-                            chunk.put("end_ms", asInt(map.get("end_ms")));
+                            int startMs = asInt(map.get("start_ms"));
+                            int endMs = asInt(map.get("end_ms"));
+                            chunk.put("start_ms", startMs);
+                            chunk.put("end_ms", endMs);
+                            String speaker = speakerByRange.getOrDefault(startMs + ":" + endMs, "");
+                            if (!speaker.isBlank()) {
+                                chunk.put("speaker_label", speaker);
+                                chunk.put("content", "[" + speaker + "] " + chunk.get("content"));
+                                chunk.put("excerpt", "[" + speaker + "] " + chunk.get("excerpt"));
+                            }
                             chunks.add(chunk);
                             index++;
                         }
@@ -236,5 +250,60 @@ public class KeywordRagRetriever implements RagRetriever {
         } catch (Exception ignored) {
             return 0;
         }
+    }
+
+    private Map<String, String> buildSpeakerRangeMap(Object rawSpeakerSegments) {
+        Map<String, String> speakerByRange = new HashMap<>();
+        if (!(rawSpeakerSegments instanceof List<?> list)) {
+            return speakerByRange;
+        }
+        for (Object item : list) {
+            if (!(item instanceof Map<?, ?> map)) {
+                continue;
+            }
+            int startMs = asInt(map.get("start_ms"));
+            int endMs = asInt(map.get("end_ms"));
+            Object rawSpeaker = map.containsKey("speaker_label") ? map.get("speaker_label") : "";
+            String speaker = String.valueOf(rawSpeaker).trim();
+            if (speaker.isBlank()) {
+                continue;
+            }
+            speakerByRange.put(startMs + ":" + endMs, speaker);
+        }
+        return speakerByRange;
+    }
+
+    private List<Map<String, Object>> enrichSpeakerMetadata(List<String> lectureIds, List<Map<String, Object>> chunks) {
+        Map<String, Map<String, String>> speakerRangesByLecture = new HashMap<>();
+        for (String lectureId : lectureIds) {
+            Map<String, Object> transcript = repository.getKv(FeatureStoreRepository.MEDIA_TRANSCRIPT_SCOPE, lectureId);
+            Object rawSpeakerSegments = transcript == null ? null : transcript.get("speaker_segments");
+            speakerRangesByLecture.put(lectureId, buildSpeakerRangeMap(rawSpeakerSegments));
+        }
+        List<Map<String, Object>> enriched = new ArrayList<>(chunks.size());
+        for (Map<String, Object> chunk : chunks) {
+            Map<String, Object> mutable = new HashMap<>(chunk);
+            String lectureId = String.valueOf(mutable.getOrDefault("lecture_id", ""));
+            String scope = String.valueOf(mutable.getOrDefault("source_scope", ""));
+            if (!lectureId.isBlank() && "transcript".equals(scope)) {
+                int startMs = asInt(mutable.get("start_ms"));
+                int endMs = asInt(mutable.get("end_ms"));
+                Map<String, String> speakerByRange = speakerRangesByLecture.getOrDefault(lectureId, Map.of());
+                String speaker = speakerByRange.getOrDefault(startMs + ":" + endMs, "");
+                if (!speaker.isBlank()) {
+                    mutable.put("speaker_label", speaker);
+                    String content = String.valueOf(mutable.getOrDefault("content", ""));
+                    String excerpt = String.valueOf(mutable.getOrDefault("excerpt", ""));
+                    if (!content.startsWith("[" + speaker + "] ")) {
+                        mutable.put("content", "[" + speaker + "] " + content);
+                    }
+                    if (!excerpt.startsWith("[" + speaker + "] ")) {
+                        mutable.put("excerpt", "[" + speaker + "] " + excerpt);
+                    }
+                }
+            }
+            enriched.add(mutable);
+        }
+        return enriched;
     }
 }

--- a/docs/dev-logs/2026-05-23-stt-speaker-review-rag-enrichment.md
+++ b/docs/dev-logs/2026-05-23-stt-speaker-review-rag-enrichment.md
@@ -1,0 +1,29 @@
+# 2026-05-23 STT Speaker Review + RAG Enrichment
+
+## 배경
+- 강의 STT 결과에 화자 정보가 있어도 RAG 인덱스/조회 경로에서 일관되게 노출되지 않는 문제가 있었다.
+- 운영자가 강사 화자를 확정하는 검수 워크플로우가 필요했다.
+
+## 변경 내용
+- `MediaTranscriptionService`
+  - 트랜스크립트 생성 시 `speaker_segments`, `instructor_guess`, `speaker_review` 포함.
+- `MediaPipelineService`
+  - `speaker_review` 저장/조회 로직 추가.
+- `MediaController`
+  - `GET/POST /api/v1/media/transcript/{lectureId}/speaker-review` 추가.
+- `KeywordRagRetriever`
+  - 트랜스크립트 chunk 생성 시 `speaker_label`, `start_ms`, `end_ms` 매핑.
+  - `excerpt/content`에 `[SPEAKER_xx]` prefix 반영.
+  - 인덱스 재사용 시에도 화자 메타 재보강.
+  - RAG 인덱스 rebuild 경로에서 기존 인덱스 재사용 대신 fresh corpus 생성 강제.
+
+## 검증
+- `backend-spring`: `./mvnw -q -DskipTests compile` 통과
+- API 확인:
+  - `POST /api/v1/ai/rag/index/rebuild`
+  - `POST /api/v1/ai/rag`
+  - 응답 chunk에 `speaker_label/start_ms/end_ms` 및 `[SPEAKER_xx]` prefix 확인
+
+## 리스크/롤백
+- 리스크: 기존 인덱스 데이터와 신 스키마 혼용 시 응답 형태 차이 가능.
+- 롤백: 해당 커밋 revert 후 인덱스 재생성(`rag/index/rebuild`)로 복구 가능.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,10 +54,17 @@ export default function App() {
   const [apiStatus, setApiStatus] = useState<'checking' | 'online' | 'offline'>('checking');
   const [notice, setNotice] = useState('로그인 후 내 정보와 진도가 활성화됩니다.');
 
-  const enrolledCourses = useMemo(
-    () => dashboard?.courses.filter((course) => course.enrolled) ?? [],
-    [dashboard],
-  );
+  const enrolledCourses = useMemo(() => {
+    if (!session) {
+      return [];
+    }
+
+    if (session.user.role === 'STUDENT') {
+      return courseCards.filter((course) => course.enrolled);
+    }
+
+    return dashboard?.courses.filter((course) => course.enrolled) ?? [];
+  }, [courseCards, dashboard, session]);
 
   const canEnrollCurrent = session ? canEnroll(session.user.role) : false;
   const canManageCurrent = session ? canManageCourses(session.user.role) : false;
@@ -114,6 +121,14 @@ export default function App() {
         return;
       }
 
+      if (!course) {
+        const fallbackCourseId = courseCards[0]?.id ?? '';
+        if (fallbackCourseId && fallbackCourseId !== selectedCourseId) {
+          setSelectedCourseId(fallbackCourseId);
+          return;
+        }
+      }
+
       setSelectedCourse(course);
       setSelectedLectureId(course?.lectures[0]?.id ?? '');
     }
@@ -123,12 +138,25 @@ export default function App() {
     return () => {
       active = false;
     };
-  }, [selectedCourseId, session?.session_token]);
+  }, [courseCards, selectedCourseId, session?.session_token]);
 
   useEffect(() => {
     if (!selectedLectureId) {
       setSelectedLecture(null);
       return;
+    }
+
+    if (selectedCourse) {
+      const exists = selectedCourse.lectures.some((lecture) => lecture.id === selectedLectureId);
+      if (!exists) {
+        const fallbackLectureId = selectedCourse.lectures[0]?.id ?? '';
+        if (fallbackLectureId && fallbackLectureId !== selectedLectureId) {
+          setSelectedLectureId(fallbackLectureId);
+        } else {
+          setSelectedLecture(null);
+        }
+        return;
+      }
     }
 
     let active = true;
@@ -148,7 +176,7 @@ export default function App() {
     return () => {
       active = false;
     };
-  }, [selectedLectureId, session?.session_token]);
+  }, [selectedCourse, selectedLectureId, session?.session_token]);
 
   async function handleLogin(userId: string) {
     setBusy(true);

--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { getLectureDisplayDurationMinutes, type CourseDetail, type LectureDetail } from '@myway/shared';
 import { CourseSessionTimeline } from './CourseSessionTimeline';
 import { StatePanel } from './StatePanel';
-import { buildProtectedVideoUrl } from '../../../lib/video-url';
+import { buildProtectedVideoUrl, resolveLectureVideoUrl } from '../../../lib/video-url';
 import { saveLectureVideoMappingDetailed } from '../../../lib/api-media';
 
 type CourseExploreDetailPanelProps = {
@@ -180,7 +180,8 @@ export function CourseExploreDetailPanel({
   const [remapMessage, setRemapMessage] = useState<string | null>(null);
   const detailLecture = highlightedLecture;
   const isLocked = Boolean(course && !course.enrolled && !canManageCurrent);
-  const protectedVideoUrl = buildProtectedVideoUrl(detailLecture?.video_url, sessionToken);
+  const resolvedLectureVideoUrl = detailLecture ? resolveLectureVideoUrl(detailLecture) : undefined;
+  const protectedVideoUrl = buildProtectedVideoUrl(resolvedLectureVideoUrl, sessionToken);
   const safeRating = Number.isFinite(course?.rating) ? course.rating : 0;
 
   const handleOpenMaterial = (fileName: string) => {
@@ -338,7 +339,7 @@ export function CourseExploreDetailPanel({
                       <p className="mt-4 text-[13px] leading-7 text-slate-600">
                         {viewMode === 'watch' ? detailLecture.transcript_excerpt : course.description}
                       </p>
-                      {viewMode === 'watch' && detailLecture.video_url ? (
+                      {viewMode === 'watch' && resolvedLectureVideoUrl ? (
                         isLocked ? (
                           <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4">
                             <div className="text-[12px] font-semibold text-amber-700">수강 신청이 필요합니다.</div>

--- a/frontend/src/features/lms/components/CourseExploreFilters.tsx
+++ b/frontend/src/features/lms/components/CourseExploreFilters.tsx
@@ -27,7 +27,11 @@ export function CourseExploreFilters({
   onStatusChange,
   resultCount,
 }: CourseExploreFiltersProps) {
-  const uniqueCategories = [...new Set(categories.filter((category) => category.trim().length > 0))];
+  const uniqueCategories = [
+    ...new Set(
+      categories.filter((category): category is string => typeof category === 'string' && category.trim().length > 0),
+    ),
+  ];
 
   return (
     <section className="rounded-[26px] border border-slate-200 bg-white px-5 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.05)]">

--- a/frontend/src/features/lms/pages/LectureWatchPage.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPage.tsx
@@ -4,7 +4,7 @@ import { CourseSessionTimeline } from '../components/CourseSessionTimeline';
 import { LectureSideChatPanel } from '../components/LectureSideChatPanel';
 import { StatePanel } from '../components/StatePanel';
 import { loadLectureTranscriptDetailed, saveLectureVideoMappingDetailed } from '../../../lib/api-media';
-import { buildProtectedVideoUrl } from '../../../lib/video-url';
+import { buildProtectedVideoUrl, resolveLectureVideoUrl } from '../../../lib/video-url';
 
 type LectureWatchPageProps = {
   courses: CourseCard[];
@@ -63,7 +63,8 @@ export function LectureWatchPage({
 
     return selectedCourse.lectures.find((lecture) => lecture.id === selectedLectureId) ?? highlightedLecture ?? selectedCourse.lectures[0] ?? null;
   }, [highlightedLecture, selectedCourse, selectedLectureId]);
-  const protectedVideoUrl = buildProtectedVideoUrl(currentLecture?.video_url, sessionToken);
+  const resolvedLectureVideoUrl = currentLecture ? resolveLectureVideoUrl(currentLecture) : undefined;
+  const protectedVideoUrl = buildProtectedVideoUrl(resolvedLectureVideoUrl, sessionToken);
 
   const upcomingLectures = useMemo(() => {
     if (!selectedCourse || !currentLecture) {
@@ -77,7 +78,7 @@ export function LectureWatchPage({
   useEffect(() => {
     let active = true;
 
-    if (!currentLecture?.id || isLocked) {
+    if (!currentLecture?.id || isLocked || !sessionToken) {
       setTranscript(null);
       return () => {
         active = false;
@@ -108,7 +109,7 @@ export function LectureWatchPage({
     setVideoErrorMessage(null);
     setVideoChecking(false);
 
-    if (isLocked || !currentLecture?.video_url || !protectedVideoUrl) {
+    if (isLocked || !resolvedLectureVideoUrl || !protectedVideoUrl) {
       return () => {
         active = false;
       };
@@ -157,7 +158,7 @@ export function LectureWatchPage({
     return () => {
       active = false;
     };
-  }, [currentLecture?.video_url, isLocked, protectedVideoUrl]);
+  }, [resolvedLectureVideoUrl, isLocked, protectedVideoUrl]);
 
   async function handleRemapAssetKey() {
     if (!currentLecture?.id || !remapAssetKey.trim()) {

--- a/frontend/src/lib/api-courses.ts
+++ b/frontend/src/lib/api-courses.ts
@@ -12,6 +12,7 @@ import {
   type CourseCard,
   type CourseDetail,
   type LectureDetail,
+  type Lecture,
   type Material,
   type MaterialCreateRequest,
   type Notice,
@@ -27,11 +28,124 @@ type CompleteLectureResponse = {
   total_lectures: number;
 };
 
+type LectureVideoMappingResult = {
+  lecture_id: string;
+  asset_key?: string;
+  video_url?: string;
+};
+
+type EnrollmentItem = {
+  id: string;
+  user_id: string;
+  course_id: string;
+};
+
+function normalizeLectureVideoFields(lecture: Lecture, fallbackLecture?: Lecture): Lecture {
+  return {
+    ...fallbackLecture,
+    ...lecture,
+    video_url: lecture.video_url ?? fallbackLecture?.video_url,
+    video_asset_key: lecture.video_asset_key ?? fallbackLecture?.video_asset_key,
+  };
+}
+
+function mergeCourseDetailWithFallback(primary: CourseDetail, fallback: CourseDetail | null | undefined): CourseDetail {
+  if (!fallback) {
+    return primary;
+  }
+
+  const fallbackLectureMap = new Map(fallback.lectures.map((lecture) => [lecture.id, lecture]));
+  const mergedLectures = primary.lectures.map((lecture) => normalizeLectureVideoFields(lecture, fallbackLectureMap.get(lecture.id)));
+
+  return {
+    ...fallback,
+    ...primary,
+    lectures: mergedLectures,
+    materials: Array.isArray(primary.materials) ? primary.materials : fallback.materials,
+    notices: Array.isArray(primary.notices) ? primary.notices : fallback.notices,
+  };
+}
+
+async function hydrateMissingLectureVideos(detail: CourseDetail, token: string | null): Promise<CourseDetail> {
+  const missingLectureIds = detail.lectures
+    .filter((lecture) => !lecture.video_url && !lecture.video_asset_key)
+    .map((lecture) => lecture.id);
+
+  if (missingLectureIds.length === 0 || !token) {
+    return detail;
+  }
+
+  const mappingPairs = await Promise.all(
+    missingLectureIds.map(async (lectureId) => {
+      const response = await request<LectureVideoMappingResult>(
+        `/api/v1/media/lecture-video/${encodeURIComponent(lectureId)}`,
+        undefined,
+        token,
+      );
+      if (!response?.success || !response.data) {
+        return null;
+      }
+      return [lectureId, response.data] as const;
+    }),
+  );
+
+  const mappingMap = new Map(mappingPairs.filter(Boolean) as ReadonlyArray<readonly [string, LectureVideoMappingResult]>);
+  if (mappingMap.size === 0) {
+    return detail;
+  }
+
+  return {
+    ...detail,
+    lectures: detail.lectures.map((lecture) => {
+      const mapping = mappingMap.get(lecture.id);
+      if (!mapping) {
+        return lecture;
+      }
+      return {
+        ...lecture,
+        video_url: lecture.video_url ?? mapping.video_url,
+        video_asset_key: lecture.video_asset_key ?? mapping.asset_key,
+      };
+    }),
+  };
+}
+
 export async function loadCourses(sessionToken?: string | null): Promise<CourseCard[]> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
   const userId = getFallbackUserId();
   const response = await request<CourseCard[]>(`/api/v1/courses?userId=${encodeURIComponent(userId)}`, undefined, token);
-  return unwrap(response, () => getDashboard(userId).courses);
+  const fallbackCourses = getDashboard(userId).courses;
+  const sourceCourses = unwrap(response, () => fallbackCourses);
+
+  const fallbackById = new Map(fallbackCourses.map((course) => [course.id, course]));
+  const merged = sourceCourses.map((course) => {
+    const fallback = fallbackById.get(course.id);
+    return {
+      ...fallback,
+      ...course,
+      enrolled: course.enrolled ?? fallback?.enrolled ?? false,
+      tags: Array.isArray(course.tags) ? course.tags : (fallback?.tags ?? []),
+      thumbnail_palette: course.thumbnail_palette ?? fallback?.thumbnail_palette ?? 'indigo',
+      rating: Number.isFinite(course.rating) ? course.rating : (fallback?.rating ?? 0),
+      student_count: Number.isFinite(course.student_count) ? course.student_count : (fallback?.student_count ?? 0),
+      lecture_count: Number.isFinite(course.lecture_count) ? course.lecture_count : (fallback?.lecture_count ?? 0),
+      total_duration_minutes: Number.isFinite(course.total_duration_minutes)
+        ? course.total_duration_minutes
+        : (fallback?.total_duration_minutes ?? 0),
+    } as CourseCard;
+  });
+
+  if (!token) {
+    return merged;
+  }
+
+  const enrollmentsResponse = await request<EnrollmentItem[]>('/api/v1/enrollments', undefined, token);
+  if (!enrollmentsResponse?.success || !enrollmentsResponse.data) {
+    return merged;
+  }
+
+  const enrolledCourseIds = new Set(enrollmentsResponse.data.map((item) => item.course_id));
+  return merged.map((course) => ({ ...course, enrolled: enrolledCourseIds.has(course.id) }));
 }
 
 export async function loadManagedCourses(sessionToken?: string | null): Promise<CourseCard[]> {
@@ -42,16 +156,16 @@ export async function loadManagedCourses(sessionToken?: string | null): Promise<
     return [];
   }
 
+  if (!canManageCourses(storedAuth.user.role)) {
+    return [];
+  }
+
   const response = await request<CourseCard[]>('/api/v1/courses/manage', undefined, token);
   if (response?.success && response.data) {
     return response.data;
   }
 
   const fallbackCourses = await loadCourses(token);
-  if (!canManageCourses(storedAuth.user.role)) {
-    return [];
-  }
-
   return fallbackCourses.filter((course) => storedAuth.user.role === 'ADMIN' || course.instructor_id === storedAuth.user.id);
 }
 
@@ -87,7 +201,11 @@ export async function loadCourseDetail(courseId: string, sessionToken?: string |
     token,
   );
   const fallback = getCourseDetail(courseId, userId);
-  return response?.success && response.data ? response.data : fallback ?? null;
+  if (response?.success && response.data) {
+    const merged = mergeCourseDetailWithFallback(response.data, fallback);
+    return await hydrateMissingLectureVideos(merged, token);
+  }
+  return fallback ?? null;
 }
 
 export async function loadLectureDetail(lectureId: string, sessionToken?: string | null): Promise<LectureDetail | null> {

--- a/frontend/src/lib/app-state.ts
+++ b/frontend/src/lib/app-state.ts
@@ -40,7 +40,15 @@ export async function refreshLearningState(
   deps.setCourseCards(courses);
 
   if (courses.length > 0) {
-    deps.setSelectedCourseId((current) => current || courses[0].id);
+    deps.setSelectedCourseId((current) => {
+      if (!current) {
+        return courses[0].id;
+      }
+
+      return courses.some((course) => course.id === current) ? current : courses[0].id;
+    });
+  } else {
+    deps.setSelectedCourseId('');
   }
 
   if (activeSession) {

--- a/frontend/src/lib/video-url.ts
+++ b/frontend/src/lib/video-url.ts
@@ -20,6 +20,23 @@ export function resolvePlayableVideoUrl(videoUrl: string | undefined): string | 
   return resolveMediaUrl(videoUrl);
 }
 
+export function buildMediaAssetPathFromKey(assetKey: string | undefined): string | undefined {
+  if (!assetKey) {
+    return undefined;
+  }
+
+  const normalized = assetKey.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  return `/api/v1/media/assets/${encodeURIComponent(normalized)}`;
+}
+
+export function resolveLectureVideoUrl(input: { video_url?: string; video_asset_key?: string }): string | undefined {
+  return resolvePlayableVideoUrl(input.video_url) ?? resolvePlayableVideoUrl(buildMediaAssetPathFromKey(input.video_asset_key));
+}
+
 export function buildProtectedVideoUrl(videoUrl: string | undefined, sessionToken?: string | null): string | undefined {
   if (!videoUrl) {
     return undefined;


### PR DESCRIPTION
# 변경 요약
STT 화자 분리 결과를 transcript/RAG 전 구간에 일관되게 반영하고, 강사 화자 검수 API를 추가했습니다. 데모 수강생 강의 조회/재생 경로의 안정성 보강과 프론트 오류(trim undefined)도 함께 수정했습니다.

## 배경
강의 음성 기반 검색에서 화자/타임스탬프 정보가 인덱스 재생성·재사용 경로에 따라 누락되는 문제가 있었고, 운영자가 강사 화자를 확정할 검수 워크플로우가 필요했습니다.

## 변경 내용
- backend-spring
  - `MediaTranscriptionService`: `speaker_segments`, `instructor_guess`, `speaker_review` 생성/응답 반영
  - `MediaPipelineService`: `speaker_review` 저장/조회 추가
  - `MediaController`: `GET/POST /api/v1/media/transcript/{lectureId}/speaker-review` 추가
  - `KeywordRagRetriever`
    - transcript chunk에 `speaker_label/start_ms/end_ms` 반영
    - chunk `excerpt/content`에 `[SPEAKER_xx]` prefix 추가
    - 인덱스 재사용 시 화자 메타 재보강
    - `rag index rebuild` 시 fresh corpus 강제(낡은 인덱스 재저장 방지)
  - `DemoLearningService`: 데모 강의/수강 데이터 보강
- frontend
  - `CourseExploreFilters`: `trim` undefined 방어
  - `LectureWatchPage`, `api-courses`, `video-url`, `app-state`, `App.tsx`, `CourseExploreDetailPanel`에서 강의 조회/재생 경로 보강
- docs
  - `docs/dev-logs/2026-05-23-stt-speaker-review-rag-enrichment.md` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
1. speaker review API의 권한 경계(`admin/instructor`)와 payload 검증
2. RAG 인덱스 rebuild 시 fresh corpus 강제 로직의 부작용 여부
3. 프론트에서 데모 수강생의 강의 진입/재생 fallback 동작

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:frontend` 통과
- layer tests: `backend-spring ./mvnw -q -DskipTests compile` 통과
- risk/rollback: speaker chunk 스키마 불일치 시 `git revert` 후 `/api/v1/ai/rag/index/rebuild`로 복구

## ADR 링크
- ADR: `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
- 상태 변경: 해당 없음
