### PR TITLE
feat: media speaker review UI + shortform compose/retry ops

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
@@ -230,6 +230,7 @@ public class ShortformService {
         video.put("export_status", "PROCESSING");
         video.put("error_message", null);
         video.put("updated_at", Instant.now().toString());
+        dispatchShortformExportJob(video);
         repository.upsertKv(SHORTFORM_VIDEO_SCOPE, shortformId, video);
         return video;
     }

--- a/docs/dev-logs/2026-05-23-media-speaker-review-shortform-compose-ops.md
+++ b/docs/dev-logs/2026-05-23-media-speaker-review-shortform-compose-ops.md
@@ -1,0 +1,22 @@
+# 2026-05-23 Media Speaker Review + Shortform Compose Ops
+
+## Summary
+- Added admin/instructor speaker-review panel on Media Pipeline page.
+- Aligned shortform compose flow to send explicit timestamp clips (lecture_id/start_ms/end_ms).
+- Fixed shortform export retry to re-dispatch export job immediately.
+- Extended shared shortform compose request type for backend-compatible payload.
+
+## Why
+- Existing shortform compose request path depended on extraction candidates that were not aligned with backend payload shape, causing compose failures.
+- Speaker-review API existed but operator UI was missing.
+- Retry endpoint changed status only but did not dispatch a new export job.
+
+## Verification
+- `npm run build:frontend`
+- `npm --workspace @myway/frontend run test`
+- `./mvnw -q -DskipTests compile` (backend-spring)
+- `./mvnw -q "-Dtest=MediaContractTest,StudentLearningFlowContractTest" test` (backend-spring)
+
+## Risk / Rollback
+- Risk: low-medium (frontend compose payload + operator panel + retry dispatch path).
+- Rollback: revert this commit; compose will return to previous extraction-candidate flow.

--- a/frontend/src/features/lms/components/ShortformWizard.tsx
+++ b/frontend/src/features/lms/components/ShortformWizard.tsx
@@ -3,9 +3,7 @@ import { getLectureDisplayDurationMinutes, type CourseCard, type CourseDetail, t
 import { loadCourseDetail, loadLectureTranscriptDetailed } from '../../../lib/api';
 import {
   composeShortformDraft,
-  generateShortformExtractionDraft,
   loadShortformCommunity,
-  loadShortformExtractionDraft,
   loadShortformVideoDraft,
   shareShortformDraft,
 } from '../../../lib/api-shortforms';
@@ -243,15 +241,6 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
   const totalDurationMs = selectedClips.reduce((sum, clip) => sum + (clip.end_time_ms - clip.start_time_ms), 0);
   const totalDurationLabel = formatDuration(totalDurationMs);
   const stepLabel = step === 1 ? '강좌 선택' : step === 2 ? '구간 선택' : '미리보기 / 저장';
-  const transcriptPayload = useMemo(
-    () =>
-      Object.fromEntries(
-        Object.entries(transcriptMap)
-          .filter(([, snapshot]) => Boolean(snapshot?.segments?.length))
-          .map(([lectureId, snapshot]) => [lectureId, snapshot?.segments ?? []]),
-      ),
-    [transcriptMap],
-  );
   const previewVideoUrl =
     resolvePlayableVideoUrl(createdVideo?.export_result_url ?? undefined) ??
     (createdVideo?.video_url && !createdVideo.video_url.startsWith('/static/shortforms/')
@@ -286,43 +275,17 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
       return;
     }
 
-    setStatus('숏폼 후보를 생성하는 중입니다.');
-
-    const extraction = await generateShortformExtractionDraft(
-      {
-        course_id: courseDetail.id,
-        mode: 'cross',
-        style: 'highlight',
-        language: 'ko',
-        transcript_segments_by_lecture: transcriptPayload,
-      },
-      sessionToken,
-    );
-
-    if (!extraction) {
-      setStatus('숏폼 후보를 생성하지 못했습니다.');
-      return;
-    }
-
-    const extractionDetail = await loadShortformExtractionDraft(extraction.id, sessionToken);
-    const selectedKeys = new Set(selectedClips.map((clip) => clipKey(clip)));
-    const candidateIds =
-      extractionDetail?.candidates
-        .filter((candidate) => selectedKeys.has(`${candidate.lecture_id}:${candidate.start_time_ms}:${candidate.end_time_ms}`))
-        .map((candidate) => candidate.id) ?? [];
-
-    if (candidateIds.length === 0) {
-      setStatus('선택한 구간과 일치하는 숏폼 후보를 찾지 못했습니다.');
-      return;
-    }
-
     setStatus('선택한 구간으로 숏폼을 생성하는 중입니다.');
     const video = await composeShortformDraft(
       {
-        extraction_id: extraction.id,
+        course_id: courseDetail.id,
         title: title.trim() || `${courseDetail.title} 숏폼`,
-        candidate_ids: candidateIds,
         description,
+        clips: selectedClips.map((clip) => ({
+          lecture_id: clip.lecture_id,
+          start_ms: clip.start_time_ms,
+          end_ms: clip.end_time_ms,
+        })),
       },
       sessionToken,
     );

--- a/frontend/src/features/lms/pages/MediaPipelinePage.tsx
+++ b/frontend/src/features/lms/pages/MediaPipelinePage.tsx
@@ -13,7 +13,10 @@ import {
   loadMediaPipeline,
   loadMediaProcessorHealth,
   loadMediaProviders,
+  loadTranscriptSpeakerReview,
+  saveTranscriptSpeakerReviewDetailed,
   uploadLectureVideoDetailed,
+  type TranscriptSpeakerReview,
   type MediaUploadResult,
 } from '../../../lib/api-media';
 import { getAiErrorMessage, getQuotaStatusText, getPublicTestPolicyText } from '../../../lib/ai-access';
@@ -62,6 +65,11 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
   );
   const [extractions, setExtractions] = useState<AudioExtraction[]>(demoMode ? [demoAudioExtraction] : []);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [speakerReview, setSpeakerReview] = useState<TranscriptSpeakerReview | null>(null);
