### PR TITLE
feat: 챗봇 reference 타임스탬프 강의 전환 seek UX 완성

### DIFF
--- a/docs/dev-logs/2026-05-23-rag-reference-seek-ux.md
+++ b/docs/dev-logs/2026-05-23-rag-reference-seek-ux.md
@@ -1,0 +1,26 @@
+# 2026-05-23 RAG Reference Seek UX
+
+## 배경
+- 챗봇 reference의 타임스탬프 클릭은 가능했지만, 다른 강의 reference를 클릭했을 때의 전환/seek 동작이 명확하지 않았다.
+- seek 실패 시 fallback 경로가 없어 사용자가 다음 액션을 판단하기 어려웠다.
+
+## 변경 내용
+- `AIChatThread`
+  - `onSeekTimestamp(startMs, lectureId?)` 시그니처로 확장
+  - reference의 `lecture_id`를 함께 전달
+- `LectureSideChatPanel`
+  - 상위로 `lectureId` 포함 seek 콜백 전달
+- `LectureWatchPage`
+  - 같은 강의 reference: 즉시 seek
+  - 다른 강의 reference:
+    - 현재 코스에 존재하면 `onSelectLecture` 후 pending seek 저장
+    - 강의 전환 완료 후 자동 seek 실행
+    - 현재 코스에 없으면 강의 상세 페이지(`courses`)로 fallback 이동
+
+## 검증
+- `npm run build:frontend` 통과
+- `npm --workspace @myway/frontend run test` 통과
+
+## 리스크/롤백
+- 리스크: reference에 `lecture_id`가 없는 응답은 기존과 동일하게 현재 강의 기준 seek 처리.
+- 롤백: 해당 커밋 revert 시 기존 단일 강의 seek 동작으로 복귀.

