### PR TITLE
feat: add manual STT approval run endpoint

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -108,6 +108,14 @@ public class MediaController {
             String stt_model
     ) {}
 
+    public record ApproveSttRequest(
+            @NotBlank String lecture_id,
+            String language,
+            Integer duration_ms,
+            String stt_provider,
+            String stt_model
+    ) {}
+
     public record SpeakerReviewRequest(
             String speaker_label,
             String instructor_name,
@@ -500,6 +508,70 @@ public class MediaController {
                         "stt_sync_metrics", syncMetricsPayload
                 ),
                 "오디오 추출 callback이 반영되어 STT가 자동 시작되었습니다."
+        ));
+    }
+
+    @PostMapping("/extract-audio/{extractionId}/approve-stt")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> approveStt(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String extractionId,
+            @Valid @RequestBody ApproveSttRequest body
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return unauthenticated();
+        if (!canManageMedia(session)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.failure("FORBIDDEN", "STT 승인 실행은 강사와 운영자만 사용할 수 있습니다."));
+        }
+        String lectureId = trimRequired(body.lecture_id());
+        Map<String, Object> extraction = mediaPipelineService.extractions(lectureId).stream()
+                .filter(item -> extractionId.equals(String.valueOf(item.getOrDefault("id", ""))))
+                .findFirst()
+                .orElse(null);
+        if (extraction == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
+        }
+        String approvalState = String.valueOf(extraction.getOrDefault("stt_approval_state", "pending"));
+        if (!"pending".equalsIgnoreCase(approvalState)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.failure("STT_APPROVAL_NOT_PENDING", "승인 대기 상태가 아닌 STT입니다."));
+        }
+
+        String language = optionalOrDefault(body.language(), "ko");
+        Integer durationMs = body.duration_ms();
+        String sttProvider = optionalOrNull(body.stt_provider());
+        String sttModel = optionalOrNull(body.stt_model());
+        String audioUrl = optionalOrNull(String.valueOf(extraction.getOrDefault("audio_url", "")));
+
+        Map<String, Object> transcript = triggerLectureMetadataAutoSync(
+                lectureId,
+                mediaPipelineService.transcribe(
+                        lectureId,
+                        language,
+                        durationMs,
+                        sttProvider,
+                        sttModel,
+                        audioUrl,
+                        extractionId
+                )
+        );
+        Map<String, Object> syncPolicy = Map.of(
+                "mode", "approval",
+                "approval_state", "approved",
+                "overwrite_policy", String.valueOf(extraction.getOrDefault("stt_overwrite_policy", "overwrite")),
+                "notification_channel", String.valueOf(extraction.getOrDefault("stt_sync_notification_channel", "dashboard")),
+                "decision", "started_by_approval"
+        );
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of(
+                        "extraction_id", extractionId,
+                        "lecture_id", lectureId,
+                        "transcript", transcript,
+                        "pipeline", mediaPipelineService.pipeline(lectureId),
+                        "stt_sync_policy", syncPolicy
+                ),
+                "STT 승인 실행이 완료되었습니다."
         ));
     }
 

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -187,6 +187,35 @@ class MediaContractTest {
     }
 
     @Test
+    void approveStt_shouldStartTranscription_whenPendingApproval() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+        JsonNode extraction = readData(mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+        String extractionId = extraction.path("id").asText();
+
+        readData(mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("X-Callback-Token", "dev-media-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\",\"event_version\":1,\"sync_mode\":\"approval\",\"approval_state\":\"pending\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        JsonNode approved = readData(mockMvc.perform(post("/api/v1/media/extract-audio/" + extractionId + "/approve-stt")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertThat(approved.path("transcript").path("stt_provider").asText()).isEqualTo("demo");
+        assertThat(approved.path("stt_sync_policy").path("decision").asText()).isEqualTo("started_by_approval");
+    }
+
+    @Test
     void mediaWriteEndpoints_shouldKeepLectureIdRequiredErrorCode_whenLectureIdBlank() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
 

--- a/docs/dev-logs/2026-05-25-stt-approval-run-endpoint.md
+++ b/docs/dev-logs/2026-05-25-stt-approval-run-endpoint.md
@@ -1,0 +1,16 @@
+# 2026-05-25 STT 승인 실행 API 추가
+
+## 배경
+- callback의 `approval/pending` 모드는 자동 시작을 보류하지만, 운영자가 승인 후 재시작하는 실행 경로가 필요했다.
+
+## 변경
+- `POST /api/v1/media/extract-audio/{extractionId}/approve-stt` 추가
+  - 권한: 강사/운영자
+  - 입력: `lecture_id` (필수), optional `language`, `duration_ms`, `stt_provider`, `stt_model`
+  - 동작: pending approval extraction을 찾아 STT 실행
+  - 응답: transcript, pipeline, stt_sync_policy(decision=`started_by_approval`)
+- `MediaContractTest`에 승인 실행 계약 테스트 추가
+
+## 검증
+- `npx tsx scripts/run-maven-wrapper.ts "-Dtest=MediaContractTest" test` 통과
+- `npm run verify` 통과


### PR DESCRIPTION
# 변경 요약
승인 대기된 STT를 운영자가 수동 승인해 즉시 실행하는 API를 추가했습니다.

## 배경
`approval/pending` 정책이 도입되면서 자동 전사 보류는 가능해졌지만, 보류된 건을 실행하는 승인 엔드포인트가 필요했습니다.

## 변경 내용
- `POST /api/v1/media/extract-audio/{extractionId}/approve-stt` 추가
- 강사/운영자 권한 체크 및 pending 상태 검증 추가
- 승인 실행 응답에 `transcript`, `pipeline`, `stt_sync_policy(decision=started_by_approval)` 포함
- `MediaContractTest` 승인 실행 시나리오 추가
- dev log 추가: `docs/dev-logs/2026-05-25-stt-approval-run-endpoint.md`

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- pending approval 이외 상태에서 충돌(409) 처리 적절성
- 승인 실행 시 extraction/pipeline 일관성

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [ ] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run verify` 통과
- layer tests: `npx tsx scripts/run-maven-wrapper.ts "-Dtest=MediaContractTest" test` 통과
- risk/rollback: 신규 승인 API 제거 및 호출 경로 롤백으로 즉시 복구 가능

## ADR 링크
- ADR: `docs/decisions/ADR-0002-stt-chunking-timestamp-strategy.md` (참고)
- 상태 변경: 해당 없음
