### PR TITLE
feat(media): STT 동기화 정책 및 알림 지표 가시화

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -108,6 +108,14 @@ public class MediaController {
             String stt_model
     ) {}
 
+    public record ApproveSttRequest(
+            @NotBlank String lecture_id,
+            String language,
+            Integer duration_ms,
+            String stt_provider,
+            String stt_model
+    ) {}
+
     public record SpeakerReviewRequest(
             String speaker_label,
             String instructor_name,
@@ -500,6 +508,70 @@ public class MediaController {
                         "stt_sync_metrics", syncMetricsPayload
                 ),
                 "오디오 추출 callback이 반영되어 STT가 자동 시작되었습니다."
+        ));
+    }
+
+    @PostMapping("/extract-audio/{extractionId}/approve-stt")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> approveStt(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String extractionId,
+            @Valid @RequestBody ApproveSttRequest body
+    ) {
+        SessionView session = require(auth);
+        if (session == null) return unauthenticated();
+        if (!canManageMedia(session)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.failure("FORBIDDEN", "STT 승인 실행은 강사와 운영자만 사용할 수 있습니다."));
+        }
+        String lectureId = trimRequired(body.lecture_id());
+        Map<String, Object> extraction = mediaPipelineService.extractions(lectureId).stream()
+                .filter(item -> extractionId.equals(String.valueOf(item.getOrDefault("id", ""))))
+                .findFirst()
+                .orElse(null);
+        if (extraction == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
+        }
+        String approvalState = String.valueOf(extraction.getOrDefault("stt_approval_state", "pending"));
+        if (!"pending".equalsIgnoreCase(approvalState)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.failure("STT_APPROVAL_NOT_PENDING", "승인 대기 상태가 아닌 STT입니다."));
+        }
+
+        String language = optionalOrDefault(body.language(), "ko");
+        Integer durationMs = body.duration_ms();
+        String sttProvider = optionalOrNull(body.stt_provider());
+        String sttModel = optionalOrNull(body.stt_model());
+        String audioUrl = optionalOrNull(String.valueOf(extraction.getOrDefault("audio_url", "")));
+
+        Map<String, Object> transcript = triggerLectureMetadataAutoSync(
+                lectureId,
+                mediaPipelineService.transcribe(
+                        lectureId,
+                        language,
+                        durationMs,
+                        sttProvider,
+                        sttModel,
+                        audioUrl,
+                        extractionId
+                )
+        );
+        Map<String, Object> syncPolicy = Map.of(
+                "mode", "approval",
+                "approval_state", "approved",
+                "overwrite_policy", String.valueOf(extraction.getOrDefault("stt_overwrite_policy", "overwrite")),
+                "notification_channel", String.valueOf(extraction.getOrDefault("stt_sync_notification_channel", "dashboard")),
+                "decision", "started_by_approval"
+        );
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of(
+                        "extraction_id", extractionId,
+                        "lecture_id", lectureId,
+                        "transcript", transcript,
+                        "pipeline", mediaPipelineService.pipeline(lectureId),
+                        "stt_sync_policy", syncPolicy
+                ),
+                "STT 승인 실행이 완료되었습니다."
         ));
     }
 

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/MediaContractTest.java
@@ -187,6 +187,35 @@ class MediaContractTest {
     }
 
     @Test
