### PR TITLE
feat: add shortform export monitoring metrics

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
@@ -34,6 +34,7 @@ public class ShortformService {
     private final String mediaProcessorToken;
     private final String mediaPublicBaseUrl;
     private final String shortformCallbackToken;
+    private final long staleProcessingThresholdMs;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public ShortformService(
@@ -43,7 +44,8 @@ public class ShortformService {
             @Value("${myway.media.processor.url:}") String mediaProcessorUrl,
             @Value("${myway.media.processor.token:}") String mediaProcessorToken,
             @Value("${myway.media.public-base-url:http://127.0.0.1:8787}") String mediaPublicBaseUrl,
-            @Value("${myway.shortform.callback.token:dev-shortform-callback-token}") String shortformCallbackToken
+            @Value("${myway.shortform.callback.token:dev-shortform-callback-token}") String shortformCallbackToken,
+            @Value("${myway.shortform.monitoring.stale-processing-ms:1800000}") long staleProcessingThresholdMs
     ) {
         this.repository = repository;
         this.activityEventService = activityEventService;
@@ -52,6 +54,7 @@ public class ShortformService {
         this.mediaProcessorToken = mediaProcessorToken == null ? "" : mediaProcessorToken.trim();
         this.mediaPublicBaseUrl = mediaPublicBaseUrl == null ? "http://127.0.0.1:8787" : mediaPublicBaseUrl.trim();
         this.shortformCallbackToken = shortformCallbackToken == null ? "dev-shortform-callback-token" : shortformCallbackToken.trim();
+        this.staleProcessingThresholdMs = Math.max(60000L, staleProcessingThresholdMs);
     }
 
     public List<Map<String, Object>> shortformLibrary(String userId) {
@@ -231,8 +234,10 @@ public class ShortformService {
         long completed = 0L;
         long failed = 0L;
         long failedPermanent = 0L;
+        long staleProcessing = 0L;
         String lastUpdatedAt = null;
         List<Map<String, Object>> failedItems = new ArrayList<>();
+        Instant now = Instant.now();
 
         for (Map<String, Object> video : videos) {
             String status = String.valueOf(video.getOrDefault("export_status", "PENDING")).toUpperCase();
@@ -241,7 +246,12 @@ public class ShortformService {
                 lastUpdatedAt = updatedAt;
             }
             switch (status) {
-                case "PROCESSING" -> processing += 1L;
+                case "PROCESSING" -> {
+                    processing += 1L;
+                    if (isStaleProcessing(updatedAt, now)) {
+                        staleProcessing += 1L;
+                    }
+                }
                 case "COMPLETED" -> completed += 1L;
                 case "FAILED" -> {
                     failed += 1L;
@@ -267,9 +277,31 @@ public class ShortformService {
         result.put("completed_count", completed);
         result.put("failed_count", failed);
         result.put("failed_permanent_count", failedPermanent);
+        result.put("stale_processing_count", staleProcessing);
+        result.put("failure_ratio", toRatio(failed + failedPermanent, videos.size()));
         result.put("last_updated_at", lastUpdatedAt);
         result.put("failed_items", failedItems);
         return result;
+    }
+
+    private boolean isStaleProcessing(String updatedAt, Instant now) {
+        if (updatedAt == null || updatedAt.isBlank()) {
+            return false;
+        }
+        try {
+            Instant updated = Instant.parse(updatedAt);
+            return now.toEpochMilli() - updated.toEpochMilli() > staleProcessingThresholdMs;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private double toRatio(long numerator, int denominator) {
+        if (denominator <= 0) {
+            return 0.0d;
+        }
+        double ratio = ((double) numerator) / ((double) denominator);
+        return Math.round(ratio * 10000.0d) / 10000.0d;
     }
 
     public Map<String, Object> retryFailedShortformExports(boolean includePermanent, int limit) {

--- a/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformAdminExportOpsIntegrationTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/integration/ShortformAdminExportOpsIntegrationTest.java
@@ -54,6 +54,9 @@ class ShortformAdminExportOpsIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
         JsonNode statusRoot = objectMapper.readTree(adminStatus);
         assertThat(statusRoot.path("data").path("failed_count").asInt()).isGreaterThanOrEqualTo(1);
+        assertThat(statusRoot.path("data").has("stale_processing_count")).isTrue();
+        assertThat(statusRoot.path("data").has("failure_ratio")).isTrue();
+        assertThat(statusRoot.path("data").path("failure_ratio").asDouble()).isGreaterThanOrEqualTo(0.0d);
 
         String retry = mockMvc.perform(post("/api/v1/shortform/admin/export/retry-failed")
                         .header("Authorization", adminAuth)

--- a/docs/dev-logs/2026-05-24-shortform-export-monitoring-metrics.md
+++ b/docs/dev-logs/2026-05-24-shortform-export-monitoring-metrics.md
@@ -1,0 +1,20 @@
+﻿# 2026-05-24 Shortform Export Monitoring Metrics
+
+## Summary
+- Extended shortform admin export status with operational monitoring fields.
+- Added stale processing detection and aggregate failure ratio for faster triage.
+
+## What changed
+- `backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java`
+  - Added `stale_processing_count` in export status response.
+  - Added `failure_ratio` (failed+failed_permanent / total).
+  - Added configurable stale threshold: `myway.shortform.monitoring.stale-processing-ms` (default 30m).
+- `backend-spring/src/test/java/com/myway/backendspring/integration/ShortformAdminExportOpsIntegrationTest.java`
+  - Added assertions for `stale_processing_count` and `failure_ratio` presence/range.
+
+## Verification
+- `cd backend-spring && .\\mvnw.cmd "-Dtest=ShortformAdminExportOpsIntegrationTest,ShortformComposeClipsIntegrationTest" test`
+
+## Risk / Rollback
+- Risk: low (read-model metrics augmentation only).
+- Rollback: revert this PR.


### PR DESCRIPTION
﻿# 변경 요약
숏폼 export 관리자 상태 API에 운영 지표(`stale_processing_count`, `failure_ratio`)를 추가해 장애 징후 탐지와 실패 추세 확인을 강화했습니다.

## 배경
기존 상태 API는 단순 카운트 중심이라 실패율/장기 처리지연을 즉시 파악하기 어려웠습니다.

## 변경 내용
- `ShortformService.shortformExportStatus()` 확장
  - `stale_processing_count`
  - `failure_ratio`
- stale 기준 configurable
  - `myway.shortform.monitoring.stale-processing-ms` (default 1800000ms)
- 통합 테스트 보강
  - `ShortformAdminExportOpsIntegrationTest`에 신규 필드 검증 추가
- dev log 추가
  - `docs/dev-logs/2026-05-24-shortform-export-monitoring-metrics.md`

## 연결 이슈
- Closes #432
- Fixes #432

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트
- stale 기준값(기본 30분) 적정성
- failure_ratio 반올림(소수점 4자리) 형식 합의 여부

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: PR 범위 테스트 통과
- layer tests: `cd backend-spring && .\\mvnw.cmd "-Dtest=ShortformAdminExportOpsIntegrationTest,ShortformComposeClipsIntegrationTest" test` 통과
- risk/rollback: 읽기 지표 추가만 수행, 문제 시 PR revert

## ADR 링크
- ADR: N/A
- 상태 변경: N/A
