### PR TITLE
feat: add shortform export admin ops dashboard and batch retry

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -37,6 +37,7 @@ public class ShortformController {
     public record ShareRequest(@NotBlank String video_id, String course_id, String visibility, String message) {}
     public record SaveRequest(@NotBlank String video_id, String note, String folder) {}
     public record LikeRequest(@NotBlank String video_id) {}
+    public record RetryFailedExportsRequest(Boolean include_permanent, Integer limit) {}
 
     private final SessionService sessionService;
     private final ShortformService shortformService;
@@ -61,6 +62,9 @@ public class ShortformController {
     }
     private String trimRequired(String value) {
         return value.trim();
+    }
+    private boolean isAdmin(SessionView session) {
+        return session != null && "admin".equals(session.user().role());
     }
 
     @GetMapping("/library")
@@ -197,6 +201,34 @@ public class ShortformController {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.success(updated, "최대 재시도 횟수를 초과했습니다."));
         }
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.success(updated, "숏폼 export job이 다시 시작되었습니다."));
+    }
+
+    @GetMapping("/admin/export-status")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> exportStatus(
+            @RequestHeader(value = "Authorization", required = false) String auth
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return unauthenticated();
+        if (!isAdmin(session)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "운영자 권한이 필요합니다."));
+        }
+        return ResponseEntity.ok(ApiResponse.success(shortformService.shortformExportStatus()));
+    }
+
+    @PostMapping("/admin/export/retry-failed")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> retryFailedExports(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) RetryFailedExportsRequest body
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return unauthenticated();
+        if (!isAdmin(session)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "운영자 권한이 필요합니다."));
+        }
+        boolean includePermanent = body != null && Boolean.TRUE.equals(body.include_permanent());
+        int limit = body == null || body.limit() == null ? 20 : body.limit();
+        Map<String, Object> result = shortformService.retryFailedShortformExports(includePermanent, limit);
+        return ResponseEntity.ok(ApiResponse.success(result, "실패한 숏폼 export 재시도가 실행되었습니다."));
     }
 
     public record ExportCallbackRequest(

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
@@ -219,20 +219,88 @@ public class ShortformService {
         if (!userId.equals(String.valueOf(video.getOrDefault("user_id", "")))) {
             return Map.of("error", "FORBIDDEN");
         }
-        int retryCount = asInt(video.get("retry_count"));
-        if (retryCount >= shortformMaxRetry) {
-            video.put("export_status", "FAILED_PERMANENT");
-            video.put("updated_at", Instant.now().toString());
-            repository.upsertKv(SHORTFORM_VIDEO_SCOPE, shortformId, video);
-            return video;
-        }
-        video.put("retry_count", retryCount + 1);
-        video.put("export_status", "PROCESSING");
-        video.put("error_message", null);
-        video.put("updated_at", Instant.now().toString());
-        dispatchShortformExportJob(video);
+        retryShortformExportInternal(video);
         repository.upsertKv(SHORTFORM_VIDEO_SCOPE, shortformId, video);
         return video;
+    }
+
+    public Map<String, Object> shortformExportStatus() {
+        List<Map<String, Object>> videos = repository.listKvByScope(SHORTFORM_VIDEO_SCOPE);
+        long pending = 0L;
+        long processing = 0L;
+        long completed = 0L;
+        long failed = 0L;
+        long failedPermanent = 0L;
+        String lastUpdatedAt = null;
+        List<Map<String, Object>> failedItems = new ArrayList<>();
+
+        for (Map<String, Object> video : videos) {
+            String status = String.valueOf(video.getOrDefault("export_status", "PENDING")).toUpperCase();
+            String updatedAt = String.valueOf(video.getOrDefault("updated_at", ""));
+            if (!updatedAt.isBlank() && (lastUpdatedAt == null || updatedAt.compareTo(lastUpdatedAt) > 0)) {
+                lastUpdatedAt = updatedAt;
+            }
+            switch (status) {
+                case "PROCESSING" -> processing += 1L;
+                case "COMPLETED" -> completed += 1L;
+                case "FAILED" -> {
+                    failed += 1L;
+                    failedItems.add(buildFailedItem(video));
+                }
+                case "FAILED_PERMANENT" -> {
+                    failedPermanent += 1L;
+                    failedItems.add(buildFailedItem(video));
+                }
+                default -> pending += 1L;
+            }
+        }
+
+        failedItems.sort((left, right) -> String.valueOf(right.getOrDefault("updated_at", ""))
+                .compareTo(String.valueOf(left.getOrDefault("updated_at", ""))));
+        if (failedItems.size() > 20) {
+            failedItems = new ArrayList<>(failedItems.subList(0, 20));
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("pending_count", pending);
+        result.put("processing_count", processing);
+        result.put("completed_count", completed);
+        result.put("failed_count", failed);
+        result.put("failed_permanent_count", failedPermanent);
+        result.put("last_updated_at", lastUpdatedAt);
+        result.put("failed_items", failedItems);
+        return result;
+    }
+
+    public Map<String, Object> retryFailedShortformExports(boolean includePermanent, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, 100));
+        List<Map<String, Object>> videos = repository.listKvByScope(SHORTFORM_VIDEO_SCOPE);
+        List<Map<String, Object>> targets = videos.stream()
+                .filter(video -> {
+                    String status = String.valueOf(video.getOrDefault("export_status", "")).toUpperCase();
+                    return "FAILED".equals(status) || (includePermanent && "FAILED_PERMANENT".equals(status));
+                })
+                .sorted((left, right) -> String.valueOf(right.getOrDefault("updated_at", ""))
+                        .compareTo(String.valueOf(left.getOrDefault("updated_at", ""))))
+                .limit(safeLimit)
+                .toList();
+
+        int retried = 0;
+        List<String> retriedIds = new ArrayList<>();
+        for (Map<String, Object> video : targets) {
+            Map<String, Object> updated = retryShortformExportInternal(video);
+            repository.upsertKv(SHORTFORM_VIDEO_SCOPE, String.valueOf(updated.getOrDefault("id", "")), updated);
+            if ("PROCESSING".equals(String.valueOf(updated.getOrDefault("export_status", "")))) {
+                retried += 1;
+                retriedIds.add(String.valueOf(updated.getOrDefault("id", "")));
+            }
+        }
+        return Map.of(
+                "retried_count", retried,
+                "target_count", targets.size(),
+                "retried_ids", retriedIds,
+                "status", shortformExportStatus()
+        );
     }
 
     public Map<String, Object> applyShortformExportCallback(String shortformId, String status, long eventVersion, String videoUrl, String errorMessage) {
@@ -271,6 +339,33 @@ public class ShortformService {
         } catch (Exception ignored) {
             return 0;
         }
+    }
+
+    private Map<String, Object> buildFailedItem(Map<String, Object> video) {
+        Map<String, Object> item = new HashMap<>();
+        item.put("id", String.valueOf(video.getOrDefault("id", "")));
+        item.put("title", String.valueOf(video.getOrDefault("title", "")));
+        item.put("user_id", String.valueOf(video.getOrDefault("user_id", "")));
+        item.put("export_status", String.valueOf(video.getOrDefault("export_status", "")));
+        item.put("retry_count", asInt(video.get("retry_count")));
+        item.put("error_message", String.valueOf(video.getOrDefault("error_message", "")));
+        item.put("updated_at", String.valueOf(video.getOrDefault("updated_at", "")));
+        return item;
+    }
+
+    private Map<String, Object> retryShortformExportInternal(Map<String, Object> video) {
+        int retryCount = asInt(video.get("retry_count"));
+        if (retryCount >= shortformMaxRetry) {
+            video.put("export_status", "FAILED_PERMANENT");
+            video.put("updated_at", Instant.now().toString());
+            return video;
+        }
+        video.put("retry_count", retryCount + 1);
+        video.put("export_status", "PROCESSING");
+        video.put("error_message", null);
+        video.put("updated_at", Instant.now().toString());
+        dispatchShortformExportJob(video);
+        return video;
     }
 
     private long asLong(Object value) {

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformAdminExportOpsIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformAdminExportOpsIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.myway.backendspring.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ShortformAdminExportOpsIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void adminExportStatusAndRetryFailed_shouldWork_forAdminOnly() throws Exception {
+        String studentAuth = "Bearer " + loginAndGetToken("usr_std_001");
+        String adminAuth = "Bearer " + loginAndGetToken("usr_admin_001");
+
+        String compose = mockMvc.perform(post("/api/v1/shortform/compose")
+                        .header("Authorization", studentAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"admin-export-ops-test\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        String shortformId = objectMapper.readTree(compose).path("data").path("id").asText();
+        assertThat(shortformId).isNotBlank();
+
+        mockMvc.perform(post("/api/v1/shortform/export/callback")
+                        .header("X-Callback-Token", "dev-shortform-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shortform_id\":\"" + shortformId + "\",\"status\":\"FAILED\",\"error_message\":\"ops-fail\",\"event_version\":2}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/shortform/admin/export-status")
+                        .header("Authorization", studentAuth))
+                .andExpect(status().isForbidden());
+
+        String adminStatus = mockMvc.perform(get("/api/v1/shortform/admin/export-status")
+                        .header("Authorization", adminAuth))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode statusRoot = objectMapper.readTree(adminStatus);
+        assertThat(statusRoot.path("data").path("failed_count").asInt()).isGreaterThanOrEqualTo(1);
+
+        String retry = mockMvc.perform(post("/api/v1/shortform/admin/export/retry-failed")
+                        .header("Authorization", adminAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"include_permanent\":false,\"limit\":20}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode retryRoot = objectMapper.readTree(retry);
+        assertThat(retryRoot.path("data").path("retried_count").asInt()).isGreaterThanOrEqualTo(1);
+        assertThat(retryRoot.path("data").path("status").path("processing_count").asInt()).isGreaterThanOrEqualTo(1);
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userId\":\"" + userId + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).path("data").path("session_token").asText();
+    }
+}
+

--- a/docs/dev-logs/2026-05-23-shortform-export-admin-ops.md
+++ b/docs/dev-logs/2026-05-23-shortform-export-admin-ops.md
@@ -1,0 +1,25 @@
+# 2026-05-23 Shortform Export Admin Ops
+
+## Summary
+- Added admin-only shortform export status API and failed-export bulk retry API.
+- Added Media Pipeline admin panel to show shortform export queue counts and failed items.
+- Added integration test coverage for admin-only access and retry flow.
+
+## Backend
+- `GET /api/v1/shortform/admin/export-status`
+- `POST /api/v1/shortform/admin/export/retry-failed`
+- `ShortformService.retryShortformExport` now reuses internal dispatch-aware retry path.
+
+## Frontend
+- Added admin queue visibility and failed-batch retry button in Media Pipeline page.
+- Added `loadShortformExportStatus`, `retryFailedShortformExports` API helpers.
+
+## Verification
+- `npm run build:frontend`
+- `npm --workspace @myway/frontend run test`
+- `./mvnw -q -DskipTests compile` (backend-spring)
+- `./mvnw -q "-Dtest=ShortformAdminExportOpsIntegrationTest,ShortformRetryStateIntegrationTest,MediaContractTest,StudentLearningFlowContractTest" test` (backend-spring)
+
+## Risk / Rollback
+- Risk: low-medium (admin ops endpoints + dashboard panel)
+- Rollback: revert this commit to restore prior behavior.

--- a/frontend/src/features/lms/pages/MediaPipelinePage.tsx
+++ b/frontend/src/features/lms/pages/MediaPipelinePage.tsx
@@ -19,6 +19,11 @@ import {
   type TranscriptSpeakerReview,
   type MediaUploadResult,
 } from '../../../lib/api-media';
+import {
+  loadShortformExportStatus,
+  retryFailedShortformExports,
+  type ShortformExportStatusSummary,
+} from '../../../lib/api-shortforms';
 import { getAiErrorMessage, getQuotaStatusText, getPublicTestPolicyText } from '../../../lib/ai-access';
 import { demoAudioExtraction, demoCourseDetail, demoLectureDetail, demoLecturePipeline, demoLectureTranscript, demoMediaProcessorHealth } from '../data/demo';
 
@@ -70,6 +75,7 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
   const [instructorName, setInstructorName] = useState('');
   const [speakerConfidence, setSpeakerConfidence] = useState('0.95');
   const [speakerNote, setSpeakerNote] = useState('');
+  const [shortformExportStatus, setShortformExportStatus] = useState<ShortformExportStatusSummary | null>(null);
 
   useEffect(() => {
     setLectureId(defaultLectureId);
@@ -244,6 +250,22 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
     return () => window.clearInterval(timer);
   }, [latestExtraction?.status, latestExtraction?.stt_status, lectureId, pipeline?.audio_status, pipeline?.transcript_status, refreshMediaState]);
 
+  useEffect(() => {
+    if (viewerRole !== 'ADMIN' || demoMode) {
+      setShortformExportStatus(null);
+      return;
+    }
+    let active = true;
+    loadShortformExportStatus(sessionToken).then((status) => {
+      if (active) {
+        setShortformExportStatus(status);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [demoMode, sessionToken, viewerRole]);
+
   async function submitExtraction(input: {
     lecture_id: string;
     video_url?: string;
@@ -397,6 +419,19 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
     }
     setSpeakerReview(response.data);
     setNotice('화자/강사 검수가 저장되었습니다.');
+  }
+
+  async function handleRetryFailedShortforms() {
+    if (viewerRole !== 'ADMIN' || demoMode) {
+      return;
+    }
+    const status = await retryFailedShortformExports({ include_permanent: false, limit: 20 }, sessionToken);
+    if (status) {
+      setShortformExportStatus(status);
+      setNotice('실패한 숏폼 export 재시도를 실행했습니다.');
+    } else {
+      setNotice('숏폼 export 재시도 실행에 실패했습니다.');
+    }
   }
 
   return (
@@ -633,6 +668,46 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
                 마지막 검수: {speakerReview.reviewed_at ?? '-'} · {speakerReview.reviewed_by ?? '-'}
               </div>
             ) : null}
+          </section>
+        ) : null}
+
+        {viewerRole === 'ADMIN' && !demoMode ? (
+          <section className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold text-slate-900">숏폼 Export 운영 현황</div>
+                <div className="mt-1 text-xs text-slate-500">실패 건만 일괄 재시도하고 최신 상태를 확인합니다.</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleRetryFailedShortforms()}
+                className="inline-flex items-center gap-2 rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-900"
+              >
+                <i className="ri-refresh-line" />
+                실패 건 재시도
+              </button>
+            </div>
+            <div className="mt-4 grid gap-3 md:grid-cols-5">
+              <div className="rounded-xl border border-slate-200 p-3 text-xs"><div className="text-slate-400">PENDING</div><div className="mt-1 text-base font-bold text-slate-900">{shortformExportStatus?.pending_count ?? '-'}</div></div>
+              <div className="rounded-xl border border-slate-200 p-3 text-xs"><div className="text-slate-400">PROCESSING</div><div className="mt-1 text-base font-bold text-slate-900">{shortformExportStatus?.processing_count ?? '-'}</div></div>
+              <div className="rounded-xl border border-slate-200 p-3 text-xs"><div className="text-slate-400">COMPLETED</div><div className="mt-1 text-base font-bold text-emerald-700">{shortformExportStatus?.completed_count ?? '-'}</div></div>
+              <div className="rounded-xl border border-slate-200 p-3 text-xs"><div className="text-slate-400">FAILED</div><div className="mt-1 text-base font-bold text-rose-700">{shortformExportStatus?.failed_count ?? '-'}</div></div>
+              <div className="rounded-xl border border-slate-200 p-3 text-xs"><div className="text-slate-400">FAILED_PERMANENT</div><div className="mt-1 text-base font-bold text-rose-900">{shortformExportStatus?.failed_permanent_count ?? '-'}</div></div>
+            </div>
+            <div className="mt-3 text-xs text-slate-500">마지막 갱신: {shortformExportStatus?.last_updated_at ?? '-'}</div>
+            <div className="mt-3 max-h-52 space-y-2 overflow-auto rounded-xl border border-slate-200 p-3">
+              {(shortformExportStatus?.failed_items ?? []).length === 0 ? (
+                <div className="text-xs text-slate-500">실패 항목이 없습니다.</div>
+              ) : (
+                (shortformExportStatus?.failed_items ?? []).map((item) => (
+                  <div key={item.id} className="rounded-lg bg-slate-50 p-2 text-xs">
+                    <div className="font-semibold text-slate-900">{item.title || item.id}</div>
+                    <div className="mt-1 text-slate-500">{item.export_status} · retry {item.retry_count} · {item.updated_at ?? '-'}</div>
+                    {item.error_message ? <div className="mt-1 text-rose-700">{item.error_message}</div> : null}
+                  </div>
+                ))
+              )}
+            </div>
           </section>
         ) : null}
       </>

--- a/frontend/src/lib/api-shortforms.ts
+++ b/frontend/src/lib/api-shortforms.ts
@@ -213,3 +213,47 @@ export async function loadShortformVideoDraft(
   const response = await request<ShortformVideoDetail>(`/api/v1/shortform/video/${encodeURIComponent(videoId)}`, undefined, token);
   return response?.success && response.data ? response.data : getShortformVideoDetail(videoId) ?? null;
 }
+
+export type ShortformExportStatusSummary = {
+  pending_count: number;
+  processing_count: number;
+  completed_count: number;
+  failed_count: number;
+  failed_permanent_count: number;
+  last_updated_at?: string | null;
+  failed_items: Array<{
+    id: string;
+    title: string;
+    user_id: string;
+    export_status: string;
+    retry_count: number;
+    error_message?: string;
+    updated_at?: string;
+  }>;
+};
+
+export async function loadShortformExportStatus(
+  sessionToken?: string | null,
+): Promise<ShortformExportStatusSummary | null> {
+  const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
+  if (!token) return null;
+  const response = await request<ShortformExportStatusSummary>('/api/v1/shortform/admin/export-status', undefined, token);
+  return response?.success && response.data ? response.data : null;
+}
+
+export async function retryFailedShortformExports(
+  input?: { include_permanent?: boolean; limit?: number },
+  sessionToken?: string | null,
+): Promise<ShortformExportStatusSummary | null> {
+  const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
+  if (!token) return null;
+  const response = await request<{ status: ShortformExportStatusSummary }>(
+    '/api/v1/shortform/admin/export/retry-failed',
+    {
+      method: 'POST',
+      body: JSON.stringify(input ?? {}),
+    },
+    token,
+  );
+  return response?.success && response.data ? response.data.status : null;
+}


### PR DESCRIPTION
# 변경 요약
숏폼 export 운영화를 위해 관리자 전용 상태 조회/실패 일괄 재시도 API와 관리자 대시보드 패널을 추가했습니다.

## 배경
- 숏폼 export 실패 건 운영 추적이 어려워 상태 집계/실패 목록/일괄 재시도 기능이 필요했습니다.
- 기존 재시도는 개별 동작 중심이어서 운영자가 실패 건을 빠르게 복구하기 어려웠습니다.

## 변경 내용
- Backend
  - `GET /api/v1/shortform/admin/export-status` (admin 전용)
  - `POST /api/v1/shortform/admin/export/retry-failed` (admin 전용)
  - `ShortformService`에 상태 집계/실패목록/일괄 재시도 로직 추가
  - `retryShortformExport` 내부 경로를 dispatch-aware 재시도 로직으로 정렬
- Frontend
  - Media Pipeline 페이지에 관리자 전용 `숏폼 Export 운영 현황` 패널 추가
  - 실패 건 일괄 재시도 버튼 추가
  - `loadShortformExportStatus`, `retryFailedShortformExports` API helper 추가
- Test
  - `ShortformAdminExportOpsIntegrationTest` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [ ] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:frontend`, `./mvnw -q -DskipTests compile`
- layer tests: `npm --workspace @myway/frontend run test`, `./mvnw -q "-Dtest=ShortformAdminExportOpsIntegrationTest,ShortformRetryStateIntegrationTest,MediaContractTest,StudentLearningFlowContractTest" test`
- risk/rollback: admin 운영 API/패널 추가 범위. 문제 시 본 PR revert로 즉시 복구 가능.

## ADR 링크
- ADR: 해당 없음 (운영 보강)
- 상태 변경: 해당 없음
