### PR TITLE
fix: align shortform compose UX with backend error codes

### DIFF
--- a/docs/dev-logs/2026-05-24-shortform-compose-ux-error-mapping.md
+++ b/docs/dev-logs/2026-05-24-shortform-compose-ux-error-mapping.md
@@ -1,0 +1,30 @@
+﻿# 2026-05-24 Shortform Compose UX Error Mapping and Frontend Optimization
+
+## Summary
+- Aligned shortform compose frontend behavior with backend validation/authorization error codes.
+- Removed authenticated compose fallback that masked backend failures.
+- Optimized clip time update bounds to match backend contract limits.
+
+## What changed
+- `frontend/src/lib/api-shortforms.ts`
+  - `composeShortformDraft` now returns structured result:
+    - `{ video, errorCode, errorMessage }`
+  - For authenticated requests, backend failure is surfaced as-is (no local fallback compose).
+- `frontend/src/features/lms/components/ShortformWizard.tsx`
+  - Added compose error-code mapping:
+    - `INVALID_CLIP_RANGE`
+    - `CLIP_DURATION_EXCEEDED`
+    - `COURSE_LECTURE_MISMATCH`
+    - `LECTURE_NOT_FOUND`
+    - `FORBIDDEN`
+  - Updated `handleCompose` to show precise status messages.
+  - Optimized clip time adjustment logic with shared bounds constants:
+    - min: 1s
+    - max: 5m
+
+## Verification
+- `npm run test:frontend`
+
+## Risk / Rollback
+- Risk: low-medium (authenticated compose no longer silently falls back).
+- Rollback: revert this PR.

--- a/frontend/src/features/lms/components/ShortformWizard.tsx
+++ b/frontend/src/features/lms/components/ShortformWizard.tsx
@@ -21,12 +21,31 @@ type ShortformWizardProps = {
   courses: CourseCard[];
   sessionToken: string | null;
 };
+const MIN_CLIP_MS = 1_000;
+const MAX_CLIP_MS = 300_000;
 
 function formatDuration(ms: number): string {
   const totalSeconds = Math.max(1, Math.round(ms / 1000));
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+function mapComposeError(code?: string, message?: string): string {
+  switch (code) {
+    case 'INVALID_CLIP_RANGE':
+      return '클립 종료 시간이 시작 시간보다 커야 합니다.';
+    case 'CLIP_DURATION_EXCEEDED':
+      return '클립 길이는 최대 5분까지 가능합니다.';
+    case 'COURSE_LECTURE_MISMATCH':
+      return '선택한 강의와 클립의 코스가 일치하지 않습니다.';
+    case 'LECTURE_NOT_FOUND':
+      return '선택한 강의를 찾을 수 없습니다. 새로고침 후 다시 시도해 주세요.';
+    case 'FORBIDDEN':
+      return '해당 강의 클립을 조합할 권한이 없습니다.';
+    default:
+      return message ?? '숏폼 생성에 실패했습니다.';
+  }
 }
 
 function clipKey(clip: ClipSuggestion): string {
@@ -276,7 +295,7 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
     }
 
     setStatus('선택한 구간으로 숏폼을 생성하는 중입니다.');
-    const video = await composeShortformDraft(
+    const result = await composeShortformDraft(
       {
         course_id: courseDetail.id,
         title: title.trim() || `${courseDetail.title} 숏폼`,
@@ -290,10 +309,11 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
       sessionToken,
     );
 
-    if (!video) {
-      setStatus('숏폼을 생성하지 못했습니다.');
+    if (!result.video) {
+      setStatus(mapComposeError(result.errorCode, result.errorMessage));
       return;
     }
+    const video = result.video;
 
     setCreatedVideo(video);
     setStatus(video.export_status === 'COMPLETED' || video.export_result_url ? '숏폼이 생성되어 재생 가능합니다.' : '숏폼이 생성되었고 export를 처리 중입니다.');
@@ -330,8 +350,10 @@ export function ShortformWizard({ highlightedLecture, selectedCourse, courses, s
           return clip;
         }
 
-        const safeStart = Math.max(0, Math.min(startTimeMs, endTimeMs - 1_000));
-        const safeEnd = Math.max(safeStart + 1_000, endTimeMs);
+        const requestedDuration = Math.max(MIN_CLIP_MS, endTimeMs - startTimeMs);
+        const boundedDuration = Math.min(MAX_CLIP_MS, requestedDuration);
+        const safeStart = Math.max(0, Math.min(startTimeMs, endTimeMs - MIN_CLIP_MS));
+        const safeEnd = safeStart + boundedDuration;
 
         return {
           ...clip,

--- a/frontend/src/lib/api-shortforms.ts
+++ b/frontend/src/lib/api-shortforms.ts
@@ -180,12 +180,12 @@ export async function loadShortformExtractionDraft(
 export async function composeShortformDraft(
   input: ShortformComposeRequest,
   sessionToken?: string | null,
-): Promise<ShortformVideo | null> {
+): Promise<{ video: ShortformVideo | null; errorCode?: string; errorMessage?: string }> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
   const userId = getFallbackUserId();
 
   if (!token) {
-    return composeShortformVideo(userId, input);
+    return { video: composeShortformVideo(userId, input) };
   }
 
   const response = await request<ShortformVideo>(
@@ -197,7 +197,15 @@ export async function composeShortformDraft(
     token,
   );
 
-  return response?.success && response.data ? response.data : composeShortformVideo(userId, input);
+  if (response?.success && response.data) {
+    return { video: response.data };
+  }
+
+  return {
+    video: null,
+    errorCode: response?.error?.code ?? 'SHORTFORM_COMPOSE_FAILED',
+    errorMessage: response?.error?.message ?? response?.message ?? '숏폼 생성에 실패했습니다.',
+  };
 }
 
 export async function loadShortformVideoDraft(


### PR DESCRIPTION
﻿# 변경 요약
숏폼 compose 프론트가 백엔드 에러코드를 정확히 반영하도록 정렬했고, 인증 상태에서 실패를 숨기던 fallback 동작을 제거했습니다.

## 배경
백엔드에서 clip/권한 검증이 강화되었지만, 프론트는 실패를 generic 처리하거나 로컬 fallback으로 덮어 실제 원인 파악이 어려웠습니다.

## 변경 내용
- `composeShortformDraft` 반환 구조 개선
  - `{ video, errorCode, errorMessage }`
  - 인증 상태 실패 시 local fallback compose 제거
- `ShortformWizard` 에러 매핑 추가
  - `INVALID_CLIP_RANGE`
  - `CLIP_DURATION_EXCEEDED`
  - `COURSE_LECTURE_MISMATCH`
  - `LECTURE_NOT_FOUND`
  - `FORBIDDEN`
- clip 시간 조정 로직 최적화
  - 공통 상수 기반 min/max bound 처리 (1초/5분)
- dev log 추가
  - `docs/dev-logs/2026-05-24-shortform-compose-ux-error-mapping.md`

## 연결 이슈
- Closes #434
- Fixes #434

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트
- 인증 상태에서 compose 실패시 fallback 제거가 기대 UX와 일치하는지
- 에러코드별 문구가 운영 메시지 정책과 맞는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: 프론트 단위 테스트 통과
- layer tests: `npm run test:frontend` 통과
- risk/rollback: 실패 표면화로 UX가 더 엄격해짐, 문제 시 PR revert

## ADR 링크
- ADR: N/A
- 상태 변경: N/A