+    void approveStt_shouldStartTranscription_whenPendingApproval() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
+        JsonNode extraction = readData(mockMvc.perform(post("/api/v1/media/extract-audio")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isCreated())
+                .andReturn());
+        String extractionId = extraction.path("id").asText();
+
+        readData(mockMvc.perform(post("/api/v1/media/extract-audio/callback")
+                        .header("X-Callback-Token", "dev-media-callback-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"extraction_id\":\"" + extractionId + "\",\"status\":\"COMPLETED\",\"event_version\":1,\"sync_mode\":\"approval\",\"approval_state\":\"pending\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        JsonNode approved = readData(mockMvc.perform(post("/api/v1/media/extract-audio/" + extractionId + "/approve-stt")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        assertThat(approved.path("transcript").path("stt_provider").asText()).isEqualTo("demo");
+        assertThat(approved.path("stt_sync_policy").path("decision").asText()).isEqualTo("started_by_approval");
+    }
+
+    @Test
     void mediaWriteEndpoints_shouldKeepLectureIdRequiredErrorCode_whenLectureIdBlank() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_ins_001");
 

--- a/docs/dev-logs/2026-05-25-stt-approval-run-endpoint.md
+++ b/docs/dev-logs/2026-05-25-stt-approval-run-endpoint.md
@@ -1,0 +1,16 @@
+# 2026-05-25 STT 승인 실행 API 추가
+
+## 배경
+- callback의 `approval/pending` 모드는 자동 시작을 보류하지만, 운영자가 승인 후 재시작하는 실행 경로가 필요했다.
+
+## 변경
+- `POST /api/v1/media/extract-audio/{extractionId}/approve-stt` 추가
+  - 권한: 강사/운영자
+  - 입력: `lecture_id` (필수), optional `language`, `duration_ms`, `stt_provider`, `stt_model`
+  - 동작: pending approval extraction을 찾아 STT 실행
+  - 응답: transcript, pipeline, stt_sync_policy(decision=`started_by_approval`)
+- `MediaContractTest`에 승인 실행 계약 테스트 추가
+
+## 검증
+- `npx tsx scripts/run-maven-wrapper.ts "-Dtest=MediaContractTest" test` 통과
+- `npm run verify` 통과

--- a/frontend/src/features/lms/pages/MediaPipelinePage.tsx
+++ b/frontend/src/features/lms/pages/MediaPipelinePage.tsx
@@ -274,6 +274,27 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
       String(latestExtraction.stt_approval_state ?? '').toLowerCase() === 'pending',
     [latestExtraction],
   );
+  const sttPolicySummary = useMemo(() => {
+    if (!latestExtraction) {
+      return null;
+    }
+    const mode = String(latestExtraction.stt_sync_mode ?? '-');
+    const overwritePolicy = String(latestExtraction.stt_overwrite_policy ?? '-');
+    const approvalState = String(latestExtraction.stt_approval_state ?? '-');
+    const notificationChannel = latestExtraction.stt_sync_notification_channel ?? '-';
+    const notifiedAt = latestExtraction.stt_sync_notified_at ?? '-';
+    const callbackEvents = latestExtraction.stt_sync_metrics?.callback_events ?? 0;
+    const notifications = latestExtraction.stt_sync_metrics?.notifications ?? 0;
+    return {
+      mode,
+      overwritePolicy,
+      approvalState,
+      notificationChannel,
+      notifiedAt,
+      callbackEvents,
+      notifications,
+    };
+  }, [latestExtraction]);
 
   async function submitExtraction(input: {
     lecture_id: string;
@@ -623,6 +644,32 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
             </div>
             <div className="mt-3 text-xs text-slate-500">
               extraction: {latestExtraction.id} · mode: {latestExtraction.stt_sync_mode ?? '-'} · approval: {latestExtraction.stt_approval_state ?? '-'}
+            </div>
+          </section>
+        ) : null}
+
+        {sttPolicySummary ? (
+          <section className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_10px_24px_rgba(6,31,57,0.07)]">
+            <div className="text-sm font-semibold text-slate-900">STT 메타 동기화 정책/지표</div>
+            <div className="mt-1 text-xs text-slate-500">자동/승인 모드, overwrite 정책, 알림 채널과 callback/알림 카운트를 함께 확인합니다.</div>
+            <div className="mt-3 grid gap-3 md:grid-cols-3">
+              <div className="rounded-2xl bg-[#f4faff] p-4">
+                <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">동기화 모드</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">{sttPolicySummary.mode}</div>
+                <div className="mt-2 text-xs text-slate-500">approval: {sttPolicySummary.approvalState}</div>
+              </div>
+              <div className="rounded-2xl bg-[#f4faff] p-4">
+                <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">Overwrite 정책</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">{sttPolicySummary.overwritePolicy}</div>
+                <div className="mt-2 text-xs text-slate-500">channel: {sttPolicySummary.notificationChannel}</div>
+              </div>
+              <div className="rounded-2xl bg-[#f4faff] p-4">
+                <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">알림/콜백 지표</div>
+                <div className="mt-1 text-sm font-semibold text-slate-900">
+                  callback {sttPolicySummary.callbackEvents} · notify {sttPolicySummary.notifications}
+                </div>
+                <div className="mt-2 text-xs text-slate-500">notified_at: {sttPolicySummary.notifiedAt}</div>
+              </div>
             </div>
           </section>
         ) : null}

