### PR TITLE
feat: sync lecture content metadata from STT and speaker review

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AdminMediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AdminMediaController.java
@@ -3,6 +3,7 @@ package com.myway.backendspring.api;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.DemoLearningService;
 import com.myway.backendspring.feature.media.MediaBatchService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,13 +16,16 @@ import java.util.Map;
 public class AdminMediaController {
 
     public record BatchTriggerRequest(String mode) {}
+    public record LectureMetadataSyncRequest(Boolean overwrite_existing) {}
 
     private final SessionService sessionService;
     private final MediaBatchService mediaBatchService;
+    private final DemoLearningService learningService;
 
-    public AdminMediaController(SessionService sessionService, MediaBatchService mediaBatchService) {
+    public AdminMediaController(SessionService sessionService, MediaBatchService mediaBatchService, DemoLearningService learningService) {
         this.sessionService = sessionService;
         this.mediaBatchService = mediaBatchService;
+        this.learningService = learningService;
     }
 
     private SessionView require(String auth) {
@@ -74,5 +78,18 @@ public class AdminMediaController {
         if (session == null) return unauthenticated();
         if (!isAdmin(session)) return forbidden();
         return ResponseEntity.ok(ApiResponse.success(mediaBatchService.bulkMapMissingLectureVideoAssets(), "누락 매핑 일괄 반영이 완료되었습니다."));
+    }
+
+    @PostMapping("/lecture-metadata/sync")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> syncLectureMetadataFromTranscripts(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LectureMetadataSyncRequest request
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return unauthenticated();
+        if (!isAdmin(session)) return forbidden();
+        boolean overwriteExisting = request != null && Boolean.TRUE.equals(request.overwrite_existing());
+        Map<String, Object> result = learningService.syncLectureMetadataFromTranscripts(overwriteExisting);
+        return ResponseEntity.ok(ApiResponse.success(result, "STT 기반 강의 메타 동기화가 완료되었습니다."));
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -15,8 +15,10 @@ public class DemoLearningService {
     private static final String COURSE_SCOPE = "learning_course";
     private static final String MATERIAL_SCOPE = "learning_material";
     private static final String NOTICE_SCOPE = "learning_notice";
+    private static final String LECTURE_META_SCOPE = "learning_lecture_meta";
     private static final String TRANSCRIPT_SCOPE = "media_transcript";
     private static final String EXTRACTION_SCOPE = "media_extraction";
+    private static final String SPEAKER_REVIEW_SCOPE = "media_speaker_review";
     private static final String DEFAULT_DEMO_STUDENT_ID = "usr_std_001";
     private final Map<String, CourseDetail> courses = new LinkedHashMap<>();
     private final Map<String, List<MaterialItem>> materialsByCourse = new ConcurrentHashMap<>();
@@ -338,12 +340,21 @@ public class DemoLearningService {
         if (lecture == null || lecture.id() == null || lecture.id().isBlank()) {
             return lecture;
         }
+        LectureItem lectureWithMeta = attachLectureMeta(lecture);
         int fallbackMinutes = Math.max(1, lecture.duration_minutes());
         int resolvedMinutes = resolveDurationMinutesFromMedia(lecture.id(), fallbackMinutes);
         if (resolvedMinutes == lecture.duration_minutes()) {
-            return lecture;
+            return lectureWithMeta;
         }
-        return new LectureItem(lecture.id(), lecture.course_id(), lecture.title(), resolvedMinutes);
+        return new LectureItem(
+                lecture.id(),
+                lecture.course_id(),
+                lecture.title(),
+                resolvedMinutes,
+                lectureWithMeta.content_text(),
+                lectureWithMeta.transcript_excerpt(),
+                lectureWithMeta.instructor_name()
+        );
     }
 
     private int resolveDurationMinutesFromMedia(String lectureId, int fallbackMinutes) {
@@ -379,6 +390,47 @@ public class DemoLearningService {
             return 0;
         }
         return (int) Math.max(1L, Math.round(durationMs / 60000.0d));
+    }
+
+    public Map<String, Object> syncLectureMetadataFromTranscripts(boolean overwriteExisting) {
+        if (!useStore()) {
+            return Map.of(
+                    "updated_count", 0,
+                    "skipped_count", 0,
+                    "items", List.of()
+            );
+        }
+
+        List<Map<String, Object>> items = new ArrayList<>();
+        int updated = 0;
+        int skipped = 0;
+        for (LectureItem lecture : listAllLectures()) {
+            String lectureId = lecture.id();
+            Map<String, Object> transcript = store.getKv(TRANSCRIPT_SCOPE, lectureId);
+            if (transcript == null) {
+                skipped += 1;
+                items.add(Map.of("lecture_id", lectureId, "status", "SKIPPED", "reason", "TRANSCRIPT_MISSING"));
+                continue;
+            }
+
+            Map<String, Object> current = store.getKv(LECTURE_META_SCOPE, lectureId);
+            Map<String, Object> suggested = buildLectureMetaFromTranscript(lecture, transcript);
+            if (suggested == null || suggested.isEmpty()) {
+                skipped += 1;
+                items.add(Map.of("lecture_id", lectureId, "status", "SKIPPED", "reason", "SUGGESTION_EMPTY"));
+                continue;
+            }
+
+            Map<String, Object> merged = mergeLectureMeta(current, suggested, overwriteExisting);
+            store.upsertKv(LECTURE_META_SCOPE, lectureId, merged);
+            updated += 1;
+            items.add(Map.of("lecture_id", lectureId, "status", "UPDATED"));
+        }
+        return Map.of(
+                "updated_count", updated,
+                "skipped_count", skipped,
+                "items", items
+        );
     }
 
     private void seedStoreDataIfMissing() {
@@ -434,6 +486,9 @@ public class DemoLearningService {
                     row.put("course_id", l.course_id());
                     row.put("title", l.title());
                     row.put("duration_minutes", l.duration_minutes());
+                    row.put("content_text", l.content_text());
+                    row.put("transcript_excerpt", l.transcript_excerpt());
+                    row.put("instructor_name", l.instructor_name());
                     return row;
                 })
                 .toList();
@@ -461,8 +516,11 @@ public class DemoLearningService {
                 String courseId = String.valueOf(map.containsKey("course_id") ? map.get("course_id") : id).trim();
                 String lectureTitle = String.valueOf(map.containsKey("title") ? map.get("title") : "").trim();
                 int duration = parseInt(map.get("duration_minutes"), 0);
+                String contentText = String.valueOf(map.containsKey("content_text") ? map.get("content_text") : "").trim();
+                String transcriptExcerpt = String.valueOf(map.containsKey("transcript_excerpt") ? map.get("transcript_excerpt") : "").trim();
+                String instructorName = String.valueOf(map.containsKey("instructor_name") ? map.get("instructor_name") : "").trim();
                 if (!lectureId.isBlank() && !lectureTitle.isBlank()) {
-                    lectures.add(new LectureItem(lectureId, courseId, lectureTitle, duration));
+                    lectures.add(new LectureItem(lectureId, courseId, lectureTitle, duration, contentText, transcriptExcerpt, instructorName));
                 }
             }
         }
@@ -530,5 +588,136 @@ public class DemoLearningService {
         if (activityEventService != null) {
             activityEventService.append(userId, type, resourceType, resourceId, metadata);
         }
+    }
+
+    private LectureItem attachLectureMeta(LectureItem lecture) {
+        if (!useStore()) {
+            return lecture;
+        }
+        String lectureId = lecture.id();
+        if (lectureId == null || lectureId.isBlank()) {
+            return lecture;
+        }
+        Map<String, Object> currentMeta = store.getKv(LECTURE_META_SCOPE, lectureId);
+        if (isLectureMetaMissing(currentMeta)) {
+            Map<String, Object> transcript = store.getKv(TRANSCRIPT_SCOPE, lectureId);
+            if (transcript != null) {
+                Map<String, Object> suggested = buildLectureMetaFromTranscript(lecture, transcript);
+                Map<String, Object> merged = mergeLectureMeta(currentMeta, suggested, false);
+                store.upsertKv(LECTURE_META_SCOPE, lectureId, merged);
+                currentMeta = merged;
+            }
+        }
+        String content = chooseText(
+                asText(currentMeta == null ? null : currentMeta.get("content_text")),
+                lecture.content_text(),
+                "강의 핵심 내용을 정리 중입니다."
+        );
+        String excerpt = chooseText(
+                asText(currentMeta == null ? null : currentMeta.get("transcript_excerpt")),
+                lecture.transcript_excerpt(),
+                ""
+        );
+        String instructorName = chooseText(
+                asText(currentMeta == null ? null : currentMeta.get("instructor_name")),
+                lecture.instructor_name(),
+                ""
+        );
+        return new LectureItem(
+                lecture.id(),
+                lecture.course_id(),
+                lecture.title(),
+                lecture.duration_minutes(),
+                content,
+                excerpt,
+                instructorName
+        );
+    }
+
+    private boolean isLectureMetaMissing(Map<String, Object> meta) {
+        if (meta == null) return true;
+        return asText(meta.get("content_text")).isBlank()
+                && asText(meta.get("transcript_excerpt")).isBlank()
+                && asText(meta.get("instructor_name")).isBlank();
+    }
+
+    private Map<String, Object> buildLectureMetaFromTranscript(LectureItem lecture, Map<String, Object> transcript) {
+        String lectureId = lecture == null ? "" : lecture.id();
+        String fullText = asText(transcript.get("full_text"));
+        if (fullText.isBlank()) {
+            Object segmentsRaw = transcript.get("segments");
+            if (segmentsRaw instanceof List<?> segments) {
+                StringBuilder builder = new StringBuilder();
+                for (Object segment : segments) {
+                    if (!(segment instanceof Map<?, ?> map)) continue;
+                    Object textRaw = map.containsKey("text") ? map.get("text") : "";
+                    String text = String.valueOf(textRaw).trim();
+                    if (!text.isBlank()) {
+                        if (!builder.isEmpty()) builder.append(' ');
+                        builder.append(text);
+                    }
+                }
+                fullText = builder.toString();
+            }
+        }
+
+        Map<String, Object> speakerReview = store.getKv(SPEAKER_REVIEW_SCOPE, lectureId);
+        String instructorName = asText(speakerReview == null ? null : speakerReview.get("instructor_name"));
+        if (instructorName.isBlank()) {
+            instructorName = asText(lecture == null ? null : lecture.instructor_name());
+        }
+        String excerpt = trimToLimit(fullText, 180);
+        String content = trimToLimit(fullText, 1200);
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("lecture_id", lectureId);
+        meta.put("content_text", content);
+        meta.put("transcript_excerpt", excerpt);
+        meta.put("instructor_name", instructorName);
+        meta.put("updated_at", Instant.now().toString());
+        return meta;
+    }
+
+    private Map<String, Object> mergeLectureMeta(Map<String, Object> current, Map<String, Object> suggested, boolean overwriteExisting) {
+        Map<String, Object> merged = new HashMap<>();
+        if (current != null) {
+            merged.putAll(current);
+        }
+        for (String field : List.of("lecture_id", "updated_at")) {
+            if (suggested.containsKey(field)) {
+                merged.put(field, suggested.get(field));
+            }
+        }
+        for (String field : List.of("content_text", "transcript_excerpt", "instructor_name")) {
+            String currentText = asText(merged.get(field));
+            String nextText = asText(suggested.get(field));
+            if (overwriteExisting || currentText.isBlank()) {
+                if (!nextText.isBlank()) {
+                    merged.put(field, nextText);
+                }
+            }
+        }
+        merged.put("updated_at", Instant.now().toString());
+        return merged;
+    }
+
+    private String trimToLimit(String value, int limit) {
+        String normalized = asText(value);
+        if (normalized.length() <= limit) {
+            return normalized;
+        }
+        return normalized.substring(0, limit).trim();
+    }
+
+    private String chooseText(String first, String second, String fallback) {
+        String a = asText(first);
+        if (!a.isBlank()) return a;
+        String b = asText(second);
+        if (!b.isBlank()) return b;
+        return fallback == null ? "" : fallback;
+    }
+
+    private String asText(Object value) {
+        if (value == null) return "";
+        return String.valueOf(value).trim();
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/LectureItem.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/LectureItem.java
@@ -1,3 +1,15 @@
 package com.myway.backendspring.domain;
 
-public record LectureItem(String id, String course_id, String title, int duration_minutes) {}
+public record LectureItem(
+        String id,
+        String course_id,
+        String title,
+        int duration_minutes,
+        String content_text,
+        String transcript_excerpt,
+        String instructor_name
+) {
+    public LectureItem(String id, String course_id, String title, int duration_minutes) {
+        this(id, course_id, title, duration_minutes, "", "", "");
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/learning/application/LearningApplicationService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/learning/application/LearningApplicationService.java
@@ -76,6 +76,14 @@ public class LearningApplicationService {
 
     private LectureItem toModel(com.myway.backendspring.domain.LectureItem item) {
         if (item == null) return null;
-        return new LectureItem(item.id(), item.course_id(), item.title(), item.duration_minutes());
+        return new LectureItem(
+                item.id(),
+                item.course_id(),
+                item.title(),
+                item.duration_minutes(),
+                item.content_text(),
+                item.transcript_excerpt(),
+                item.instructor_name()
+        );
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/learning/model/LectureItem.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/learning/model/LectureItem.java
@@ -1,3 +1,15 @@
 package com.myway.backendspring.domain.learning.model;
 
-public record LectureItem(String id, String course_id, String title, int duration_minutes) {}
+public record LectureItem(
+        String id,
+        String course_id,
+        String title,
+        int duration_minutes,
+        String content_text,
+        String transcript_excerpt,
+        String instructor_name
+) {
+    public LectureItem(String id, String course_id, String title, int duration_minutes) {
+        this(id, course_id, title, duration_minutes, "", "", "");
+    }
+}

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/AdminMediaBatchIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/AdminMediaBatchIntegrationTest.java
@@ -118,6 +118,32 @@ class AdminMediaBatchIntegrationTest {
         assertThat(missingAfter).isLessThanOrEqualTo(missingBefore);
     }
 
+    @Test
+    void lectureMetadataSync_shouldBeAdminOnly_andReturnSummary() throws Exception {
+        String instructorAuth = "Bearer " + loginAndGetToken("usr_ins_001");
+        String adminAuth = "Bearer " + loginAndGetToken("usr_admin_001");
+
+        mockMvc.perform(post("/api/v1/admin/media/lecture-metadata/sync")
+                        .header("Authorization", instructorAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"overwrite_existing\":false}"))
+                .andExpect(status().isForbidden());
+
+        String response = mockMvc.perform(post("/api/v1/admin/media/lecture-metadata/sync")
+                        .header("Authorization", adminAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"overwrite_existing\":false}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode data = objectMapper.readTree(response).path("data");
+        assertThat(data.path("updated_count").asInt()).isGreaterThanOrEqualTo(0);
+        assertThat(data.path("skipped_count").asInt()).isGreaterThanOrEqualTo(0);
+        assertThat(data.path("items").isArray()).isTrue();
+    }
+
     private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/docs/dev-logs/2026-05-23-lecture-metadata-sync-from-stt.md
+++ b/docs/dev-logs/2026-05-23-lecture-metadata-sync-from-stt.md
@@ -1,0 +1,24 @@
+# 2026-05-23 Lecture Metadata Sync From STT
+
+## Summary
+- Added DB-backed lecture metadata scope (`learning_lecture_meta`) synchronization from transcript and speaker-review data.
+- Added admin endpoint to run metadata migration/sync in batch.
+- Enriched lecture response model with `content_text`, `transcript_excerpt`, `instructor_name` so synced metadata is returned from backend.
+
+## What changed
+- Extended lecture item models (domain + API model) with metadata fields.
+- In `DemoLearningService`:
+  - auto-attach lecture metadata on course detail read
+  - lazy-generate metadata when missing from `media_transcript` + `media_speaker_review`
+  - explicit sync method: `syncLectureMetadataFromTranscripts(overwriteExisting)`
+- New admin API:
+  - `POST /api/v1/admin/media/lecture-metadata/sync`
+- Integration test updated for admin-only + sync summary response.
+
+## Verification
+- `./mvnw -q -DskipTests compile`
+- `./mvnw -q "-Dtest=AdminMediaBatchIntegrationTest,StudentLearningFlowContractTest,MediaContractTest" test`
+
+## Risk / Rollback
+- Risk: low-medium (lecture payload enrichment and metadata merge on read path).
+- Rollback: revert this commit.


### PR DESCRIPTION
# 변경 요약
DB 실동영상(STT) 기반으로 강의 메타(content/excerpt/instructor)를 자동 재작성/동기화하는 기능을 추가했습니다.

## 배경
- 기존에는 강의 내용 메타(`content_text`, `transcript_excerpt`, `instructor_name`)가 DB 실데이터(STT 결과)와 자동 동기화되지 않았습니다.
- 운영 중 STT/화자검수 결과가 쌓여도 강의 메타로 반영되지 않아 UI/챗봇 품질이 고정값에 의존했습니다.

## 변경 내용
- Lecture 모델 확장
  - backend domain/API lecture item에 `content_text`, `transcript_excerpt`, `instructor_name` 필드 추가
- STT 기반 메타 동기화 로직 추가 (`DemoLearningService`)
  - 신규 scope: `learning_lecture_meta`
  - transcript + speaker-review를 읽어 메타 생성/병합
  - 코스 상세 조회 시 메타 lazy attach
  - 명시적 마이그레이션 메서드: `syncLectureMetadataFromTranscripts(overwriteExisting)`
- 관리자 API 추가
  - `POST /api/v1/admin/media/lecture-metadata/sync`
  - body: `{ "overwrite_existing": true|false }`
- 통합 테스트 보강
  - `AdminMediaBatchIntegrationTest`에 관리자 전용 접근/요약 응답 검증 추가
- 개발 로그 추가
  - `docs/dev-logs/2026-05-23-lecture-metadata-sync-from-stt.md`

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `./mvnw -q -DskipTests compile`
- layer tests: `./mvnw -q "-Dtest=AdminMediaBatchIntegrationTest,StudentLearningFlowContractTest,MediaContractTest" test`
- risk/rollback: lecture payload 확장 + metadata merge path 영향. 문제 시 본 PR revert로 즉시 복구 가능.

## ADR 링크
- ADR: 해당 없음 (운영 동기화 보강)
- 상태 변경: 해당 없음
