### PR TITLE
test: harden demo jwt e2e smoke coverage

### DIFF
--- a/docs/dev-logs/2026-05-24-demo-jwt-e2e-smoke-hardening.md
+++ b/docs/dev-logs/2026-05-24-demo-jwt-e2e-smoke-hardening.md
@@ -1,0 +1,21 @@
+# 2026-05-24 demo JWT E2E smoke hardening
+
+## 요약
+- `scripts/smoke-media-ai-shortform.ts`를 확장해 데모 JWT 기반 학습 플로우를 종단 검증하도록 강화했다.
+
+## 추가 검증 항목
+- `/api/v1/auth/me`로 로그인 사용자 일치 검증 (`usr_std_001`).
+- `/api/v1/enrollments`에 스모크 코스(`crs_java_01`) 수강 상태 포함 여부 검증.
+- `/api/v1/courses/{courseId}`에서 강의 목록 존재 및 대상 강의(`lec_java_01`) 포함 여부 검증.
+- `/api/v1/lectures/{lectureId}`에서 강의-코스 매핑 무결성 검증.
+- `/api/v1/media/lecture-video/{lectureId}`에서 영상 에셋 매핑(`asset_key`) 존재 검증.
+- `/api/v1/media/transcript/{lectureId}`에서 강의 트랜스크립트 존재 검증.
+
+## 기존 검증 유지
+- RAG 검색 타임스탬프/lecture mapping 검증.
+- AI search source 타임스탬프 범위 검증.
+- shortform compose/callback/video 조회 및 multi-lecture compose payload 무결성 검증.
+- 관리자 배치 상태 API 검증.
+
+## 로컬 검증
+- `npm run smoke:media-ai-shortform` 통과.

--- a/scripts/smoke-media-ai-shortform.ts
+++ b/scripts/smoke-media-ai-shortform.ts
@@ -9,6 +9,43 @@ type BatchStatusData = {
   success_count?: number;
 };
 
