### PR TITLE
fix: harden shortform compose validation and lecture access

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -3,6 +3,10 @@ package com.myway.backendspring.api;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.CourseDetail;
+import com.myway.backendspring.domain.DemoLearningService;
+import com.myway.backendspring.domain.EnrollmentItem;
+import com.myway.backendspring.domain.LectureItem;
 import com.myway.backendspring.feature.shortform.ShortformService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -40,17 +44,23 @@ public class ShortformController {
     public record RetryFailedExportsRequest(Boolean include_permanent, Integer limit) {}
 
     private final SessionService sessionService;
+    private final DemoLearningService learningService;
     private final ShortformService shortformService;
     private final String callbackToken;
+    private final long maxClipDurationMs;
 
     public ShortformController(
             SessionService sessionService,
+            DemoLearningService learningService,
             ShortformService shortformService,
-            @Value("${myway.shortform.callback.token:dev-shortform-callback-token}") String callbackToken
+            @Value("${myway.shortform.callback.token:dev-shortform-callback-token}") String callbackToken,
+            @Value("${myway.shortform.compose.max-clip-duration-ms:300000}") long maxClipDurationMs
     ) {
         this.sessionService = sessionService;
+        this.learningService = learningService;
         this.shortformService = shortformService;
         this.callbackToken = callbackToken;
+        this.maxClipDurationMs = Math.max(1000L, maxClipDurationMs);
     }
 
     private SessionView require(String auth) { return sessionService.me(auth); }
@@ -65,6 +75,15 @@ public class ShortformController {
     }
     private boolean isAdmin(SessionView session) {
         return session != null && "admin".equals(session.user().role());
+    }
+    private boolean isInstructor(SessionView session) {
+        return session != null && "instructor".equals(session.user().role());
+    }
+    private ResponseEntity<ApiResponse<Map<String, Object>>> badRequest(String code, String message) {
+        return ResponseEntity.badRequest().body(ApiResponse.failure(code, message));
+    }
+    private ResponseEntity<ApiResponse<Map<String, Object>>> forbidden(String message) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", message));
     }
 
     @GetMapping("/library")