--- a/frontend/src/features/lms/components/AIChatThread.tsx
+++ b/frontend/src/features/lms/components/AIChatThread.tsx
@@ -15,7 +15,7 @@ export type AIChatMessage = {
 type AIChatThreadProps = {
   messages: AIChatMessage[];
   loading: boolean;
-  onSeekTimestamp?: (startMs: number) => void;
+  onSeekTimestamp?: (startMs: number, lectureId?: string | null) => void;
 };
 
 function sanitizeDisplayText(value: string): string {
@@ -52,6 +52,7 @@ export function AIChatThread({ messages, loading, onSeekTimestamp }: AIChatThrea
                 <div className="mt-3 space-y-2">
                   {message.references.slice(0, 3).map((reference) => {
                     const startMs = extractReferenceStartMs(reference);
+                    const lectureId = typeof reference.lecture_id === 'string' ? reference.lecture_id : null;
                     return (
                       <div key={reference.id} className="rounded-xl border border-[#c9e0f2] bg-white/90 px-3 py-2 text-[11px] text-[#31516f]">
                         <div className="flex items-center justify-between gap-2">
@@ -62,7 +63,7 @@ export function AIChatThread({ messages, loading, onSeekTimestamp }: AIChatThrea
                         {startMs !== null && onSeekTimestamp ? (
                           <button
                             type="button"
-                            onClick={() => onSeekTimestamp(startMs)}
+                            onClick={() => onSeekTimestamp(startMs, lectureId)}
                             className="mt-2 inline-flex items-center gap-1 rounded-full bg-slate-900 px-2.5 py-1 text-[10px] font-semibold text-white transition hover:bg-indigo-600"
                           >
                             <i className="ri-time-line" />

--- a/frontend/src/features/lms/components/LectureSideChatPanel.tsx
+++ b/frontend/src/features/lms/components/LectureSideChatPanel.tsx
@@ -8,7 +8,7 @@ import { AIChatThread, type AIChatMessage } from './AIChatThread';
 type LectureSideChatPanelProps = {
   highlightedLecture: LectureDetail | null;
   sessionToken?: string | null;
-  onSeekTimestamp?: (startMs: number) => void;
+  onSeekTimestamp?: (startMs: number, lectureId?: string | null) => void;
 };
 
 function createWelcomeMessage(highlightedLecture: LectureDetail | null): AIChatMessage {

--- a/frontend/src/features/lms/pages/LectureWatchPage.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPage.tsx
@@ -54,6 +54,7 @@ export function LectureWatchPage({
   const [remapAssetKey, setRemapAssetKey] = useState('');
   const [remapMessage, setRemapMessage] = useState<string | null>(null);
   const [remapBusy, setRemapBusy] = useState(false);
+  const [pendingSeek, setPendingSeek] = useState<{ lectureId: string; startMs: number } | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const isLocked = Boolean(selectedCourse && !selectedCourse.enrolled && !canManageCurrent);
   const currentLecture = useMemo(() => {
@@ -210,6 +211,33 @@ export function LectureWatchPage({
       });
     }
   }
+
+  function handleSeekFromChat(startMs: number, lectureId?: string | null) {
+    const targetLectureId = (lectureId ?? '').trim();
+    const activeLectureId = currentLecture?.id ?? '';
+    if (targetLectureId && activeLectureId && targetLectureId !== activeLectureId) {
+      const existsInCourse = Boolean(selectedCourse?.lectures.some((lecture) => lecture.id === targetLectureId));
+      if (existsInCourse) {
+        setPendingSeek({ lectureId: targetLectureId, startMs });
+        onSelectLecture(targetLectureId);
+        return;
+      }
+      onNavigate('courses');
+      return;
+    }
+    seekVideoTo(startMs);
+  }
+
+  useEffect(() => {
+    if (!pendingSeek || !currentLecture?.id) {
+      return;
+    }
+    if (pendingSeek.lectureId !== currentLecture.id) {
+      return;
+    }
+    seekVideoTo(pendingSeek.startMs);
+    setPendingSeek(null);
+  }, [currentLecture?.id, pendingSeek]);
 
   if (!selectedCourse) {
     return (
@@ -549,7 +577,7 @@ export function LectureWatchPage({
                   <LectureSideChatPanel
                     highlightedLecture={highlightedLecture}
                     sessionToken={sessionToken}
-                    onSeekTimestamp={seekVideoTo}
+                    onSeekTimestamp={handleSeekFromChat}
                   />
                 ) : null}
               </div>


### PR DESCRIPTION
# 변경 요약
강의 시청 챗봇 reference 클릭 시 타임스탬프 이동을 강의 전환까지 포함해 완성했습니다.

## 배경
기존에는 reference의 timestamp를 현재 영상에서만 seek했고, 다른 강의 reference를 클릭하면 의도한 이동이 보장되지 않았습니다.

## 변경 내용
- `AIChatThread`
  - `onSeekTimestamp(startMs, lectureId?)` 확장
  - reference의 `lecture_id` 전달
- `LectureSideChatPanel`
  - 상위로 `lectureId` 포함 seek 콜백 전달
- `LectureWatchPage`
  - 같은 강의: 즉시 seek
  - 다른 강의(현재 코스 포함): 차시 전환 후 pending seek로 자동 이동
  - 다른 강의(현재 코스 미포함): `courses`로 fallback 이동
- 문서
  - `docs/dev-logs/2026-05-23-rag-reference-seek-ux.md` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
1. reference `lecture_id`가 없는 응답의 fallback 동작(현재 강의 seek)
2. pending seek 상태가 lecture 전환 시 정확히 1회만 실행되는지
3. 코스 외 강의 reference 클릭 시 `courses` 이동 UX가 의도와 맞는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:frontend` 통과
- layer tests: `npm --workspace @myway/frontend run test` 통과
- risk/rollback: reference lecture 전환 UX 이슈 발생 시 revert 가능

## ADR 링크
- ADR: `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md`
- 상태 변경: 해당 없음