+type SessionData = {
+  user?: { id?: string; role?: string };
+  session_token?: string;
+};
+
+type EnrollmentData = {
+  id?: string;
+  course_id?: string;
+  user_id?: string;
+};
+
+type CourseLecture = {
+  id?: string;
+  course_id?: string;
+};
+
+type CourseDetailData = {
+  id?: string;
+  lectures?: CourseLecture[];
+};
+
+type LectureData = {
+  id?: string;
+  course_id?: string;
+};
+
+type LectureVideoData = {
+  lecture_id?: string;
+  asset_key?: string;
+  video_url?: string;
+};
+
+type TranscriptData = {
+  lecture_id?: string;
+  segments?: Array<{ start_ms?: number; end_ms?: number; text?: string }>;
+};
+
 type ShortformData = {
   id?: string;
   export_status?: string;
@@ -66,6 +103,62 @@ async function run(): Promise<void> {
 
   const studentToken = await login(studentUserId);
   const adminToken = await login(adminUserId);
+
+  const me = await api<SessionData>("/api/v1/auth/me", {
+    method: "GET",
+    headers: authHeader(studentToken),
+  });
+  assertOk(me.res.ok, `auth me failed (${me.res.status})`);
+  assertOk(me.body?.data?.user?.id === studentUserId, "auth me user mismatch");
+
+  const enrollments = await api<EnrollmentData[]>("/api/v1/enrollments", {
+    method: "GET",
+    headers: authHeader(studentToken),
+  });
+  assertOk(enrollments.res.ok, `enrollments failed (${enrollments.res.status})`);
+  assertOk(Array.isArray(enrollments.body?.data), "enrollments missing");
+  assertOk(
+    (enrollments.body?.data ?? []).some((enrollment) => enrollment?.course_id === smokeCourseId),
+    "student is not enrolled in smoke course",
+  );
+
+  const courseDetail = await api<CourseDetailData>(`/api/v1/courses/${encodeURIComponent(smokeCourseId)}`, {
+    method: "GET",
+    headers: authHeader(studentToken),
+  });
+  assertOk(courseDetail.res.ok, `course detail failed (${courseDetail.res.status})`);
+  const lectureIds = (courseDetail.body?.data?.lectures ?? [])
+    .map((lecture) => lecture?.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+  assertOk(lectureIds.length > 0, "course lectures missing");
+  assertOk(lectureIds.includes(smokeLectureId), "smoke lecture missing in course detail");
+
+  const lectureDetail = await api<LectureData>(`/api/v1/lectures/${encodeURIComponent(smokeLectureId)}`, {
+    method: "GET",
+    headers: authHeader(studentToken),
+  });
+  assertOk(lectureDetail.res.ok, `lecture detail failed (${lectureDetail.res.status})`);
+  assertOk(lectureDetail.body?.data?.id === smokeLectureId, "lecture detail id mismatch");
+  assertOk(lectureDetail.body?.data?.course_id === smokeCourseId, "lecture detail course mapping mismatch");
+
+  const lectureVideo = await api<LectureVideoData>(`/api/v1/media/lecture-video/${encodeURIComponent(smokeLectureId)}`, {
+    method: "GET",
+    headers: authHeader(studentToken),
+  });
+  assertOk(lectureVideo.res.ok, `lecture video mapping failed (${lectureVideo.res.status})`);
+  assertOk(lectureVideo.body?.data?.lecture_id === smokeLectureId, "lecture video lecture id mismatch");
+  assertOk(
+    typeof lectureVideo.body?.data?.asset_key === "string" && lectureVideo.body.data.asset_key.length > 0,
+    "lecture video asset key missing",
+  );
+
+  const transcript = await api<TranscriptData>(`/api/v1/media/transcript/${encodeURIComponent(smokeLectureId)}`, {
+    method: "GET",
+    headers: authHeader(studentToken),
+  });
+  assertOk(transcript.res.ok, `transcript failed (${transcript.res.status})`);
+  assertOk(transcript.body?.data?.lecture_id === smokeLectureId, "transcript lecture mismatch");
+  assertOk(Array.isArray(transcript.body?.data?.segments), "transcript segments missing");
 
   const rag = await api<{ chunks?: unknown[] }>("/api/v1/ai/rag", {
     method: "POST",


### PR DESCRIPTION
﻿# 변경 요약
데모 JWT 로그인 이후 실제 학습 플로우(auth/me, enrollments, course/lecture/video/transcript)를 스모크 테스트에서 종단 검증하도록 확장했습니다.

## 배경
최근 데모 계정으로 로그인해도 수강/강의/재생 경로에서 401/404가 발생하는 회귀를 빠르게 감지할 필요가 있습니다. 기존 스모크는 RAG/숏폼 중심이어서 인증-수강-강의 매핑 구간을 충분히 커버하지 못했습니다.

## 변경 내용
- `scripts/smoke-media-ai-shortform.ts`
  - `/api/v1/auth/me` 사용자 일치 검증 추가
  - `/api/v1/enrollments` 수강 상태 검증 추가
  - `/api/v1/courses/{courseId}` 강의 목록/대상 강의 포함 검증 추가
  - `/api/v1/lectures/{lectureId}` 강의-코스 매핑 검증 추가
  - `/api/v1/media/lecture-video/{lectureId}` 영상 asset 매핑 검증 추가
  - `/api/v1/media/transcript/{lectureId}` transcript 존재 검증 추가
- `docs/dev-logs/2026-05-24-demo-jwt-e2e-smoke-hardening.md` 추가

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run smoke:media-ai-shortform` 통과
- layer tests: smoke E2E 시나리오(pass)
- risk/rollback: 스모크 스크립트 검증 범위 확장으로 런타임 코드 영향 없음. 롤백은 스크립트 변경 커밋 revert로 즉시 가능.

## ADR 링크
- ADR: 해당 없음(테스트 커버리지 확장)
- 상태 변경: 해당 없음