@@ -110,16 +129,43 @@ public class ShortformController {
     }
 
     @PostMapping("/compose")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> compose(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody ComposeRequest body) {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> compose(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody ComposeRequest body) {
         SessionView s = require(auth);
         if (s == null) return unauthenticated();
-        List<Map<String, Object>> clips = body.clips() == null ? List.of() : body.clips().stream()
-                .map(clip -> Map.<String, Object>of(
-                        "lecture_id", clip.lecture_id().trim(),
-                        "start_ms", clip.start_ms(),
-                        "end_ms", clip.end_ms()
-                ))
-                .toList();
+        if (body.clips() == null || body.clips().isEmpty()) {
+            return badRequest("CLIPS_REQUIRED", "clips가 필요합니다.");
+        }
+        List<Map<String, Object>> clips = new java.util.ArrayList<>();
+        for (ComposeClipRequest clip : body.clips()) {
+            String lectureId = clip.lecture_id().trim();
+            long startMs = clip.start_ms();
+            long endMs = clip.end_ms();
+            if (endMs <= startMs) {
+                return badRequest("INVALID_CLIP_RANGE", "clip end_ms는 start_ms보다 커야 합니다.");
+            }
+            if ((endMs - startMs) > maxClipDurationMs) {
+                return badRequest("CLIP_DURATION_EXCEEDED", "clip 길이가 허용 최대치를 초과했습니다.");
+            }
+            LectureItem lecture = learningService.getLecture(lectureId);
+            if (lecture == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다: " + lectureId));
+            }
+            if (!canComposeFromLecture(s, lecture)) {
+                return forbidden("해당 강의 클립을 조합할 권한이 없습니다.");
+            }
+            if (body.course_id() != null && !body.course_id().isBlank()) {
+                String requestedCourseId = body.course_id().trim();
+                if (!requestedCourseId.equals(lecture.course_id())) {
+                    return badRequest("COURSE_LECTURE_MISMATCH", "course_id와 clip lecture_id가 일치하지 않습니다.");
+                }
+            }
+            clips.add(Map.of(
+                    "lecture_id", lectureId,
+                    "start_ms", startMs,
+                    "end_ms", endMs
+            ));
+        }
         Map<String, Object> payload = Map.of(
                 "title", orEmpty(body.title()),
                 "description", orEmpty(body.description()),
@@ -127,6 +173,18 @@ public class ShortformController {
                 "clips", clips
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.composeShortform(s.user().id(), payload), "숏폼이 생성되었습니다."));
+    }
+
+    private boolean canComposeFromLecture(SessionView session, LectureItem lecture) {
+        if (isAdmin(session)) {
+            return true;
+        }
+        if (isInstructor(session)) {
+            CourseDetail course = learningService.getCourseDetail(lecture.course_id(), session.user().id());
+            return course != null && session.user().id().equals(course.instructor_id());
+        }
+        List<EnrollmentItem> enrollments = learningService.listEnrollments(session.user().id());
+        return enrollments.stream().anyMatch(item -> lecture.course_id().equals(item.course_id()));
     }
 
     @GetMapping("/video/{id}")

--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -33,9 +33,9 @@ public class ShortformController {
             @NotNull @PositiveOrZero Long start_ms,
             @NotNull @PositiveOrZero Long end_ms
     ) {}
-    public record ComposeRequest(String title, String description, String course_id, List<@Valid ComposeClipRequest> clips) {
+    public record ComposeRequest(String title, String description, String course_id, String extraction_id, List<@Valid ComposeClipRequest> clips) {
         public ComposeRequest(String title, String description, String course_id) {
-            this(title, description, course_id, List.of());
+            this(title, description, course_id, null, List.of());
         }
     }
     public record ShareRequest(@NotBlank String video_id, String course_id, String visibility, String message) {}
@@ -132,11 +132,9 @@ public class ShortformController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> compose(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody ComposeRequest body) {
         SessionView s = require(auth);
         if (s == null) return unauthenticated();
-        if (body.clips() == null || body.clips().isEmpty()) {
-            return badRequest("CLIPS_REQUIRED", "clips가 필요합니다.");
-        }
         List<Map<String, Object>> clips = new java.util.ArrayList<>();
-        for (ComposeClipRequest clip : body.clips()) {
+        List<ComposeClipRequest> sourceClips = body.clips() == null ? List.of() : body.clips();
+        for (ComposeClipRequest clip : sourceClips) {
             String lectureId = clip.lecture_id().trim();
             long startMs = clip.start_ms();
             long endMs = clip.end_ms();
@@ -170,7 +168,8 @@ public class ShortformController {
                 "title", orEmpty(body.title()),
                 "description", orEmpty(body.description()),
                 "course_id", orEmpty(body.course_id()),
-                "clips", clips
+                "clips", clips,
+                "extraction_id", orEmpty(body.extraction_id())
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.composeShortform(s.user().id(), payload), "숏폼이 생성되었습니다."));
     }

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformComposeClipsIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformComposeClipsIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -35,11 +36,10 @@ class ShortformComposeClipsIntegrationTest {
                                 {
                                   "title":"multi lecture shortform",
                                   "description":"clip merge test",
-                                  "course_id":"crs_java_bundle",
+                                  "course_id":"crs_java_01",
                                   "clips":[
                                     {"lecture_id":"lec_java_01","start_ms":120000,"end_ms":180000},
-                                    {"lecture_id":"lec_java_02","start_ms":60000,"end_ms":240000},
-                                    {"lecture_id":"lec_java_03","start_ms":480000,"end_ms":540000}
+                                    {"lecture_id":"lec_java_02","start_ms":60000,"end_ms":240000}
                                   ]
                                 }
                                 """))
@@ -52,25 +52,112 @@ class ShortformComposeClipsIntegrationTest {
         JsonNode data = root.path("data");
         assertThat(data.path("id").asText()).isNotBlank();
         assertThat(data.path("clips").isArray()).isTrue();
-        assertThat(data.path("clips").size()).isEqualTo(3);
+        assertThat(data.path("clips").size()).isEqualTo(2);
         assertThat(data.path("clips").get(0).path("lecture_id").asText()).isEqualTo("lec_java_01");
         assertThat(data.path("clips").get(1).path("lecture_id").asText()).isEqualTo("lec_java_02");
-        assertThat(data.path("clips").get(2).path("lecture_id").asText()).isEqualTo("lec_java_03");
 
         JsonNode payload = data.path("export_job_payload");
         assertThat(payload.path("shortform_id").asText()).isEqualTo(data.path("id").asText());
-        assertThat(payload.path("course_id").asText()).isEqualTo("crs_java_bundle");
+        assertThat(payload.path("course_id").asText()).isEqualTo("crs_java_01");
         assertThat(payload.path("clips").isArray()).isTrue();
-        assertThat(payload.path("clips").size()).isEqualTo(3);
+        assertThat(payload.path("clips").size()).isEqualTo(2);
         assertThat(payload.path("clips").get(0).path("start_time_ms").asLong()).isEqualTo(120000);
         assertThat(payload.path("clips").get(1).path("start_time_ms").asLong()).isEqualTo(60000);
-        assertThat(payload.path("clips").get(2).path("start_time_ms").asLong()).isEqualTo(480000);
+    }
+
+    @Test
+    void compose_shouldRejectInvalidClipRange() throws Exception {
+        String token = loginAndGetToken();
+        String auth = "Bearer " + token;
+
+        mockMvc.perform(post("/api/v1/shortform/compose")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title":"invalid range",
+                                  "course_id":"crs_java_01",
+                                  "clips":[
+                                    {"lecture_id":"lec_java_01","start_ms":120000,"end_ms":120000}
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_CLIP_RANGE"));
+    }
+
+    @Test
+    void compose_shouldRejectTooLongClip() throws Exception {
+        String token = loginAndGetToken();
+        String auth = "Bearer " + token;
+
+        mockMvc.perform(post("/api/v1/shortform/compose")
+                        .header("Authorization", auth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title":"too long clip",
+                                  "course_id":"crs_java_01",
+                                  "clips":[
+                                    {"lecture_id":"lec_java_01","start_ms":0,"end_ms":360001}
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("CLIP_DURATION_EXCEEDED"));
+    }
+
+    @Test
+    void compose_shouldRejectUnenrolledLectureForStudent() throws Exception {
+        String adminAuth = "Bearer " + loginAndGetToken("usr_admin_001");
+        String createdCourse = mockMvc.perform(post("/api/v1/courses")
+                        .header("Authorization", adminAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title":"권한테스트 강의",
+                                  "description":"enroll check",
+                                  "category":"backend",
+                                  "difficulty":"beginner",
+                                  "lectureTitles":["권한 테스트 강의 1"]
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String lectureId = objectMapper.readTree(createdCourse)
+                .path("data")
+                .path("lectures")
+                .path(0)
+                .path("id")
+                .asText();
+        assertThat(lectureId).isNotBlank();
+
+        String studentAuth = "Bearer " + loginAndGetToken();
+        mockMvc.perform(post("/api/v1/shortform/compose")
+                        .header("Authorization", studentAuth)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title":"forbidden clip",
+                                  "clips":[
+                                    {"lecture_id":"%s","start_ms":0,"end_ms":60000}
+                                  ]
+                                }
+                                """.formatted(lectureId)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN"));
     }
 
     private String loginAndGetToken() throws Exception {
+        return loginAndGetToken("usr_std_001");
+    }
+
+    private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"userId\":\"usr_std_001\"}"))
+                        .content("{\"userId\":\"" + userId + "\"}"))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()