--- a/frontend/src/features/lms/pages/MediaPipelinePage.tsx
+++ b/frontend/src/features/lms/pages/MediaPipelinePage.tsx
@@ -7,6 +7,7 @@ import { MediaPipelineStatusBoard } from '../components/MediaPipelineStatusBoard
 import { TranscriptTimelineWorkspace } from '../components/TranscriptTimelineWorkspace';
 import { MediaPipelineSummaryPanel } from '../components/MediaPipelineSummaryPanel';
 import {
+  approveSttExtractionDetailed,
   createAudioExtractionDetailed,
   loadAudioExtractions,
   loadLectureTranscriptDetailed,
@@ -266,6 +267,14 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
     };
   }, [demoMode, sessionToken, viewerRole]);
 
+  const requiresManualApproval = useMemo(
+    () =>
+      !!latestExtraction &&
+      String(latestExtraction.stt_sync_mode ?? '').toLowerCase() === 'approval' &&
+      String(latestExtraction.stt_approval_state ?? '').toLowerCase() === 'pending',
+    [latestExtraction],
+  );
+
   async function submitExtraction(input: {
     lecture_id: string;
     video_url?: string;
@@ -434,6 +443,34 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
     }
   }
 
+  async function handleApproveStt() {
+    if (demoMode) {
+      setNotice('데모 데이터 상태에서는 승인 실행을 하지 않습니다.');
+      return;
+    }
+    if (!lectureId || !latestExtraction?.id) {
+      setNotice('승인할 추출 항목을 먼저 선택해 주세요.');
+      return;
+    }
+    setBusy(true);
+    setNotice('승인된 STT를 실행하고 있습니다.');
+    try {
+      const approved = await approveSttExtractionDetailed(
+        latestExtraction.id,
+        { lecture_id: lectureId },
+        sessionToken,
+      );
+      if (!approved?.success || !approved.data) {
+        setNotice(getAiErrorMessage(approved, 'STT 승인 실행에 실패했습니다.'));
+        return;
+      }
+      setNotice('승인된 STT 실행이 완료되었습니다.');
+      await refreshMediaState(lectureId);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <div className="space-y-5">
       <section className="rounded-3xl border border-cyan-100 bg-[linear-gradient(135deg,#03162a_0%,#005d93_48%,#0bc5ea_100%)] px-6 py-6 text-white shadow-[0_22px_50px_rgba(4,49,84,0.24)]">
@@ -563,6 +600,31 @@ export function MediaPipelinePage({ selectedCourse, highlightedLecture, sessionT
             title="오디오 추출이 실패했습니다."
             description={latestExtraction.processing_error ?? '외부 처리 서비스 또는 callback 반영 과정에서 실패했습니다. 입력 경로를 확인한 뒤 다시 요청해 주세요.'}
           />
+        ) : null}
+
+        {requiresManualApproval ? (
+          <section className="rounded-3xl border border-amber-200 bg-amber-50/70 p-5 shadow-sm">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold text-slate-900">승인 대기 중인 STT</div>
+                <div className="mt-1 text-sm text-slate-600">
+                  현재 추출 건은 자동 시작이 보류되었습니다. 검토 후 승인 실행 버튼으로 전사를 시작할 수 있습니다.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleApproveStt()}
+                disabled={busy || viewerRole === 'STUDENT'}
+                className="inline-flex items-center gap-2 rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <i className={`${busy ? 'ri-loader-4-line animate-spin' : 'ri-check-double-line'}`} />
+                STT 승인 실행
+              </button>
+            </div>
+            <div className="mt-3 text-xs text-slate-500">
+              extraction: {latestExtraction.id} · mode: {latestExtraction.stt_sync_mode ?? '-'} · approval: {latestExtraction.stt_approval_state ?? '-'}
+            </div>
+          </section>
         ) : null}
 
         {latestExtraction?.status === 'FAILED' ? (

--- a/frontend/src/lib/api-media.ts
+++ b/frontend/src/lib/api-media.ts
@@ -47,6 +47,20 @@ export type TranscriptSpeakerReview = {
   reviewed_at?: string;
 };
 
+export type ApproveSttResult = {
+  extraction_id: string;
+  lecture_id: string;
+  transcript: LectureTranscript;
+  pipeline: LecturePipeline;
+  stt_sync_policy: {
+    mode: string;
+    approval_state: string;
+    overwrite_policy: string;
+    notification_channel: string;
+    decision: string;
+  };
+};
+
 export async function uploadLectureVideoDetailed(
   lectureId: string,
   file: File,
@@ -179,4 +193,26 @@ export async function saveLectureVideoMappingDetailed(
     method: 'POST',
     body: JSON.stringify(input),
   }, token);
+}
+
+export async function approveSttExtractionDetailed(
+  extractionId: string,
+  input: {
+    lecture_id: string;
+    language?: string;
+    duration_ms?: number;
+    stt_provider?: string;
+    stt_model?: string;
+  },
+  sessionToken?: string | null,
+): Promise<ApiRequestResult<ApproveSttResult> | null> {
+  const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
+  return await request<ApproveSttResult>(
+    `/api/v1/media/extract-audio/${encodeURIComponent(extractionId)}/approve-stt`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+    token,
+  );
 }

--- a/packages/shared/src/types/lms.ts
+++ b/packages/shared/src/types/lms.ts
@@ -194,6 +194,15 @@ export type AudioExtraction = {
     | 'failed'
     | null;
   processing_step?: string | null;
+  stt_sync_mode?: 'auto' | 'approval' | string;
+  stt_overwrite_policy?: 'overwrite' | 'skip_if_exists' | string;
+  stt_approval_state?: 'approved' | 'pending' | string;
+  stt_sync_notification_channel?: string;
+  stt_sync_notified_at?: string;
+  stt_sync_metrics?: {
+    callback_events?: number;
+    notifications?: number;
+  };
   audio_url?: string | null;
   audio_format: string;
   audio_duration_ms: number;


### PR DESCRIPTION
﻿# 변경 요약
STT 메타 동기화 정책 고도화의 후속으로, 미디어 파이프라인 화면에서 overwrite 정책과 알림/콜백 지표를 즉시 확인할 수 있는 운영 카드 섹션을 추가했습니다.

## 배경
승인 실행 기능은 연결됐지만 운영자가 화면에서 현재 동기화 정책(mode/overwrite/approval)과 notification/callback 지표를 한 번에 확인하기 어려워 추적성이 낮았습니다.

## 변경 내용
- `frontend/src/features/lms/pages/MediaPipelinePage.tsx`
  - `sttPolicySummary` 계산 로직 추가
  - `STT 메타 동기화 정책/지표` 카드 UI 추가
    - mode / approval state
    - overwrite policy / notification channel
    - callback_events / notifications / notified_at

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

리뷰 포인트:
- extraction 정책 필드가 비어 있는 경우 fallback(`-`, `0`) 표기가 의도대로 보이는지
- 승인 대기 카드와 정책/지표 카드가 동시에 표시될 때 레이아웃 충돌이 없는지

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run verify` 통과
- layer tests: verify 단계 포함 백엔드 테스트 통과 (70 passed)
- risk/rollback: 정보성 카드 추가이므로 런타임 영향 낮음. 필요 시 PR revert로 롤백 가능.

## ADR 링크
- ADR: 해당 없음 (운영 UI 가시성 보강)
- 상태 변경: 해당 없음
