### PR TITLE
feat: JWT/DB 인증 전환 및 학생 학습 플로우 계약 테스트 고정

### DIFF
--- a/backend-spring/pom.xml
+++ b/backend-spring/pom.xml
@@ -50,6 +50,23 @@
             <version>2.6.0</version>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/backend-spring/src/main/java/com/myway/backendspring/api/AuthController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AuthController.java
@@ -1,7 +1,6 @@
 package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.DemoUser;
-import com.myway.backendspring.auth.DemoUsers;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
@@ -25,7 +24,7 @@ public class AuthController {
 
     @GetMapping("/users")
     public ApiResponse<List<DemoUser>> users() {
-        return ApiResponse.success(DemoUsers.USERS);
+        return ApiResponse.success(sessionService.listUsers());
     }
 
     public record LoginBody(@NotBlank String userId) {}

--- a/backend-spring/src/main/java/com/myway/backendspring/auth/AuthJdbcStore.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/auth/AuthJdbcStore.java
@@ -1,0 +1,144 @@
+package com.myway.backendspring.auth;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class AuthJdbcStore {
+    private final JdbcTemplate jdbcTemplate;
+
+    public AuthJdbcStore(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public Optional<DemoUser> findUserById(String userId) {
+        List<DemoUser> rows = jdbcTemplate.query(
+                """
+                SELECT id, name, email, role, department, bio
+                FROM auth_users
+                WHERE id = ?
+                """,
+                (rs, rowNum) -> new DemoUser(
+                        rs.getString("id"),
+                        rs.getString("name"),
+                        rs.getString("email"),
+                        rs.getString("role"),
+                        rs.getString("department"),
+                        rs.getString("bio")
+                ),
+                userId
+        );
+        return rows.stream().findFirst();
+    }
+
+    public List<DemoUser> listUsers() {
+        return jdbcTemplate.query(
+                """
+                SELECT id, name, email, role, department, bio
+                FROM auth_users
+                ORDER BY id
+                """,
+                (rs, rowNum) -> new DemoUser(
+                        rs.getString("id"),
+                        rs.getString("name"),
+                        rs.getString("email"),
+                        rs.getString("role"),
+                        rs.getString("department"),
+                        rs.getString("bio")
+                )
+        );
+    }
+
+    public void upsertUser(DemoUser user) {
+        int updated = jdbcTemplate.update(
+                """
+                UPDATE auth_users
+                SET name = ?, email = ?, role = ?, department = ?, bio = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                user.name(), user.email(), user.role(), user.department(), user.bio(), user.id()
+        );
+        if (updated > 0) {
+            return;
+        }
+        jdbcTemplate.update(
+                """
+                INSERT INTO auth_users(id, name, email, role, department, bio, created_at, updated_at)
+                VALUES(?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """,
+                user.id(), user.name(), user.email(), user.role(), user.department(), user.bio()
+        );
+    }
+
+    public void upsertSession(String tokenId, String userId, Instant issuedAt, Instant expiresAt) {
+        int updated = jdbcTemplate.update(
+                """
+                UPDATE auth_sessions
+                SET user_id = ?, issued_at = ?, expires_at = ?, revoked = FALSE, updated_at = CURRENT_TIMESTAMP
+                WHERE token_id = ?
+                """,
+                userId,
+                Timestamp.from(issuedAt),
+                Timestamp.from(expiresAt),
+                tokenId
+        );
+        if (updated > 0) {
+            return;
+        }
+        jdbcTemplate.update(
+                """
+                INSERT INTO auth_sessions(token_id, user_id, issued_at, expires_at, revoked, created_at, updated_at)
+                VALUES(?, ?, ?, ?, FALSE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """,
+                tokenId,
+                userId,
+                Timestamp.from(issuedAt),
+                Timestamp.from(expiresAt)
+        );
+    }
+
+    public Optional<SessionRecord> findActiveSession(String tokenId) {
+        List<SessionRecord> rows = jdbcTemplate.query(
+                """
+                SELECT token_id, user_id, issued_at, expires_at, revoked
+                FROM auth_sessions
+                WHERE token_id = ?
+                """,
+                (rs, rowNum) -> new SessionRecord(
+                        rs.getString("token_id"),
+                        rs.getString("user_id"),
+                        rs.getTimestamp("issued_at").toInstant(),
+                        rs.getTimestamp("expires_at").toInstant(),
+                        rs.getBoolean("revoked")
+                ),
+                tokenId
+        );
+        return rows.stream()
+                .filter(row -> !row.revoked())
+                .findFirst();
+    }
+
+    public void revokeSession(String tokenId) {
+        jdbcTemplate.update(
+                """
+                UPDATE auth_sessions
+                SET revoked = TRUE, updated_at = CURRENT_TIMESTAMP
+                WHERE token_id = ?
+                """,
+                tokenId
+        );
+    }
+
+    public record SessionRecord(
+            String tokenId,
+            String userId,
+            Instant issuedAt,
+            Instant expiresAt,
+            boolean revoked
+    ) {}
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/auth/SessionService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/auth/SessionService.java
@@ -1,23 +1,70 @@
 package com.myway.backendspring.auth;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class SessionService {
-    private final Map<String, DemoUser> sessions = new ConcurrentHashMap<>();
+    private static final Duration DEFAULT_TOKEN_TTL = Duration.ofHours(12);
+
+    private final AuthJdbcStore authJdbcStore;
+    private final SecretKey jwtKey;
+    private final Duration tokenTtl;
+
+    public SessionService(
+            AuthJdbcStore authJdbcStore,
+            @Value("${myway.auth.jwt.secret:myway-class-dev-secret-key-change-me-32bytes}") String jwtSecret,
+            @Value("${myway.auth.jwt.ttl-hours:12}") long tokenTtlHours
+    ) {
+        this.authJdbcStore = authJdbcStore;
+        String resolvedSecret = (jwtSecret == null || jwtSecret.isBlank())
+                ? "myway-class-dev-secret-key-change-me-32bytes"
+                : jwtSecret.trim();
+        this.jwtKey = Keys.hmacShaKeyFor(normalizeSecret(resolvedSecret).getBytes(StandardCharsets.UTF_8));
+        this.tokenTtl = tokenTtlHours <= 0 ? DEFAULT_TOKEN_TTL : Duration.ofHours(tokenTtlHours);
+    }
+
+    @PostConstruct
+    void seedDemoUsers() {
+        for (DemoUser user : DemoUsers.USERS) {
+            authJdbcStore.upsertUser(user);
+        }
+    }
 
     public Optional<DemoUser> findUser(String userId) {
-        return DemoUsers.USERS.stream().filter(u -> u.id().equals(userId)).findFirst();
+        return authJdbcStore.findUserById(userId);
+    }
+
+    public List<DemoUser> listUsers() {
+        return authJdbcStore.listUsers();
     }
 
     public SessionView login(DemoUser user) {
-        String token = "sess_" + UUID.randomUUID();
-        sessions.put(token, user);
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = issuedAt.plus(tokenTtl);
+        String tokenId = "sid_" + UUID.randomUUID();
+        String token = Jwts.builder()
+                .subject(user.id())
+                .id(tokenId)
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiresAt))
+                .claim("role", user.role())
+                .signWith(jwtKey)
+                .compact();
+        authJdbcStore.upsertSession(tokenId, user.id(), issuedAt, expiresAt);
         return new SessionView(token, user, DemoUsers.ROLE_PERMISSIONS.getOrDefault(user.role(), java.util.List.of()));
     }
 
@@ -26,7 +73,30 @@ public class SessionService {
         if (token == null) {
             return null;
         }
-        DemoUser user = sessions.get(token);
+        Claims claims;
+        try {
+            claims = Jwts.parser()
+                    .verifyWith(jwtKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (Exception ignored) {
+            return null;
+        }
+        String tokenId = claims.getId();
+        String userId = claims.getSubject();
+        if (tokenId == null || tokenId.isBlank() || userId == null || userId.isBlank()) {
+            return null;
+        }
+        AuthJdbcStore.SessionRecord session = authJdbcStore.findActiveSession(tokenId).orElse(null);
+        if (session == null || !userId.equals(session.userId())) {
+            return null;
+        }
+        if (session.expiresAt().isBefore(Instant.now())) {
+            authJdbcStore.revokeSession(tokenId);
+            return null;
+        }
+        DemoUser user = authJdbcStore.findUserById(userId).orElse(null);
         if (user == null) {
             return null;
         }
@@ -35,8 +105,20 @@ public class SessionService {
 
     public void logout(String authHeader) {
         String token = extractToken(authHeader);
-        if (token != null) {
-            sessions.remove(token);
+        if (token == null) {
+            return;
+        }
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(jwtKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            String tokenId = claims.getId();
+            if (tokenId != null && !tokenId.isBlank()) {
+                authJdbcStore.revokeSession(tokenId);
+            }
+        } catch (Exception ignored) {
         }
     }
 
@@ -48,5 +130,17 @@ public class SessionService {
             return null;
         }
         return authHeader.substring("Bearer ".length()).trim();
+    }
+
+    private String normalizeSecret(String raw) {
+        String secret = raw == null ? "" : raw.trim();
+        if (secret.length() >= 32) {
+            return secret;
+        }
+        StringBuilder builder = new StringBuilder(secret);
+        while (builder.length() < 32) {
+            builder.append("0");
+        }
+        return builder.toString();
     }
 }

--- a/backend-spring/src/main/resources/schema.sql
+++ b/backend-spring/src/main/resources/schema.sql
@@ -50,3 +50,30 @@ CREATE TABLE IF NOT EXISTS activity_event (
 
 CREATE INDEX IF NOT EXISTS idx_activity_event_user_time ON activity_event(user_id, occurred_at DESC);
 CREATE INDEX IF NOT EXISTS idx_activity_event_user_type_time ON activity_event(user_id, type, occurred_at DESC);
+
+CREATE TABLE IF NOT EXISTS auth_users (
+  id VARCHAR(128) NOT NULL,
+  name VARCHAR(128) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  role VARCHAR(64) NOT NULL,
+  department VARCHAR(128) NULL,
+  bio TEXT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_users_email ON auth_users(email);
+
+CREATE TABLE IF NOT EXISTS auth_sessions (
+  token_id VARCHAR(128) NOT NULL,
+  user_id VARCHAR(128) NOT NULL,
+  issued_at TIMESTAMP NOT NULL,
+  expires_at TIMESTAMP NOT NULL,
+  revoked BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (token_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_user ON auth_sessions(user_id, created_at DESC);

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/StudentLearningFlowContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/StudentLearningFlowContractTest.java
@@ -1,0 +1,104 @@
+package com.myway.backendspring.contract;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class StudentLearningFlowContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void studentFlow_shouldSeeEnrolledCourse_watchLecture_andUseTranscriptRag() throws Exception {
+        String instructorToken = loginAndGetToken("usr_ins_001");
+        String instructorAuthHeader = "Bearer " + instructorToken;
+        String token = loginAndGetToken("usr_std_001");
+        String authHeader = "Bearer " + token;
+
+        JsonNode coursesData = readData(mockMvc.perform(get("/api/v1/courses")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn()
+        );
+        assertThat(coursesData.isArray()).isTrue();
+        assertThat(coursesData).isNotEmpty();
+        String courseId = coursesData.get(0).path("id").asText();
+        assertThat(courseId).isNotBlank();
+
+        JsonNode courseDetail = readData(mockMvc.perform(get("/api/v1/courses/{courseId}", courseId)
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn()
+        );
+        JsonNode lectures = courseDetail.path("lectures");
+        assertThat(lectures.isArray()).isTrue();
+        assertThat(lectures).isNotEmpty();
+        String lectureId = lectures.get(0).path("id").asText();
+        assertThat(lectureId).isNotBlank();
+
+        readData(mockMvc.perform(post("/api/v1/media/transcribe")
+                        .header("Authorization", instructorAuthHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"" + lectureId + "\",\"language\":\"ko\"}"))
+                .andExpect(status().isCreated())
+                .andReturn()
+        );
+
+        JsonNode lectureDetail = readData(mockMvc.perform(get("/api/v1/lectures/{lectureId}", lectureId))
+                .andExpect(status().isOk())
+                .andReturn()
+        );
+        assertThat(lectureDetail.path("id").asText()).isEqualTo(lectureId);
+
+        JsonNode transcript = readData(mockMvc.perform(get("/api/v1/media/transcript/{lectureId}", lectureId)
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andReturn()
+        );
+        assertThat(transcript.path("segments").isArray()).isTrue();
+        assertThat(transcript.path("segments").size()).isGreaterThan(0);
+
+        JsonNode rag = readData(mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"핵심 개념 요약\",\"lecture_id\":\"" + lectureId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+        );
+        assertThat(rag.path("chunks").isArray()).isTrue();
+        assertThat(rag.path("chunks").size()).isGreaterThan(0);
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+
+    private JsonNode readData(org.springframework.test.web.servlet.MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("success").asBoolean()).isTrue();
+        return root.path("data");
+    }
+}

--- a/docs/dev-logs/2026-05-23-jwt-db-auth-and-student-flow-contract.md
+++ b/docs/dev-logs/2026-05-23-jwt-db-auth-and-student-flow-contract.md
@@ -1,0 +1,35 @@
+# 2026-05-23 JWT/DB Auth + Student Learning Flow Contract
+
+## 배경
+- 데모 계정/세션이 메모리 기반이라 서버 재기동 시 인증 상태가 사라지고, 토큰이 비표준 형식(`sess_*`)이었다.
+- 학생 권한 기준의 핵심 학습 흐름(강의목록/강의상세/전사/RAG) 회귀를 CI에서 고정할 필요가 있었다.
+
+## 변경 내용
+- 인증 저장소 DB 전환
+  - `auth_users`, `auth_sessions` 테이블을 `schema.sql`에 추가.
+  - `AuthJdbcStore` 추가:
+    - 사용자 조회/목록/업서트
+    - 세션 생성/조회/폐기
+- JWT 세션 도입
+  - `SessionService`를 JWT 발급/검증 기반으로 교체.
+  - 로그인 시 `jti(token_id)`를 `auth_sessions`에 저장하고, `me` 호출 시 서명+만료+DB 세션 상태를 함께 검증.
+  - logout 시 세션 revoke 처리.
+  - 서버 시작 시 `DemoUsers`를 DB로 시드.
+- Auth API 조정
+  - `/api/v1/auth/users`가 상수 목록이 아니라 DB 사용자 목록을 반환하도록 변경.
+- 학생 학습 플로우 계약 테스트 추가
+  - `StudentLearningFlowContractTest`
+  - 시나리오:
+    1) 학생 로그인
+    2) 수강 코스/강의 조회
+    3) 강사 선행 전사 생성
+    4) 학생 전사 조회
+    5) 학생 RAG 질의 성공 확인
+
+## 검증
+- `backend-spring`: `./mvnw -q -DskipTests compile` 통과
+- 계약 테스트: `./mvnw -q "-Dtest=StudentLearningFlowContractTest,MediaContractTest,AiContractTest" test` 통과
+
+## 리스크/롤백
+- 리스크: JWT secret 설정이 너무 짧으면 키 생성 이슈 가능(코드에서 최소 길이 패딩 처리).
+- 롤백: 해당 커밋 revert 시 기존 메모리 세션 모델로 복귀.


### PR DESCRIPTION
# 변경 요약
데모 인증을 메모리 세션에서 JWT + DB 세션 저장 방식으로 전환하고, 학생 학습 핵심 플로우를 계약 테스트로 CI에 고정했습니다.

## 배경
서버 재기동 시 메모리 세션이 유실되고, 데모 계정/세션이 DB에 남지 않아 환경 재현성이 떨어졌습니다. 또한 학생 권한의 핵심 경로(수강목록/강의상세/전사/RAG) 회귀를 자동 검증할 필요가 있었습니다.

## 변경 내용
- `SessionService`
  - JWT 발급/검증 기반으로 전환
  - `jti(token_id)` 세션을 DB(`auth_sessions`)에 저장 및 검증
  - logout 시 revoke 처리
  - 부팅 시 데모 유저 DB 시드
- `AuthJdbcStore` 추가
  - `auth_users`, `auth_sessions` 조회/업서트/revoke 로직
- `AuthController`
  - `/api/v1/auth/users`를 DB 기준으로 반환
- `schema.sql`
  - `auth_users`, `auth_sessions` 테이블/인덱스 추가
- `StudentLearningFlowContractTest` 추가
  - 학생 로그인 → 코스/강의 조회 → 전사 조회 → RAG 질의 성공 시나리오 고정
- 문서
  - `docs/dev-logs/2026-05-23-jwt-db-auth-and-student-flow-contract.md` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
1. JWT 검증 + DB 세션 검증(이중 검증) 경계가 의도대로 동작하는지
2. media asset query token 정책과 JWT 토큰 형태 충돌 여부
3. StudentLearningFlowContractTest가 실제 수강생 흐름 회귀를 충분히 커버하는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:frontend` 통과
- layer tests: `./mvnw -q "-Dtest=StudentLearningFlowContractTest,MediaContractTest,AiContractTest" test` 통과
- risk/rollback: JWT 전환 장애 시 본 커밋 revert 후 기존 토큰 체계 복구

## ADR 링크
- ADR: `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
- 상태 변경: 해당 없음