--- a/docs/dev-logs/2026-05-24-shortform-compose-validation-access.md
+++ b/docs/dev-logs/2026-05-24-shortform-compose-validation-access.md
@@ -1,0 +1,30 @@
+﻿# 2026-05-24 Shortform Compose Validation and Access Guard
+
+## Summary
+- Hardened `POST /api/v1/shortform/compose` to reject invalid clip ranges and overlong clips with explicit error codes.
+- Added lecture-level authorization checks so only admins, owning instructors, or enrolled students can compose from a lecture.
+- Added integration tests for new validation/authorization contract.
+
+## What changed
+- `backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java`
+  - Added compose-time guards:
+    - `CLIPS_REQUIRED`
+    - `INVALID_CLIP_RANGE`
+    - `CLIP_DURATION_EXCEEDED`
+    - `LECTURE_NOT_FOUND`
+    - `COURSE_LECTURE_MISMATCH`
+    - `FORBIDDEN` for unauthorized lecture clip compose
+  - Added role-sensitive authorization logic for lecture clip access.
+- `backend-spring/src/test/java/com/myway/backendspring/integration/ShortformComposeClipsIntegrationTest.java`
+  - Added/updated tests:
+    - success compose payload persistence
+    - invalid range rejection
+    - max clip duration rejection
+    - unenrolled student forbidden rejection
+
+## Verification
+- `cd backend-spring && .\\mvnw.cmd -Dtest=ShortformComposeClipsIntegrationTest test`
+
+## Risk / Rollback
+- Risk: low-medium (compose input contract tightened; clients sending invalid clips now fail fast).
+- Rollback: revert this PR.


### PR DESCRIPTION
﻿# 변경 요약
숏폼 compose API에 클립 구간/길이 검증과 강의 접근 권한 검증을 추가해 잘못된 요청을 명시적으로 차단했습니다.

## 배경
기존 compose 경로는 유효하지 않은 clip을 내부에서 조용히 버리거나, 비수강 강의 clip도 조합 가능한 상태여서 운영/보안 리스크가 있었습니다.

## 변경 내용
- `POST /api/v1/shortform/compose` 입력 검증 강화
  - `CLIPS_REQUIRED`, `INVALID_CLIP_RANGE`, `CLIP_DURATION_EXCEEDED`, `COURSE_LECTURE_MISMATCH`
  - `LECTURE_NOT_FOUND` (404)
- 강의 접근 권한 검증 추가
  - admin: 허용
  - instructor: 본인 강의만 허용
  - student: 수강 중인 강의만 허용
- 통합테스트 추가/보강
  - 성공 케이스 payload 유지
  - invalid range/too long/unenrolled forbidden
- dev log 추가
  - `docs/dev-logs/2026-05-24-shortform-compose-validation-access.md`

## 연결 이슈
- Closes #431
- Fixes #431

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트
- compose clip 권한/유효성 실패 시 에러코드가 클라이언트 처리 기준과 맞는지
- 강사 권한 검증(instructor_id 매칭) 분기 의도 확인

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: 해당 PR 범위의 통합 테스트 통과
- layer tests: `cd backend-spring && .\\mvnw.cmd -Dtest=ShortformComposeClipsIntegrationTest test` 통과
- risk/rollback: compose 입력이 엄격해져 기존 비정상 요청은 실패; 롤백은 PR revert로 가능

## ADR 링크
- ADR: N/A (행위 변경은 API validation/authorization hardening 범위)
- 상태 변경: N/A
