### PR TITLE
fix: harden RAG timestamp contract for fallback chunks

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/rag/RagService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/rag/RagService.java
@@ -49,7 +49,7 @@ public class RagService {
         double threshold = minScore == null ? 0.0 : Math.max(0.0, Math.min(1.0, minScore));
 
         List<Map<String, Object>> retrieved = retriever.retrieve(normalizedQuery, targetLectureIds, threshold);
-        List<Map<String, Object>> rankedChunks = reranker.rerank(retrieved, resolvedLimit);
+        List<Map<String, Object>> rankedChunks = ensureChunkTimestamps(reranker.rerank(retrieved, resolvedLimit));
 
         List<Map<String, Object>> entities = new ArrayList<>();
         if (lectureId != null && !lectureId.isBlank()) {
@@ -272,5 +272,31 @@ public class RagService {
         } catch (Exception ignored) {
             return 0.0;
         }
+    }
+
+    private List<Map<String, Object>> ensureChunkTimestamps(List<Map<String, Object>> chunks) {
+        if (chunks == null || chunks.isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, Object>> normalized = new ArrayList<>(chunks.size());
+        for (Map<String, Object> chunk : chunks) {
+            Map<String, Object> row = new HashMap<>(chunk);
+            long start = row.get("start_ms") instanceof Number number ? number.longValue() : 0L;
+            long end;
+            if (row.get("end_ms") instanceof Number number) {
+                end = number.longValue();
+            } else {
+                String lectureId = normalizeText(String.valueOf(row.getOrDefault("lecture_id", "")));
+                LectureItem lecture = lectureId.isBlank() ? null : learningService.getLecture(lectureId);
+                end = lecture == null ? 60_000L : Math.max(60_000L, lecture.duration_minutes() * 60_000L);
+            }
+            if (end < start) {
+                end = start + 1_000L;
+            }
+            row.put("start_ms", start);
+            row.put("end_ms", end);
+            normalized.add(row);
+        }
+        return normalized;
     }
 }

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
@@ -243,6 +243,34 @@ class AiContractTest {
         assertThat(answerData.path("source_ids").isArray()).isTrue();
     }
 
+    @Test
+    void aiRag_shouldKeepTimestampedChunks_whenTranscriptIsNotPrepared() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+        setDailyLimit(authHeader, 999999);
+
+        JsonNode ragData = readData(mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"핵심 개념\",\"lecture_id\":\"lec_react_02\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertThat(ragData.path("chunks").isArray()).isTrue();
+        assertThat(ragData.path("chunks").size()).isGreaterThan(0);
+        JsonNode firstChunk = ragData.path("chunks").get(0);
+        assertThat(firstChunk.path("start_ms").isNumber()).isTrue();
+        assertThat(firstChunk.path("end_ms").isNumber()).isTrue();
+        String chunkText = firstChunk.path("text").asText();
+        if (chunkText.isBlank()) {
+            chunkText = firstChunk.path("excerpt").asText();
+        }
+        if (chunkText.isBlank()) {
+            chunkText = firstChunk.path("content").asText();
+        }
+        assertThat(chunkText).isNotBlank();
+        assertThat(ragData.path("answer").asText()).isNotBlank();
+    }
+
     private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/docs/dev-logs/2026-05-24-rag-timestamp-contract-hardening.md
+++ b/docs/dev-logs/2026-05-24-rag-timestamp-contract-hardening.md
@@ -1,0 +1,22 @@
+# 2026-05-24 RAG Timestamp Contract Hardening
+
+## Summary
+- Ensured RAG chunks always include `start_ms`/`end_ms` even when transcript is not prepared.
+- Added contract test that validates timestamped chunk response and non-empty answer for transcript-missing lecture fallback.
+
+## What changed
+- `backend-spring/src/main/java/com/myway/backendspring/feature/rag/RagService.java`
+  - Added chunk timestamp normalization (`ensureChunkTimestamps`)
+  - Fallback behavior:
+    - `start_ms`: defaults to `0`
+    - `end_ms`: uses lecture duration when available, otherwise minimum window
+- `backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java`
+  - Added `aiRag_shouldKeepTimestampedChunks_whenTranscriptIsNotPrepared`
+  - Validates chunk timestamps + fallback text/content/excerpt presence + non-empty answer
+
+## Verification
+- `cd backend-spring && ./mvnw -q "-Dtest=AiContractTest" test`
+
+## Risk / Rollback
+- Risk: low-medium (RAG payload enrichment).
+- Rollback: revert this PR.


### PR DESCRIPTION
# 변경 요약
전사 미준비 강의 fallback에서도 RAG chunk 타임스탬프(`start_ms/end_ms`)를 항상 제공하도록 보강하고 계약 테스트를 추가했습니다.

## 배경
- 일부 fallback chunk는 타임스탬프 필드가 비어 있어 챗봇 시킹/타임스탬프 UX가 불안정했습니다.

## 변경 내용
- `backend-spring/src/main/java/com/myway/backendspring/feature/rag/RagService.java`
  - `ensureChunkTimestamps` 추가
  - 전사 없는 경우에도 `start_ms/end_ms` 기본값 보장
- `backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java`
  - `aiRag_shouldKeepTimestampedChunks_whenTranscriptIsNotPrepared` 추가
- `docs/dev-logs/2026-05-24-rag-timestamp-contract-hardening.md` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `cd backend-spring && ./mvnw -q -Dtest=AiContractTest test`
- layer tests: same as above
- risk/rollback: RAG payload 필드 보강 변경이며 revert로 롤백 가능

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 없음