+  const [speakerLabel, setSpeakerLabel] = useState('SPEAKER_01');
+  const [instructorName, setInstructorName] = useState('');
+  const [speakerConfidence, setSpeakerConfidence] = useState('0.95');
+  const [speakerNote, setSpeakerNote] = useState('');
 
   useEffect(() => {
     setLectureId(defaultLectureId);
@@ -103,23 +111,29 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
       }
 
       try {
-        const [nextPipeline, nextExtractions, nextProcessorHealth, nextTranscript] = await Promise.all([
+        const [nextPipeline, nextExtractions, nextProcessorHealth, nextTranscript, nextSpeakerReview] = await Promise.all([
           loadMediaPipeline(targetLectureId, sessionToken),
           loadAudioExtractions(targetLectureId, sessionToken),
           loadMediaProcessorHealth(sessionToken),
           loadLectureTranscriptDetailed(targetLectureId, sessionToken),
+          viewerRole === 'ADMIN' || viewerRole === 'INSTRUCTOR' ? loadTranscriptSpeakerReview(targetLectureId, sessionToken) : Promise.resolve(null),
         ]);
         setPipeline(nextPipeline);
         setExtractions(nextExtractions);
         setProcessorHealth(nextProcessorHealth);
         setTranscript(nextTranscript);
+        setSpeakerReview(nextSpeakerReview);
+        setSpeakerLabel(nextSpeakerReview?.speaker_label ?? 'SPEAKER_01');
+        setInstructorName(nextSpeakerReview?.instructor_name ?? selectedCourse?.instructor_name ?? '');
+        setSpeakerConfidence(String(nextSpeakerReview?.confidence ?? 0.95));
+        setSpeakerNote(nextSpeakerReview?.note ?? '');
       } finally {
         if (!options?.silent) {
           setIsRefreshing(false);
         }
       }
     },
-    [demoMode, sessionToken],
+    [demoMode, selectedCourse?.instructor_name, sessionToken, viewerRole],
   );
 
   useEffect(() => {
@@ -129,6 +143,7 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
       setExtractions([demoAudioExtraction]);
       setProcessorHealth(demoMediaProcessorHealth);
       setTranscript(demoLectureTranscript);
+      setSpeakerReview(null);
       setUploadResult({
         lecture_id: demoLectureDetail.id,
         asset_key: demoAudioExtraction.source_video_key ?? 'media/demo/ai-orchestration-intro.mp4',
@@ -155,7 +170,8 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
       loadAudioExtractions(lectureId, sessionToken),
       loadMediaProcessorHealth(sessionToken),
       loadLectureTranscriptDetailed(lectureId, sessionToken),
-    ]).then(([nextProviders, nextPipeline, nextExtractions, nextProcessorHealth, nextTranscript]) => {
+      viewerRole === 'ADMIN' || viewerRole === 'INSTRUCTOR' ? loadTranscriptSpeakerReview(lectureId, sessionToken) : Promise.resolve(null),
+    ]).then(([nextProviders, nextPipeline, nextExtractions, nextProcessorHealth, nextTranscript, nextSpeakerReview]) => {
       if (!active) {
         return;
       }
@@ -165,12 +181,17 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
       setExtractions(nextExtractions);
       setProcessorHealth(nextProcessorHealth);
       setTranscript(nextTranscript);
+      setSpeakerReview(nextSpeakerReview);
+      setSpeakerLabel(nextSpeakerReview?.speaker_label ?? 'SPEAKER_01');
+      setInstructorName(nextSpeakerReview?.instructor_name ?? selectedCourse?.instructor_name ?? '');
+      setSpeakerConfidence(String(nextSpeakerReview?.confidence ?? 0.95));
+      setSpeakerNote(nextSpeakerReview?.note ?? '');
     });
 
     return () => {
       active = false;
     };
-  }, [demoMode, lectureId, sessionToken]);
+  }, [demoMode, lectureId, selectedCourse?.instructor_name, sessionToken, viewerRole]);
 
   const selectedLecture = useMemo(
     () => lectureOptions.find((lecture) => lecture.id === lectureId) ?? highlightedLecture ?? demoLectureDetail,
@@ -344,6 +365,38 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
     } finally {
       setBusy(false);
     }
+  }
+
+  async function handleSaveSpeakerReview() {
+    if (demoMode) {
+      setNotice('데모 데이터 상태에서는 화자 검수를 저장하지 않습니다.');
+      return;
+    }
+    if (!lectureId) {
+      setNotice('강의를 먼저 선택해 주세요.');
+      return;
+    }
+    if (!instructorName.trim()) {
+      setNotice('강사명은 필수입니다.');
+      return;
+    }
+    const confidence = Number(speakerConfidence);
+    const response = await saveTranscriptSpeakerReviewDetailed(
+      lectureId,
+      {
+        speaker_label: speakerLabel.trim() || 'SPEAKER_01',
+        instructor_name: instructorName.trim(),
+        confidence: Number.isFinite(confidence) ? confidence : undefined,
+        note: speakerNote.trim() || undefined,
+      },
+      sessionToken,
+    );
+    if (!response?.success || !response.data) {
+      setNotice(getAiErrorMessage(response, '화자 검수 저장에 실패했습니다.'));
+      return;
+    }
+    setSpeakerReview(response.data);
+    setNotice('화자/강사 검수가 저장되었습니다.');
   }
 
   return (
@@ -538,6 +591,50 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
             <TranscriptTimelineWorkspace selectedLecture={selectedLecture} transcript={transcript} />
           </section>
         )}
+
+        {(viewerRole === 'ADMIN' || viewerRole === 'INSTRUCTOR') && !demoMode ? (
+          <section className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold text-slate-900">화자/강사 검수</div>
+                <div className="mt-1 text-xs text-slate-500">
+                  STT 화자 라벨을 실제 강사명으로 매핑해 RAG/요약 품질을 안정화합니다.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleSaveSpeakerReview()}
+                className="inline-flex items-center gap-2 rounded-full bg-cyan-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-cyan-700"
+              >
+                <i className="ri-save-line" />
+                검수 저장
+              </button>
+            </div>
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <label className="space-y-2">
+                <span className="text-xs font-semibold text-slate-600">화자 라벨</span>
+                <input value={speakerLabel} onChange={(event) => setSpeakerLabel(event.target.value)} className="w-full rounded-xl border border-[#cce0f2] px-3 py-2 text-sm" />
+              </label>
+              <label className="space-y-2">
+                <span className="text-xs font-semibold text-slate-600">강사명</span>
+                <input value={instructorName} onChange={(event) => setInstructorName(event.target.value)} className="w-full rounded-xl border border-[#cce0f2] px-3 py-2 text-sm" />
+              </label>
+              <label className="space-y-2">
+                <span className="text-xs font-semibold text-slate-600">신뢰도 (0~1)</span>
+                <input value={speakerConfidence} onChange={(event) => setSpeakerConfidence(event.target.value)} className="w-full rounded-xl border border-[#cce0f2] px-3 py-2 text-sm" />
+              </label>
+              <label className="space-y-2">
+                <span className="text-xs font-semibold text-slate-600">메모</span>
+                <input value={speakerNote} onChange={(event) => setSpeakerNote(event.target.value)} className="w-full rounded-xl border border-[#cce0f2] px-3 py-2 text-sm" />
+              </label>
+            </div>
+            {speakerReview ? (
+              <div className="mt-3 text-xs text-slate-500">
+                마지막 검수: {speakerReview.reviewed_at ?? '-'} · {speakerReview.reviewed_by ?? '-'}
+              </div>
+            ) : null}
+          </section>
+        ) : null}
       </>
     </div>
   );

--- a/frontend/src/lib/api-media.ts
+++ b/frontend/src/lib/api-media.ts
@@ -37,6 +37,16 @@ export type LectureVideoMappingResult = {
   video_url: string;
 };
 
+export type TranscriptSpeakerReview = {
+  status: string;
+  speaker_label?: string;
+  instructor_name?: string;
+  confidence?: number;
+  note?: string;
+  reviewed_by?: string;
+  reviewed_at?: string;
+};
+
 export async function uploadLectureVideoDetailed(
   lectureId: string,
   file: File,
@@ -112,6 +122,40 @@ export async function loadLectureTranscriptDetailed(lectureId: string, sessionTo
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
   const response = await request<LectureTranscript>(`/api/v1/media/transcript/${encodeURIComponent(lectureId)}`, undefined, token);
   return response?.success && response.data ? response.data : null;
+}
+
+export async function loadTranscriptSpeakerReview(
+  lectureId: string,
+  sessionToken?: string | null,
+): Promise<TranscriptSpeakerReview | null> {
+  const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
+  const response = await request<TranscriptSpeakerReview>(
+    `/api/v1/media/transcript/${encodeURIComponent(lectureId)}/speaker-review`,
+    undefined,
+    token,
+  );
+  return response?.success && response.data ? response.data : null;
+}
+
+export async function saveTranscriptSpeakerReviewDetailed(
+  lectureId: string,
+  input: {
+    speaker_label?: string;
+    instructor_name: string;
+    confidence?: number;
+    note?: string;
+  },
+  sessionToken?: string | null,
+): Promise<ApiRequestResult<TranscriptSpeakerReview> | null> {
+  const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
+  return await request<TranscriptSpeakerReview>(
+    `/api/v1/media/transcript/${encodeURIComponent(lectureId)}/speaker-review`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+    token,
+  );
 }
 
 export async function loadMediaProviders(sessionToken?: string | null): Promise<STTProviderCatalog | null> {

--- a/packages/shared/src/types/shortform.ts
+++ b/packages/shared/src/types/shortform.ts
@@ -116,9 +116,15 @@ export type ShortformSelectRequest = {
 };
 
 export type ShortformComposeRequest = {
-  extraction_id: string;
+  extraction_id?: string;
+  course_id?: string;
   title: string;
   candidate_ids?: string[];
+  clips?: Array<{
+    lecture_id: string;
+    start_ms: number;
+    end_ms: number;
+  }>;
   description?: string;
 };
 


### PR DESCRIPTION
# 변경 요약
미디어 파이프라인 관리자 화자 검수 UI를 추가하고, 숏폼 조합/재시도 경로를 운영 가능한 형태로 정렬했습니다.

## 배경
- `/api/v1/media/transcript/{lectureId}/speaker-review` API는 있었지만 운영자가 검수 입력할 화면이 없었습니다.
- 숏폼 compose는 프론트 요청 타입과 백엔드 compose 입력(`clips`)이 어긋나 실제 타임스탬프 조합이 깨질 수 있었습니다.
- 숏폼 export retry는 상태만 변경하고 실제 재디스패치를 하지 않아 재시도 효력이 불완전했습니다.

## 변경 내용
- `MediaPipelinePage`에 관리자/강사용 화자 검수 패널 추가
  - speaker label / instructor name / confidence / note 입력 및 저장
  - lecture 변경/새로고침 시 검수 상태 로드
- 숏폼 compose 흐름을 `selectedClips -> clips(lecture_id,start_ms,end_ms)` 직접 전송 방식으로 정렬
- `ShortformService.retryShortformExport`에서 재시도 시 `dispatchShortformExportJob(video)` 즉시 실행
- `ShortformComposeRequest` 타입을 백엔드 스펙 호환 필드(`course_id`, `clips`)로 확장
- `docs/dev-logs/2026-05-23-media-speaker-review-shortform-compose-ops.md` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [x] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [ ] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:frontend`, `./mvnw -q -DskipTests compile`
- layer tests: `npm --workspace @myway/frontend run test`, `./mvnw -q "-Dtest=MediaContractTest,StudentLearningFlowContractTest" test`
- risk/rollback: 숏폼 compose payload 경로 및 재시도 dispatch 경로에 영향. 문제 시 본 PR revert로 즉시 복구 가능.

## ADR 링크
- ADR: 해당 없음 (기존 API 스펙 정렬/운영 UI 보강)
- 상태 변경: 해당 없음
