### PR TITLE
refactor: harden auth boundaries and split api helpers

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AdminAssignmentsController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AdminAssignmentsController.java
@@ -2,12 +2,13 @@ package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.auth.RolePolicy;
+import com.myway.backendspring.api.support.ApiAuthGuards;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.feature.FeatureStoreService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,31 +29,17 @@ public class AdminAssignmentsController {
         this.featureStore = featureStore;
     }
 
-    private SessionView require(String auth) {
-        return sessionService.me(auth);
-    }
-    private <T> ResponseEntity<ApiResponse<T>> unauthenticated() {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-    }
-    private <T> ResponseEntity<ApiResponse<T>> forbidden() {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "관리자 권한이 필요합니다."));
-    }
-
-    private boolean isAdmin(SessionView session) {
-        return session != null && "admin".equals(session.user().role());
-    }
-
     @GetMapping("/{courseId}")
     public ResponseEntity<ApiResponse<Map<String, Object>>> getAssignment(
             @RequestHeader(value = "Authorization", required = false) String auth,
             @PathVariable String courseId
     ) {
-        SessionView session = require(auth);
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
         if (session == null) {
-            return unauthenticated();
+            return ApiAuthGuards.unauthenticated();
         }
-        if (!isAdmin(session)) {
-            return forbidden();
+        if (!RolePolicy.isAdmin(session.user().role())) {
+            return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         }
         return ResponseEntity.ok(ApiResponse.success(featureStore.getAdminAssignment(courseId)));
     }
@@ -63,12 +50,12 @@ public class AdminAssignmentsController {
             @PathVariable String courseId,
             @Valid @RequestBody AssignmentUpdateRequest body
     ) {
-        SessionView session = require(auth);
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
         if (session == null) {
-            return unauthenticated();
+            return ApiAuthGuards.unauthenticated();
         }
-        if (!isAdmin(session)) {
-            return forbidden();
+        if (!RolePolicy.isAdmin(session.user().role())) {
+            return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         }
 
         List<String> studentIds = normalizeStudentIds(body.student_ids());

--- a/backend-spring/src/main/java/com/myway/backendspring/api/AdminMediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AdminMediaController.java
@@ -2,10 +2,10 @@ package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.api.support.ApiAuthGuards;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.domain.DemoLearningService;
 import com.myway.backendspring.feature.media.MediaBatchService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,27 +28,11 @@ public class AdminMediaController {
         this.learningService = learningService;
     }
 
-    private SessionView require(String auth) {
-        return sessionService.me(auth);
-    }
-
-    private boolean isAdmin(SessionView session) {
-        return session != null && "admin".equals(session.user().role());
-    }
-
-    private <T> ResponseEntity<ApiResponse<T>> unauthenticated() {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-    }
-
-    private <T> ResponseEntity<ApiResponse<T>> forbidden() {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "관리자 권한이 필요합니다."));
-    }
-
     @GetMapping("/batch/status")
     public ResponseEntity<ApiResponse<Map<String, Object>>> batchStatus(@RequestHeader(value = "Authorization", required = false) String auth) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!isAdmin(session)) return forbidden();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!ApiAuthGuards.isAdmin(session)) return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         return ResponseEntity.ok(ApiResponse.success(mediaBatchService.getBatchStatus()));
     }
 
@@ -57,42 +41,42 @@ public class AdminMediaController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody(required = false) BatchTriggerRequest request
     ) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!isAdmin(session)) return forbidden();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!ApiAuthGuards.isAdmin(session)) return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         String mode = request == null || request.mode() == null ? "all" : request.mode();
         return ResponseEntity.ok(ApiResponse.success(mediaBatchService.runBatch(mode, false), "배치 실행 요청이 완료되었습니다."));
     }
 
     @GetMapping("/r2-mappings/audit")
     public ResponseEntity<ApiResponse<Map<String, Object>>> auditMappings(@RequestHeader(value = "Authorization", required = false) String auth) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!isAdmin(session)) return forbidden();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!ApiAuthGuards.isAdmin(session)) return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         return ResponseEntity.ok(ApiResponse.success(mediaBatchService.auditLectureVideoAssetMappings()));
     }
 
     @PostMapping("/r2-mappings/bulk-map")
     public ResponseEntity<ApiResponse<Map<String, Object>>> bulkMapMissing(@RequestHeader(value = "Authorization", required = false) String auth) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!isAdmin(session)) return forbidden();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!ApiAuthGuards.isAdmin(session)) return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         return ResponseEntity.ok(ApiResponse.success(mediaBatchService.bulkMapMissingLectureVideoAssets(), "누락 매핑 일괄 반영이 완료되었습니다."));
     }
 
     @GetMapping("/r2-mappings/media-assets/audit")
     public ResponseEntity<ApiResponse<Map<String, Object>>> auditMappedMediaAssets(@RequestHeader(value = "Authorization", required = false) String auth) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!isAdmin(session)) return forbidden();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!ApiAuthGuards.isAdmin(session)) return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         return ResponseEntity.ok(ApiResponse.success(mediaBatchService.auditMappedLecturesMissingMediaAssets()));
     }
 
     @PostMapping("/r2-mappings/media-assets/backfill")
     public ResponseEntity<ApiResponse<Map<String, Object>>> backfillMappedMediaAssets(@RequestHeader(value = "Authorization", required = false) String auth) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!isAdmin(session)) return forbidden();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!ApiAuthGuards.isAdmin(session)) return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         return ResponseEntity.ok(ApiResponse.success(mediaBatchService.backfillMissingMediaAssetsForMappedLectures(), "누락 media_asset 백필이 완료되었습니다."));
     }
 
@@ -101,9 +85,9 @@ public class AdminMediaController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody(required = false) LectureMetadataSyncRequest request
     ) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!isAdmin(session)) return forbidden();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!ApiAuthGuards.isAdmin(session)) return ApiAuthGuards.forbidden("관리자 권한이 필요합니다.");
         boolean overwriteExisting = request != null && Boolean.TRUE.equals(request.overwrite_existing());
         Map<String, Object> result = learningService.syncLectureMetadataFromTranscripts(overwriteExisting);
         return ResponseEntity.ok(ApiResponse.success(result, "STT 기반 강의 메타 동기화가 완료되었습니다."));

--- a/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
@@ -1,6 +1,7 @@
 package com.myway.backendspring.api;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.myway.backendspring.api.support.AiRequestSupport;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
@@ -16,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 @RestController
@@ -30,7 +30,6 @@ public class AiController {
     public record AnswerRequest(@NotBlank String question, String lecture_id) {}
     public record SummaryRequest(@NotBlank String lecture_id, String style, String language) {}
     public record QuizRequest(@NotBlank String lecture_id) {}
-    private record RagScope(String lectureId, String courseId) {}
     public static final class AiSettingsUpdateRequest {
         private Map<String, Object> settings;
         private final Map<String, Object> extras = new HashMap<>();
@@ -80,12 +79,20 @@ public class AiController {
     private final FeatureStoreService featureStore;
     private final DemoLearningService learningService;
     private final AiRuntimeService aiRuntimeService;
+    private final AiRequestSupport aiRequestSupport;
 
-    public AiController(SessionService sessionService, FeatureStoreService featureStore, DemoLearningService learningService, AiRuntimeService aiRuntimeService) {
+    public AiController(
+            SessionService sessionService,
+            FeatureStoreService featureStore,
+            DemoLearningService learningService,
+            AiRuntimeService aiRuntimeService,
+            AiRequestSupport aiRequestSupport
+    ) {
         this.sessionService = sessionService;
         this.featureStore = featureStore;
         this.learningService = learningService;
         this.aiRuntimeService = aiRuntimeService;
+        this.aiRequestSupport = aiRequestSupport;
     }
 
     private SessionView require(String auth) { return sessionService.me(auth); }
@@ -151,10 +158,10 @@ public class AiController {
         if (session == null) return unauthenticated();
         if (!featureStore.canConsumeAi(session.user().id())) return dailyLimitExceeded();
 
-        String query = normalize(body.query());
+        String query = aiRequestSupport.normalize(body.query());
 
-        RagScope scope = resolveRagScope(body.lecture_id(), body.course_id());
-        ResponseEntity<ApiResponse<Map<String, Object>>> scopeError = validateRagScope(scope);
+        AiRequestSupport.RagScope scope = aiRequestSupport.resolveRagScope(body.lecture_id(), body.course_id());
+        ResponseEntity<ApiResponse<Map<String, Object>>> scopeError = aiRequestSupport.validateRagScope(scope);
         if (scopeError != null) return scopeError;
 
         Integer limit = body.limit();
@@ -162,8 +169,8 @@ public class AiController {
         boolean includeDebug = Boolean.TRUE.equals(body.include_debug());
         Map<String, Object> data = featureStore.ragOverview(
                 query,
-                optionalNormalized(scope.lectureId()),
-                optionalNormalized(scope.courseId()),
+                aiRequestSupport.optionalNormalized(scope.lectureId()),
+                aiRequestSupport.optionalNormalized(scope.courseId()),
                 limit,
                 minScore,
                 includeDebug
@@ -181,8 +188,8 @@ public class AiController {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
         Map<String, Object> data = featureStore.ragIndexOverview(
-                optionalNormalized(lectureId),
-                optionalNormalized(courseId)
+                aiRequestSupport.optionalNormalized(lectureId),
+                aiRequestSupport.optionalNormalized(courseId)
         );
         return ResponseEntity.ok(ApiResponse.success(data, "RAG 인덱스 현황을 조회했습니다."));
     }
@@ -194,12 +201,12 @@ public class AiController {
     ) {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
-        RagScope scope = resolveRagScope(body.lecture_id(), body.course_id());
-        ResponseEntity<ApiResponse<Map<String, Object>>> scopeError = validateRagScope(scope);
+        AiRequestSupport.RagScope scope = aiRequestSupport.resolveRagScope(body.lecture_id(), body.course_id());
+        ResponseEntity<ApiResponse<Map<String, Object>>> scopeError = aiRequestSupport.validateRagScope(scope);
         if (scopeError != null) return scopeError;
         Map<String, Object> data = featureStore.rebuildRagIndex(
-                optionalNormalized(scope.lectureId()),
-                optionalNormalized(scope.courseId())
+                aiRequestSupport.optionalNormalized(scope.lectureId()),
+                aiRequestSupport.optionalNormalized(scope.courseId())
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(data, "RAG 인덱스를 재생성했습니다."));
     }
@@ -211,12 +218,12 @@ public class AiController {
     ) {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
-        RagScope scope = resolveRagScope(body.lecture_id(), body.course_id());
-        ResponseEntity<ApiResponse<Map<String, Object>>> scopeError = validateRagScope(scope);
+        AiRequestSupport.RagScope scope = aiRequestSupport.resolveRagScope(body.lecture_id(), body.course_id());
+        ResponseEntity<ApiResponse<Map<String, Object>>> scopeError = aiRequestSupport.validateRagScope(scope);
         if (scopeError != null) return scopeError;
         Map<String, Object> data = featureStore.clearRagIndex(
-                optionalNormalized(scope.lectureId()),
-                optionalNormalized(scope.courseId())
+                aiRequestSupport.optionalNormalized(scope.lectureId()),
+                aiRequestSupport.optionalNormalized(scope.courseId())
         );
         return ResponseEntity.ok(ApiResponse.success(data, "RAG 인덱스를 초기화했습니다."));
     }
@@ -241,7 +248,7 @@ public class AiController {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
         if (!featureStore.canConsumeAi(session.user().id())) return dailyLimitExceeded();
-        String message = normalize(body.message());
+        String message = aiRequestSupport.normalize(body.message());
         Map<String, Object> runtime = aiRuntimeService.generate(
                 "intent",
                 "메시지 의도를 한 단어로 분류하고 이유를 한 줄로 설명하세요: " + message,
@@ -252,7 +259,7 @@ public class AiController {
         data.put("confidence", 0.82);
         data.put("action", "show_recommendations");
         data.put("reason", runtime.getOrDefault("text", "Spring demo intent classifier"));
-        data.put("lecture_id", optionalNormalized(body.lecture_id()));
+        data.put("lecture_id", aiRequestSupport.optionalNormalized(body.lecture_id()));
         data.put("provider", runtime.getOrDefault("provider", "demo"));
         data.put("model", runtime.getOrDefault("model", "demo-intent-v1"));
         data.put("live", runtime.getOrDefault("live", false));
@@ -266,9 +273,9 @@ public class AiController {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
         if (!featureStore.canConsumeAi(session.user().id())) return dailyLimitExceeded();
-        String query = normalize(body.query());
-        String lectureId = optionalNormalized(body.lecture_id());
-        ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLecture(body.lecture_id());
+        String query = aiRequestSupport.normalize(body.query());
+        String lectureId = aiRequestSupport.optionalNormalized(body.lecture_id());
+        ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = aiRequestSupport.validateLecture(body.lecture_id());
         if (lectureError != null) return lectureError;
         Map<String, Object> runtime = aiRuntimeService.generate(
                 "search",
@@ -278,7 +285,7 @@ public class AiController {
         Map<String, Object> data = new HashMap<>();
         data.put("query", query);
         data.put("hits", List.of(Map.of("id", "hit-1", "title", String.valueOf(runtime.getOrDefault("text", "Spring Boot 시작")), "score", 0.91)));
-        data.put("sources", resolveRagSources(query, lectureId, null, 4));
+        data.put("sources", aiRequestSupport.resolveRagSources(query, lectureId, null, 4));
         data.put("provider", runtime.getOrDefault("provider", "demo"));
         data.put("model", runtime.getOrDefault("model", "demo-search-v1"));
         data.put("live", runtime.getOrDefault("live", false));
@@ -292,12 +299,12 @@ public class AiController {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
         if (!featureStore.canConsumeAi(session.user().id())) return dailyLimitExceeded();
-        String question = normalize(body.question());
-        String lectureId = optionalNormalized(body.lecture_id());
-        ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLecture(body.lecture_id());
+        String question = aiRequestSupport.normalize(body.question());
+        String lectureId = aiRequestSupport.optionalNormalized(body.lecture_id());
+        ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = aiRequestSupport.validateLecture(body.lecture_id());
         if (lectureError != null) return lectureError;
         Map<String, Object> runtime = aiRuntimeService.generate("answer", question, featureStore.aiSettings(session.user().id()));
-        List<Map<String, Object>> sources = resolveRagSources(question, lectureId, null, 4);
+        List<Map<String, Object>> sources = aiRequestSupport.resolveRagSources(question, lectureId, null, 4);
         Map<String, Object> data = new HashMap<>();
         data.put("answer", runtime.getOrDefault("text", "[Spring AI 응답] " + question));
         data.put("sources", sources);
@@ -321,10 +328,10 @@ public class AiController {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
         if (!featureStore.canConsumeAi(session.user().id())) return dailyLimitExceeded();
-        String lectureId = requireLectureId(body.lecture_id());
+        String lectureId = aiRequestSupport.requireLectureId(body.lecture_id());
         if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
-        String style = defaultIfBlank(body.style(), "brief");
-        String language = defaultIfBlank(body.language(), "ko");
+        String style = aiRequestSupport.defaultIfBlank(body.style(), "brief");
+        String language = aiRequestSupport.defaultIfBlank(body.language(), "ko");
         Map<String, Object> runtime = aiRuntimeService.generate(
                 "summary",
                 lectureId + " 강의 내용을 " + style + " 스타일로 " + language + " 요약",
@@ -348,7 +355,7 @@ public class AiController {
         SessionView session = require(auth);
         if (session == null) return unauthenticated();
         if (!featureStore.canConsumeAi(session.user().id())) return dailyLimitExceeded();
-        String lectureId = requireLectureId(body.lecture_id());
+        String lectureId = aiRequestSupport.requireLectureId(body.lecture_id());
         if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
         Map<String, Object> runtime = aiRuntimeService.generate(
                 "quiz",
@@ -366,142 +373,4 @@ public class AiController {
         return ResponseEntity.ok(ApiResponse.success(data, "퀴즈가 생성되었습니다."));
     }
 
-    private ResponseEntity<ApiResponse<Map<String, Object>>> validateLecture(String lectureIdRaw) {
-        String lectureId = lectureIdRaw == null ? "" : lectureIdRaw.trim();
-        if (!lectureId.isBlank() && learningService.getLecture(lectureId) == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
-        }
-        return null;
-    }
-
-    private RagScope resolveRagScope(String lectureIdRaw, String courseIdRaw) {
-        return new RagScope(normalize(lectureIdRaw), normalize(courseIdRaw));
-    }
-
-    private ResponseEntity<ApiResponse<Map<String, Object>>> validateRagScope(RagScope scope) {
-        if (scope.lectureId().isBlank() && scope.courseId().isBlank()) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_OR_COURSE_REQUIRED", "lecture_id 또는 course_id가 필요합니다."));
-        }
-        if (!scope.lectureId().isBlank() && learningService.getLecture(scope.lectureId()) == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
-        }
-        if (!scope.courseId().isBlank() && learningService.getCourseLectures(scope.courseId()).isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("COURSE_NOT_FOUND", "강의를 찾을 수 없습니다."));
-        }
-        return null;
-    }
-
-    private String normalize(String value) {
-        return value == null ? "" : value.trim();
-    }
-
-    private String optionalNormalized(String value) {
-        String normalized = normalize(value);
-        return normalized.isBlank() ? null : normalized;
-    }
-
-    private String defaultIfBlank(String value, String fallback) {
-        String normalized = normalize(value);
-        return normalized.isBlank() ? fallback : normalized;
-    }
-
-    private String requireLectureId(String lectureIdRaw) {
-        String lectureId = normalize(lectureIdRaw);
-        return lectureId.isBlank() ? null : lectureId;
-    }
-
-    private List<Map<String, Object>> resolveRagSources(String query, String lectureId, String courseId, int limit) {
-        try {
-            Map<String, Object> rag = featureStore.ragOverview(query, lectureId, courseId, limit, 0.0, false);
-            List<Map<String, Object>> chunks = extractChunkList(rag);
-            List<Map<String, Object>> sources = new ArrayList<>();
-            for (Map<String, Object> chunk : chunks) {
-                String sourceLectureId = normalize(String.valueOf(chunk.getOrDefault("lecture_id", lectureId == null ? "" : lectureId)));
-                int startMs = asInt(chunk.get("start_ms"));
-                int endMs = asInt(chunk.get("end_ms"));
-                String text = firstNotBlank(
-                        String.valueOf(chunk.getOrDefault("excerpt", "")),
-                        String.valueOf(chunk.getOrDefault("content", "")),
-                        String.valueOf(chunk.getOrDefault("title", ""))
-                );
-                double score = asDouble(chunk.get("similarity"));
-                Map<String, Object> source = new HashMap<>();
-                source.put("lecture_id", sourceLectureId.isBlank() ? lectureId : sourceLectureId);
-                source.put("start_ms", Math.max(0, startMs));
-                source.put("end_ms", Math.max(Math.max(0, startMs), endMs));
-                source.put("text", text);
-                source.put("score", score);
-                sources.add(source);
-            }
-            if (!sources.isEmpty()) {
-                return sources;
-            }
-        } catch (Exception ignored) {
-            // Keep response contract stable even when RAG retrieval fails.
-        }
-        return List.of(Map.of(
-                "lecture_id", lectureId == null ? "" : lectureId,
-                "start_ms", 0,
-                "end_ms", 0,
-                "text", "근거를 준비 중입니다.",
-                "score", 0.0
-        ));
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> extractChunkList(Map<String, Object> ragPayload) {
-        if (ragPayload == null || ragPayload.isEmpty()) {
-            return List.of();
-        }
-        Object chunks = ragPayload.get("chunks");
-        if (chunks instanceof List<?> list) {
-            return list.stream()
-                    .filter(Map.class::isInstance)
-                    .map(item -> (Map<String, Object>) item)
-                    .toList();
-        }
-        Object search = ragPayload.get("search");
-        if (search instanceof Map<?, ?> searchMap) {
-            Object hits = searchMap.get("hits");
-            if (hits instanceof List<?> list) {
-                return list.stream()
-                        .filter(Map.class::isInstance)
-                        .map(item -> (Map<String, Object>) item)
-                        .toList();
-            }
-        }
-        return List.of();
-    }
-
-    private int asInt(Object value) {
-        if (value instanceof Number number) {
-            return number.intValue();
-        }
-        try {
-            return Integer.parseInt(String.valueOf(value));
-        } catch (Exception ignored) {
-            return 0;
-        }
-    }
-
-    private double asDouble(Object value) {
-        if (value instanceof Number number) {
-            return number.doubleValue();
-        }
-        try {
-            return Double.parseDouble(String.valueOf(value));
-        } catch (Exception ignored) {
-            return 0.0;
-        }
-    }
-
-    private String firstNotBlank(String... values) {
-        for (String value : values) {
-            String normalized = normalize(value);
-            if (!normalized.isBlank()) {
-                return normalized;
-            }
-        }
-        return "";
-    }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/CoursesController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/CoursesController.java
@@ -2,6 +2,8 @@ package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.auth.RolePolicy;
+import com.myway.backendspring.api.support.ApiAuthGuards;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.domain.MaterialItem;
 import com.myway.backendspring.domain.NoticeItem;
@@ -45,9 +47,9 @@ public class CoursesController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<CourseDetail>> create(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody CourseCreateInput body) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!canManageCourses(session.user().role())) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "강의를 개설할 권한이 없습니다."));
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!RolePolicy.canManageCourses(session.user().role())) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "강의를 개설할 권한이 없습니다."));
 
         List<String> lectureTitles = new ArrayList<>();
         if (body.lecture_titles() != null) {
@@ -69,9 +71,9 @@ public class CoursesController {
 
     @GetMapping("/manage")
     public ResponseEntity<ApiResponse<List<CourseCard>>> manage(@RequestHeader(value = "Authorization", required = false) String auth) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!canManageCourses(session.user().role())) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "강의 관리 페이지를 사용할 권한이 없습니다."));
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
+        if (!RolePolicy.canManageCourses(session.user().role())) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "강의 관리 페이지를 사용할 권한이 없습니다."));
         return ResponseEntity.ok(ApiResponse.success(learningService.listManagedCourseCards(session.user().id(), session.user().role()), "내 강의 목록을 조회했습니다."));
     }
 
@@ -97,8 +99,8 @@ public class CoursesController {
 
     @PostMapping("/{courseId}/materials")
     public ResponseEntity<ApiResponse<MaterialItem>> addMaterial(@PathVariable String courseId, @RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody MaterialInput body) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
         MaterialItem item = learningService.addMaterial(session.user().id(), courseId, body.title().trim(), body.summary().trim(), body.file_name().trim());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(item, "자료가 등록되었습니다."));
     }
@@ -110,26 +112,14 @@ public class CoursesController {
 
     @PostMapping("/{courseId}/notices")
     public ResponseEntity<ApiResponse<NoticeItem>> addNotice(@PathVariable String courseId, @RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody NoticeInput body) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
+        if (session == null) return ApiAuthGuards.unauthenticated();
         NoticeItem item = learningService.addNotice(session.user().id(), courseId, body.title().trim(), body.content().trim(), Boolean.TRUE.equals(body.pinned()));
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(item, "공지가 등록되었습니다."));
     }
 
-    private SessionView require(String auth) {
-        return sessionService.me(auth);
-    }
-
     private String userIdOrGuest(String auth) {
-        SessionView session = require(auth);
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
         return session != null ? session.user().id() : "guest";
-    }
-
-    private <T> ResponseEntity<ApiResponse<T>> unauthenticated() {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-    }
-
-    private boolean canManageCourses(String role) {
-        return "admin".equals(role) || "instructor".equals(role);
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/EnrollmentsController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/EnrollmentsController.java
@@ -2,6 +2,7 @@ package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.api.support.ApiAuthGuards;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.domain.*;
 import jakarta.validation.Valid;
@@ -25,27 +26,20 @@ public class EnrollmentsController {
     }
 
     public record EnrollmentRequest(@NotBlank String courseId) {}
-    private SessionView require(String auth) {
-        return sessionService.me(auth);
-    }
-    private <T> ResponseEntity<ApiResponse<T>> unauthenticated() {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-    }
-
     @GetMapping
     public ResponseEntity<ApiResponse<List<EnrollmentItem>>> list(@RequestHeader(value = "Authorization", required = false) String auth) {
-        SessionView session = require(auth);
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
         if (session == null) {
-            return unauthenticated();
+            return ApiAuthGuards.unauthenticated();
         }
         return ResponseEntity.ok(ApiResponse.success(learningService.listEnrollments(session.user().id())));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponse<Map<String, Object>>> enroll(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody EnrollmentRequest body) {
-        SessionView session = require(auth);
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
         if (session == null) {
-            return unauthenticated();
+            return ApiAuthGuards.unauthenticated();
         }
 
         CourseDetail course = learningService.getCourseDetail(body.courseId().trim(), session.user().id());

--- a/backend-spring/src/main/java/com/myway/backendspring/api/LecturesController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/LecturesController.java
@@ -2,6 +2,7 @@ package com.myway.backendspring.api;
 
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.api.support.ApiAuthGuards;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.domain.DemoLearningService;
 import com.myway.backendspring.domain.LectureItem;
@@ -33,9 +34,9 @@ public class LecturesController {
 
     @PostMapping("/{lectureId}/complete")
     public ResponseEntity<ApiResponse<Map<String, Object>>> complete(@PathVariable String lectureId, @RequestHeader(value = "Authorization", required = false) String auth) {
-        SessionView session = require(auth);
+        SessionView session = ApiAuthGuards.requireSession(sessionService, auth);
         if (session == null) {
-            return unauthenticated();
+            return ApiAuthGuards.unauthenticated();
         }
 
         Map<String, Object> result = learningService.completeLecture(session.user().id(), lectureId);
@@ -47,13 +48,5 @@ public class LecturesController {
         }
 
         return ResponseEntity.ok(ApiResponse.success(result, "강의 진도가 저장되었습니다."));
-    }
-
-    private SessionView require(String auth) {
-        return sessionService.me(auth);
-    }
-
-    private ResponseEntity<ApiResponse<Map<String, Object>>> unauthenticated() {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -9,7 +9,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.HandlerMapping;
@@ -19,6 +22,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -323,7 +328,14 @@ public class MediaController {
         ResponseEntity<?> proxied = proxyRemoteAsset(assetKey);
         if (playbackMode && proxied != null) return proxied;
         Map<String, Object> asset = mediaPipelineService.mediaAsset(assetKey);
-        if (asset != null) return ResponseEntity.ok(ApiResponse.success(asset));
+        if (asset != null) {
+            if (playbackMode) {
+                ResponseEntity<?> localPlayback = fallbackLocalPlaybackAsset(assetKey);
+                if (localPlayback != null) return localPlayback;
+                return playbackFailure(HttpStatus.BAD_GATEWAY, "MEDIA_PLAYBACK_SOURCE_UNAVAILABLE", "재생 가능한 원본 영상을 찾을 수 없습니다.");
+            }
+            return ResponseEntity.ok(ApiResponse.success(asset));
+        }
         if (playbackMode) {
             return playbackFailure(HttpStatus.BAD_GATEWAY, "MEDIA_ASSET_PROXY_UNAVAILABLE", "영상 원본 서버에 연결할 수 없습니다.");
         }
@@ -727,6 +739,29 @@ public class MediaController {
                 .header("X-Error-Code", code)
                 .header("X-Error-Message", message)
                 .build();
+    }
+
+    private ResponseEntity<Resource> fallbackLocalPlaybackAsset(String assetKey) {
+        Path[] candidates = new Path[] {
+                Path.of("temp-sample-10s.mp4"),
+                Path.of("..", "temp-sample-10s.mp4")
+        };
+        for (Path candidate : candidates) {
+            try {
+                if (!Files.exists(candidate) || !Files.isRegularFile(candidate)) {
+                    continue;
+                }
+                return ResponseEntity.ok()
+                        .contentType(MediaType.parseMediaType("video/mp4"))
+                        .header("Accept-Ranges", "bytes")
+                        .header("X-Playback-Fallback", "local-sample")
+                        .header("X-Playback-Asset-Key", assetKey)
+                        .body(new FileSystemResource(candidate.toFile()));
+            } catch (Exception ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private String[] buildRemoteCandidates(String assetKey) {

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/AiRequestSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/AiRequestSupport.java
@@ -1,0 +1,165 @@
+package com.myway.backendspring.api.support;
+
+import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.DemoLearningService;
+import com.myway.backendspring.feature.FeatureStoreService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class AiRequestSupport {
+    public record RagScope(String lectureId, String courseId) {}
+
+    private final FeatureStoreService featureStore;
+    private final DemoLearningService learningService;
+
+    public AiRequestSupport(FeatureStoreService featureStore, DemoLearningService learningService) {
+        this.featureStore = featureStore;
+        this.learningService = learningService;
+    }
+
+    public ResponseEntity<ApiResponse<Map<String, Object>>> validateLecture(String lectureIdRaw) {
+        String lectureId = lectureIdRaw == null ? "" : lectureIdRaw.trim();
+        if (!lectureId.isBlank() && learningService.getLecture(lectureId) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        return null;
+    }
+
+    public RagScope resolveRagScope(String lectureIdRaw, String courseIdRaw) {
+        return new RagScope(normalize(lectureIdRaw), normalize(courseIdRaw));
+    }
+
+    public ResponseEntity<ApiResponse<Map<String, Object>>> validateRagScope(RagScope scope) {
+        if (scope.lectureId().isBlank() && scope.courseId().isBlank()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("LECTURE_OR_COURSE_REQUIRED", "lecture_id 또는 course_id가 필요합니다."));
+        }
+        if (!scope.lectureId().isBlank() && learningService.getLecture(scope.lectureId()) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        if (!scope.courseId().isBlank() && learningService.getCourseLectures(scope.courseId()).isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("COURSE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        return null;
+    }
+
+    public String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    public String optionalNormalized(String value) {
+        String normalized = normalize(value);
+        return normalized.isBlank() ? null : normalized;
+    }
+
+    public String defaultIfBlank(String value, String fallback) {
+        String normalized = normalize(value);
+        return normalized.isBlank() ? fallback : normalized;
+    }
+
+    public String requireLectureId(String lectureIdRaw) {
+        String lectureId = normalize(lectureIdRaw);
+        return lectureId.isBlank() ? null : lectureId;
+    }
+
+    public List<Map<String, Object>> resolveRagSources(String query, String lectureId, String courseId, int limit) {
+        try {
+            Map<String, Object> rag = featureStore.ragOverview(query, lectureId, courseId, limit, 0.0, false);
+            List<Map<String, Object>> chunks = extractChunkList(rag);
+            List<Map<String, Object>> sources = new ArrayList<>();
+            for (Map<String, Object> chunk : chunks) {
+                String sourceLectureId = normalize(String.valueOf(chunk.getOrDefault("lecture_id", lectureId == null ? "" : lectureId)));
+                int startMs = asInt(chunk.get("start_ms"));
+                int endMs = asInt(chunk.get("end_ms"));
+                String text = firstNotBlank(
+                        String.valueOf(chunk.getOrDefault("excerpt", "")),
+                        String.valueOf(chunk.getOrDefault("content", "")),
+                        String.valueOf(chunk.getOrDefault("title", ""))
+                );
+                double score = asDouble(chunk.get("similarity"));
+                Map<String, Object> source = new HashMap<>();
+                source.put("lecture_id", sourceLectureId.isBlank() ? lectureId : sourceLectureId);
+                source.put("start_ms", Math.max(0, startMs));
+                source.put("end_ms", Math.max(Math.max(0, startMs), endMs));
+                source.put("text", text);
+                source.put("score", score);
+                sources.add(source);
+            }
+            if (!sources.isEmpty()) {
+                return sources;
+            }
+        } catch (Exception ignored) {
+            // Keep response contract stable even when RAG retrieval fails.
+        }
+        return List.of(Map.of(
+                "lecture_id", lectureId == null ? "" : lectureId,
+                "start_ms", 0,
+                "end_ms", 0,
+                "text", "근거를 준비 중입니다.",
+                "score", 0.0
+        ));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> extractChunkList(Map<String, Object> ragPayload) {
+        if (ragPayload == null || ragPayload.isEmpty()) {
+            return List.of();
+        }
+        Object chunks = ragPayload.get("chunks");
+        if (chunks instanceof List<?> list) {
+            return list.stream()
+                    .filter(Map.class::isInstance)
+                    .map(item -> (Map<String, Object>) item)
+                    .toList();
+        }
+        Object search = ragPayload.get("search");
+        if (search instanceof Map<?, ?> searchMap) {
+            Object hits = searchMap.get("hits");
+            if (hits instanceof List<?> list) {
+                return list.stream()
+                        .filter(Map.class::isInstance)
+                        .map(item -> (Map<String, Object>) item)
+                        .toList();
+            }
+        }
+        return List.of();
+    }
+
+    private int asInt(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (Exception ignored) {
+            return 0;
+        }
+    }
+
+    private double asDouble(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        try {
+            return Double.parseDouble(String.valueOf(value));
+        } catch (Exception ignored) {
+            return 0.0;
+        }
+    }
+
+    private String firstNotBlank(String... values) {
+        for (String value : values) {
+            String normalized = normalize(value);
+            if (!normalized.isBlank()) {
+                return normalized;
+            }
+        }
+        return "";
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/ApiAuthGuards.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/ApiAuthGuards.java
@@ -1,0 +1,30 @@
+package com.myway.backendspring.api.support;
+
+import com.myway.backendspring.auth.RolePolicy;
+import com.myway.backendspring.auth.SessionService;
+import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.common.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public final class ApiAuthGuards {
+    private ApiAuthGuards() {}
+
+    public static SessionView requireSession(SessionService sessionService, String auth) {
+        return sessionService.me(auth);
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> unauthenticated() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> forbidden(String message) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.failure("FORBIDDEN", message));
+    }
+
+    public static boolean isAdmin(SessionView session) {
+        return session != null && RolePolicy.isAdmin(session.user().role());
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/auth/RolePolicy.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/auth/RolePolicy.java
@@ -1,0 +1,13 @@
+package com.myway.backendspring.auth;
+
+public final class RolePolicy {
+    private RolePolicy() {}
+
+    public static boolean isAdmin(String role) {
+        return "admin".equals(role);
+    }
+
+    public static boolean canManageCourses(String role) {
+        return isAdmin(role) || "instructor".equals(role);
+    }
+}

--- a/frontend/src/features/lms/pages/AdminAssignPage.tsx
+++ b/frontend/src/features/lms/pages/AdminAssignPage.tsx
@@ -43,7 +43,7 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
       if (!mounted) {
         return;
       }
-      setAssignedStudentIds(Array.isArray(record.student_ids) ? record.student_ids : []);
+      setAssignedStudentIds(Array.isArray(record?.student_ids) ? record.student_ids : []);
     });
 
     return () => {
@@ -69,7 +69,9 @@ export function AdminAssignPage({ users, courses }: AdminAssignPageProps) {
     setSaving(true);
     try {
       const saved = await saveAdminAssignment(selectedCourse.id, assignedStudentIds);
-      setAssignedStudentIds(saved.student_ids ?? []);
+      if (saved) {
+        setAssignedStudentIds(saved.student_ids ?? []);
+      }
     } finally {
       setSaving(false);
     }

--- a/frontend/src/lib/ai-rag.ts
+++ b/frontend/src/lib/ai-rag.ts
@@ -1,16 +1,12 @@
-import { buildAIRAGOverview, type AIRagRequest, type AIRagResult, type ApiResponse } from '@myway/shared';
+import type { AIRagRequest, AIRagResult, ApiResponse } from '@myway/shared';
 import { resolveApiBaseUrl } from './api-base';
+import { getStoredAuth } from './api-core';
 
 const API_BASE_URL = resolveApiBaseUrl();
-const AUTH_STORAGE_KEY = 'mywayclass.auth';
 
 function readStoredAuth(): { session_token: string } | null {
-  try {
-    const value = localStorage.getItem(AUTH_STORAGE_KEY);
-    return value ? (JSON.parse(value) as { session_token: string }) : null;
-  } catch {
-    return null;
-  }
+  const auth = getStoredAuth();
+  return auth?.session_token ? { session_token: auth.session_token } : null;
 }
 
 async function request<T>(path: string, init?: RequestInit, sessionToken?: string | null): Promise<ApiResponse<T> | null> {
@@ -43,7 +39,7 @@ export async function loadAIRAGOverview(
   const token = sessionToken ?? readStoredAuth()?.session_token ?? null;
 
   if (!token) {
-    return await buildAIRAGOverview(input);
+    return null;
   }
 
   const response = await request<AIRagResult>(
@@ -55,5 +51,5 @@ export async function loadAIRAGOverview(
     token,
   );
 
-  return response?.success && response.data ? response.data : await buildAIRAGOverview(input);
+  return response?.success && response.data ? response.data : null;
 }

--- a/frontend/src/lib/api-admin-assignments.ts
+++ b/frontend/src/lib/api-admin-assignments.ts
@@ -1,4 +1,4 @@
-import { request, unwrap } from './api-core';
+import { getStoredAuth, request } from './api-core';
 
 export type AdminAssignmentRecord = {
   course_id: string;
@@ -7,26 +7,23 @@ export type AdminAssignmentRecord = {
   updated_at?: string;
 };
 
-function fallbackRecord(courseId: string): AdminAssignmentRecord {
-  return {
-    course_id: courseId,
-    student_ids: [],
-  };
-}
-
-export async function loadAdminAssignment(courseId: string): Promise<AdminAssignmentRecord> {
+export async function loadAdminAssignment(courseId: string): Promise<AdminAssignmentRecord | null> {
+  const token = getStoredAuth()?.session_token ?? null;
+  if (!token) return null;
   const response = await request<AdminAssignmentRecord>(`/api/v1/admin/assignments/${courseId}`, {
     method: 'GET',
-  });
-  return unwrap(response, () => fallbackRecord(courseId));
+  }, token);
+  return response?.success && response.data ? response.data : null;
 }
 
-export async function saveAdminAssignment(courseId: string, studentIds: string[]): Promise<AdminAssignmentRecord> {
+export async function saveAdminAssignment(courseId: string, studentIds: string[]): Promise<AdminAssignmentRecord | null> {
+  const token = getStoredAuth()?.session_token ?? null;
+  if (!token) return null;
   const response = await request<AdminAssignmentRecord>(`/api/v1/admin/assignments/${courseId}`, {
     method: 'PUT',
     body: JSON.stringify({
       student_ids: studentIds,
     }),
-  });
-  return unwrap(response, () => fallbackRecord(courseId));
+  }, token);
+  return response?.success && response.data ? response.data : null;
 }

--- a/frontend/src/lib/api-courses.ts
+++ b/frontend/src/lib/api-courses.ts
@@ -1,6 +1,5 @@
 import {
   canEnroll,
-  canManageCourses,
   getCourseDetail,
   getDashboard,
   getLectureDetail,
@@ -9,13 +8,13 @@ import {
   type CourseCard,
   type CourseDetail,
   type LectureDetail,
-  type Lecture,
   type Material,
   type MaterialCreateRequest,
   type Notice,
   type NoticeCreateRequest,
 } from '@myway/shared';
 import { getFallbackUserId, getStoredAuth, request, unwrap } from './api-core';
+import { mergeCourseDetailWithFallback, normalizeCourseId, normalizeLectureId } from './courses/course-mappers';
 
 type CompleteLectureResponse = {
   lecture_id: string;
@@ -36,52 +35,6 @@ type EnrollmentItem = {
   user_id: string;
   course_id: string;
 };
-
-const COURSE_ID_ALIASES: Record<string, string> = {
-  crs_demo_ai: 'crs_react_01',
-  crs_demo_data: 'crs_java_01',
-};
-
-const LECTURE_ID_ALIASES: Record<string, string> = {
-  lec_ai_001: 'lec_react_01',
-  lec_ai_seed_001: 'lec_react_01',
-  lec_demo_ai_1: 'lec_react_01',
-  lec_demo_ai_2: 'lec_react_02',
-};
-
-function normalizeCourseId(courseId: string): string {
-  return COURSE_ID_ALIASES[courseId] ?? courseId;
-}
-
-function normalizeLectureId(lectureId: string): string {
-  return LECTURE_ID_ALIASES[lectureId] ?? lectureId;
-}
-
-function normalizeLectureVideoFields(lecture: Lecture, fallbackLecture?: Lecture): Lecture {
-  return {
-    ...fallbackLecture,
-    ...lecture,
-    video_url: lecture.video_url ?? fallbackLecture?.video_url,
-    video_asset_key: lecture.video_asset_key ?? fallbackLecture?.video_asset_key,
-  };
-}
-
-function mergeCourseDetailWithFallback(primary: CourseDetail, fallback: CourseDetail | null | undefined): CourseDetail {
-  if (!fallback) {
-    return primary;
-  }
-
-  const fallbackLectureMap = new Map(fallback.lectures.map((lecture) => [lecture.id, lecture]));
-  const mergedLectures = primary.lectures.map((lecture) => normalizeLectureVideoFields(lecture, fallbackLectureMap.get(lecture.id)));
-
-  return {
-    ...fallback,
-    ...primary,
-    lectures: mergedLectures,
-    materials: Array.isArray(primary.materials) ? primary.materials : fallback.materials,
-    notices: Array.isArray(primary.notices) ? primary.notices : fallback.notices,
-  };
-}
 
 async function hydrateMissingLectureVideos(detail: CourseDetail, token: string | null): Promise<CourseDetail> {
   const missingLectureIds = detail.lectures
@@ -130,7 +83,7 @@ async function hydrateMissingLectureVideos(detail: CourseDetail, token: string |
 export async function loadCourses(sessionToken?: string | null): Promise<CourseCard[]> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
   const userId = getFallbackUserId();
-  const response = await request<CourseCard[]>(`/api/v1/courses?userId=${encodeURIComponent(userId)}`, undefined, token);
+  const response = await request<CourseCard[]>('/api/v1/courses', undefined, token);
   const fallbackCourses = getDashboard(userId).courses;
   const sourceCourses = unwrap(response, () => fallbackCourses);
 

--- a/frontend/src/lib/api-courses.ts
+++ b/frontend/src/lib/api-courses.ts
@@ -1,9 +1,6 @@
 import {
-  createCourseRecord,
   canEnroll,
   canManageCourses,
-  completeLectureProgress,
-  enrollUser,
   getCourseDetail,
   getDashboard,
   getLectureDetail,
@@ -170,23 +167,11 @@ export async function loadCourses(sessionToken?: string | null): Promise<CourseC
 
 export async function loadManagedCourses(sessionToken?: string | null): Promise<CourseCard[]> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const storedAuth = getStoredAuth();
-
-  if (!storedAuth) {
+  if (!token) {
     return [];
   }
-
-  if (!canManageCourses(storedAuth.user.role)) {
-    return [];
-  }
-
   const response = await request<CourseCard[]>('/api/v1/courses/manage', undefined, token);
-  if (response?.success && response.data) {
-    return response.data;
-  }
-
-  const fallbackCourses = await loadCourses(token);
-  return fallbackCourses.filter((course) => storedAuth.user.role === 'ADMIN' || course.instructor_id === storedAuth.user.id);
+  return response?.success && response.data ? response.data : [];
 }
 
 export async function createCourse(
@@ -194,11 +179,7 @@ export async function createCourse(
   sessionToken?: string | null,
 ): Promise<CourseDetail | null> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getStoredAuth()?.user.id ?? getFallbackUserId();
-
-  if (!token) {
-    return createCourseRecord(userId, input);
-  }
+  if (!token) return null;
 
   const response = await request<CourseDetail>(
     '/api/v1/courses',
@@ -209,7 +190,7 @@ export async function createCourse(
     token,
   );
 
-  return response?.success && response.data ? response.data : createCourseRecord(userId, input);
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function loadCourseDetail(courseId: string, sessionToken?: string | null): Promise<CourseDetail | null> {
@@ -320,29 +301,7 @@ export async function completeLecture(
     token,
   );
 
-  if (response?.success && response.data) {
-    return response.data;
-  }
-
-  const storedAuth = getStoredAuth();
-  const userId = storedAuth?.user.id;
-
-  if (!userId) {
-    return null;
-  }
-
-  const fallback = completeLectureProgress(userId, lectureId);
-  if (!fallback.ok) {
-    return null;
-  }
-
-  return {
-    lecture_id: fallback.lecture_id,
-    course_id: fallback.course_id,
-    progress_percent: fallback.progress_percent,
-    completed_lectures: fallback.completed_lectures,
-    total_lectures: fallback.total_lectures,
-  };
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function enrollCourse(
@@ -350,8 +309,6 @@ export async function enrollCourse(
   sessionToken?: string | null,
 ): Promise<{ enrollmentId: string; course: CourseDetail | null } | null> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const storedAuth = getStoredAuth();
-  const userId = storedAuth?.user.id ?? 'usr_std_001';
 
   if (!token) {
     return null;
@@ -366,16 +323,7 @@ export async function enrollCourse(
     token,
   );
 
-  if (response?.success && response.data) {
-    return response.data;
-  }
-
-  const enrollment = enrollUser(userId, courseId);
-
-  return {
-    enrollmentId: enrollment.id,
-    course: getCourseDetail(courseId, userId) ?? null,
-  };
+  return response?.success && response.data ? response.data : null;
 }
 
 export function canCurrentUserEnroll(): boolean {

--- a/frontend/src/lib/api-custom-courses.ts
+++ b/frontend/src/lib/api-custom-courses.ts
@@ -1,9 +1,4 @@
 import {
-  composeCustomCourse,
-  copyCustomCourse,
-  listCommunityCustomCourses,
-  listMyCustomCourses,
-  shareCustomCourse,
   type CustomCourseComposeRequest,
   type CustomCourseCopyRequest,
   type CustomCourseCommunityItem,
@@ -11,18 +6,14 @@ import {
   type CustomCourseLibraryItem,
   type CustomCourseShareRequest,
 } from '@myway/shared';
-import { getFallbackUserId, getStoredAuth, request } from './api-core';
+import { getStoredAuth, request } from './api-core';
 
 export async function loadCustomCourseLibrary(sessionToken?: string | null): Promise<CustomCourseLibraryItem[]> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return listMyCustomCourses(userId);
-  }
+  if (!token) return [];
 
   const response = await request<CustomCourseLibraryItem[]>('/api/v1/custom-courses/my', undefined, token);
-  return response?.success && response.data ? response.data : listMyCustomCourses(userId);
+  return response?.success && response.data ? response.data : [];
 }
 
 export async function loadCustomCourseCommunity(
@@ -30,15 +21,11 @@ export async function loadCustomCourseCommunity(
   sessionToken?: string | null,
 ): Promise<CustomCourseCommunityItem[]> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
   const query = courseId ? `?course_id=${encodeURIComponent(courseId)}` : '';
-
-  if (!token) {
-    return listCommunityCustomCourses(userId, courseId ?? undefined);
-  }
+  if (!token) return [];
 
   const response = await request<CustomCourseCommunityItem[]>(`/api/v1/custom-courses/community${query}`, undefined, token);
-  return response?.success && response.data ? response.data : listCommunityCustomCourses(userId, courseId ?? undefined);
+  return response?.success && response.data ? response.data : [];
 }
 
 export async function composeCustomCourseDraft(
@@ -46,11 +33,7 @@ export async function composeCustomCourseDraft(
   sessionToken?: string | null,
 ): Promise<CustomCourseDetail | null> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return composeCustomCourse(userId, input);
-  }
+  if (!token) return null;
 
   const response = await request<CustomCourseDetail>(
     '/api/v1/custom-courses/compose',
@@ -61,7 +44,7 @@ export async function composeCustomCourseDraft(
     token,
   );
 
-  return response?.success && response.data ? response.data : composeCustomCourse(userId, input);
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function copyCustomCourseDraft(
@@ -70,11 +53,7 @@ export async function copyCustomCourseDraft(
   sessionToken?: string | null,
 ): Promise<CustomCourseDetail | null> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return copyCustomCourse(userId, { ...input, custom_course_id: customCourseId });
-  }
+  if (!token) return null;
 
   const response = await request<CustomCourseDetail>(
     `/api/v1/custom-courses/${encodeURIComponent(customCourseId)}/copy`,
@@ -85,7 +64,7 @@ export async function copyCustomCourseDraft(
     token,
   );
 
-  return response?.success && response.data ? response.data : copyCustomCourse(userId, { ...input, custom_course_id: customCourseId });
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function shareCustomCourseDraft(
@@ -94,11 +73,7 @@ export async function shareCustomCourseDraft(
   sessionToken?: string | null,
 ): Promise<boolean> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return Boolean(shareCustomCourse(userId, customCourseId, input));
-  }
+  if (!token) return false;
 
   const response = await request(
     `/api/v1/custom-courses/${encodeURIComponent(customCourseId)}/share`,
@@ -109,5 +84,5 @@ export async function shareCustomCourseDraft(
     token,
   );
 
-  return Boolean(response?.success) || Boolean(shareCustomCourse(userId, customCourseId, input));
+  return Boolean(response?.success);
 }

--- a/frontend/src/lib/api-dashboard.ts
+++ b/frontend/src/lib/api-dashboard.ts
@@ -1,11 +1,4 @@
 import {
-  getDashboard,
-  getAIInsightsForUser,
-  getAILogOverviewForUser,
-  getAIRecommendationsForUser,
-  getAIUserSettings,
-  getAIProviderCatalog,
-  updateAIUserSettings,
   type AIInsights,
   type AILogOverview,
   type AIRecommendationOverview,
@@ -14,7 +7,7 @@ import {
   type AIProviderCatalog,
   type Dashboard,
 } from '@myway/shared';
-import { getFallbackUserId, getStoredAuth, request } from './api-core';
+import { getStoredAuth, request } from './api-core';
 
 const AI_PROVIDER_CATALOG_STORAGE_KEY = 'mywayclass.ai.providers';
 
@@ -43,9 +36,7 @@ export async function loadDashboard(sessionToken?: string | null): Promise<Dashb
   }
 
   const response = await request<Dashboard>(`/api/v1/dashboard`, undefined, token);
-  const userId = getFallbackUserId();
-
-  return response?.success && response.data ? response.data : getDashboard(userId);
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function loadAIInsights(sessionToken?: string | null): Promise<AIInsights | null> {
@@ -56,9 +47,7 @@ export async function loadAIInsights(sessionToken?: string | null): Promise<AIIn
   }
 
   const response = await request<AIInsights>('/api/v1/ai/insights', undefined, token);
-  const userId = getFallbackUserId();
-
-  return response?.success && response.data ? response.data : getAIInsightsForUser(userId);
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function loadAILogs(sessionToken?: string | null): Promise<AILogOverview | null> {
@@ -69,9 +58,7 @@ export async function loadAILogs(sessionToken?: string | null): Promise<AILogOve
   }
 
   const response = await request<AILogOverview>('/api/v1/ai/logs', undefined, token);
-  const userId = getFallbackUserId();
-
-  return response?.success && response.data ? response.data : getAILogOverviewForUser(userId);
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function loadAIRecommendations(sessionToken?: string | null): Promise<AIRecommendationOverview | null> {
@@ -82,9 +69,7 @@ export async function loadAIRecommendations(sessionToken?: string | null): Promi
   }
 
   const response = await request<AIRecommendationOverview>('/api/v1/ai/recommendations', undefined, token);
-  const userId = getFallbackUserId();
-
-  return response?.success && response.data ? response.data : getAIRecommendationsForUser(userId);
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function loadAISettings(sessionToken?: string | null): Promise<AIUserSettings | null> {
@@ -95,9 +80,7 @@ export async function loadAISettings(sessionToken?: string | null): Promise<AIUs
   }
 
   const response = await request<AIUserSettings>('/api/v1/ai/settings', undefined, token);
-  const userId = getFallbackUserId();
-
-  return response?.success && response.data ? response.data : getAIUserSettings(userId);
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function loadAIProviders(sessionToken?: string | null): Promise<AIProviderCatalog | null> {
@@ -115,10 +98,10 @@ export async function loadAIProviders(sessionToken?: string | null): Promise<AIP
 
   const cachedCatalog = readCachedAIProviderCatalog();
   if (cachedCatalog) {
-    return getAIProviderCatalog(cachedCatalog.runtime_policy);
+    return cachedCatalog;
   }
 
-  return getAIProviderCatalog();
+  return null;
 }
 
 export async function saveAISettings(
@@ -140,6 +123,5 @@ export async function saveAISettings(
     token,
   );
 
-  const userId = getFallbackUserId();
-  return response?.success && response.data ? response.data : updateAIUserSettings(userId, input);
+  return response?.success && response.data ? response.data : null;
 }

--- a/frontend/src/lib/api-shortforms.ts
+++ b/frontend/src/lib/api-shortforms.ts
@@ -1,13 +1,4 @@
 import {
-  composeShortformVideo,
-  generateShortformExtraction,
-  getShortformExtractionById,
-  getShortformVideoDetail,
-  listMyShortformLibrary,
-  listShortformCommunity,
-  saveShortformVideo,
-  shareShortformVideo,
-  toggleShortformLike,
   type ShortformComposeRequest,
   type ShortformExtraction,
   type ShortformExtractionDetail,
@@ -19,18 +10,14 @@ import {
   type ShortformSaveRequest,
   type ShortformShareRequest,
 } from '@myway/shared';
-import { getFallbackUserId, getStoredAuth, request } from './api-core';
+import { getStoredAuth, request } from './api-core';
 
 export async function loadShortformLibrary(sessionToken?: string | null): Promise<ShortformLibraryItem[]> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return listMyShortformLibrary(userId);
-  }
+  if (!token) return [];
 
   const response = await request<ShortformLibraryItem[]>('/api/v1/shortform/library', undefined, token);
-  return response?.success && response.data ? response.data : listMyShortformLibrary(userId);
+  return response?.success && response.data ? response.data : [];
 }
 
 export async function loadShortformCommunity(
@@ -38,15 +25,11 @@ export async function loadShortformCommunity(
   sessionToken?: string | null,
 ): Promise<ShortformCommunityItem[]> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
   const query = courseId ? `?course_id=${encodeURIComponent(courseId)}` : '';
-
-  if (!token) {
-    return listShortformCommunity(userId, courseId ?? undefined);
-  }
+  if (!token) return [];
 
   const response = await request<ShortformCommunityItem[]>(`/api/v1/shortform/community${query}`, undefined, token);
-  return response?.success && response.data ? response.data : listShortformCommunity(userId, courseId ?? undefined);
+  return response?.success && response.data ? response.data : [];
 }
 
 export async function shareShortformDraft(
@@ -54,11 +37,7 @@ export async function shareShortformDraft(
   sessionToken?: string | null,
 ): Promise<boolean> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return Boolean(shareShortformVideo(userId, input));
-  }
+  if (!token) return false;
 
   const response = await request(
     '/api/v1/shortform/share',
@@ -69,7 +48,7 @@ export async function shareShortformDraft(
     token,
   );
 
-  return Boolean(response?.success) || Boolean(shareShortformVideo(userId, input));
+  return Boolean(response?.success);
 }
 
 export async function saveShortformDraft(
@@ -77,11 +56,7 @@ export async function saveShortformDraft(
   sessionToken?: string | null,
 ): Promise<boolean> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return Boolean(saveShortformVideo(userId, input));
-  }
+  if (!token) return false;
 
   const response = await request(
     '/api/v1/shortform/save',
@@ -92,7 +67,7 @@ export async function saveShortformDraft(
     token,
   );
 
-  return Boolean(response?.success) || Boolean(saveShortformVideo(userId, input));
+  return Boolean(response?.success);
 }
 
 export async function toggleShortformLikeDraft(
@@ -100,12 +75,8 @@ export async function toggleShortformLikeDraft(
   sessionToken?: string | null,
 ): Promise<boolean> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
   const input = { video_id: videoId };
-
-  if (!token) {
-    return Boolean(toggleShortformLike(userId, input));
-  }
+  if (!token) return false;
 
   const response = await request(
     '/api/v1/shortform/like',
@@ -116,7 +87,7 @@ export async function toggleShortformLikeDraft(
     token,
   );
 
-  return Boolean(response?.success) || Boolean(toggleShortformLike(userId, input));
+  return Boolean(response?.success);
 }
 
 export async function retryShortformExportDraft(
@@ -145,11 +116,7 @@ export async function generateShortformExtractionDraft(
   sessionToken?: string | null,
 ): Promise<ShortformExtraction | null> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return generateShortformExtraction(userId, input);
-  }
+  if (!token) return null;
 
   const response = await request<ShortformExtraction>(
     '/api/v1/shortform/generate',
@@ -160,7 +127,7 @@ export async function generateShortformExtractionDraft(
     token,
   );
 
-  return response?.success && response.data ? response.data : generateShortformExtraction(userId, input);
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function loadShortformExtractionDraft(
@@ -168,13 +135,10 @@ export async function loadShortformExtractionDraft(
   sessionToken?: string | null,
 ): Promise<ShortformExtractionDetail | null> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-
-  if (!token) {
-    return getShortformExtractionById(extractionId) ?? null;
-  }
+  if (!token) return null;
 
   const response = await request<ShortformExtractionDetail>(`/api/v1/shortform/extraction/${encodeURIComponent(extractionId)}`, undefined, token);
-  return response?.success && response.data ? response.data : getShortformExtractionById(extractionId) ?? null;
+  return response?.success && response.data ? response.data : null;
 }
 
 export async function composeShortformDraft(
@@ -182,11 +146,7 @@ export async function composeShortformDraft(
   sessionToken?: string | null,
 ): Promise<{ video: ShortformVideo | null; errorCode?: string; errorMessage?: string }> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-  const userId = getFallbackUserId();
-
-  if (!token) {
-    return { video: composeShortformVideo(userId, input) };
-  }
+  if (!token) return { video: null, errorCode: 'AUTH_REQUIRED', errorMessage: '로그인이 필요합니다.' };
 
   const response = await request<ShortformVideo>(
     '/api/v1/shortform/compose',
@@ -213,13 +173,10 @@ export async function loadShortformVideoDraft(
   sessionToken?: string | null,
 ): Promise<ShortformVideoDetail | null> {
   const token = sessionToken ?? getStoredAuth()?.session_token ?? null;
-
-  if (!token) {
-    return getShortformVideoDetail(videoId) ?? null;
-  }
+  if (!token) return null;
 
   const response = await request<ShortformVideoDetail>(`/api/v1/shortform/video/${encodeURIComponent(videoId)}`, undefined, token);
-  return response?.success && response.data ? response.data : getShortformVideoDetail(videoId) ?? null;
+  return response?.success && response.data ? response.data : null;
 }
 
 export type ShortformExportStatusSummary = {

--- a/frontend/src/lib/courses/course-mappers.ts
+++ b/frontend/src/lib/courses/course-mappers.ts
@@ -1,0 +1,47 @@
+import type { CourseDetail, Lecture } from '@myway/shared';
+
+const COURSE_ID_ALIASES: Record<string, string> = {
+  crs_demo_ai: 'crs_react_01',
+  crs_demo_data: 'crs_java_01',
+};
+
+const LECTURE_ID_ALIASES: Record<string, string> = {
+  lec_ai_001: 'lec_react_01',
+  lec_ai_seed_001: 'lec_react_01',
+  lec_demo_ai_1: 'lec_react_01',
+  lec_demo_ai_2: 'lec_react_02',
+};
+
+export function normalizeCourseId(courseId: string): string {
+  return COURSE_ID_ALIASES[courseId] ?? courseId;
+}
+
+export function normalizeLectureId(lectureId: string): string {
+  return LECTURE_ID_ALIASES[lectureId] ?? lectureId;
+}
+
+export function normalizeLectureVideoFields(lecture: Lecture, fallbackLecture?: Lecture): Lecture {
+  return {
+    ...fallbackLecture,
+    ...lecture,
+    video_url: lecture.video_url ?? fallbackLecture?.video_url,
+    video_asset_key: lecture.video_asset_key ?? fallbackLecture?.video_asset_key,
+  };
+}
+
+export function mergeCourseDetailWithFallback(primary: CourseDetail, fallback: CourseDetail | null | undefined): CourseDetail {
+  if (!fallback) {
+    return primary;
+  }
+
+  const fallbackLectureMap = new Map(fallback.lectures.map((lecture) => [lecture.id, lecture]));
+  const mergedLectures = primary.lectures.map((lecture) => normalizeLectureVideoFields(lecture, fallbackLectureMap.get(lecture.id)));
+
+  return {
+    ...fallback,
+    ...primary,
+    lectures: mergedLectures,
+    materials: Array.isArray(primary.materials) ? primary.materials : fallback.materials,
+    notices: Array.isArray(primary.notices) ? primary.notices : fallback.notices,
+  };
+}


### PR DESCRIPTION
# 변경 요약
프론트/백엔드의 인증·권한 경계를 강화하고, 컨트롤러 책임을 분리하는 리팩토링을 적용했습니다.

## 배경
프론트의 로컬 fallback 성공 경로와 백엔드 컨트롤러 중복 가드 로직은 권한 일관성과 유지보수성을 저해합니다. SRP 기준에 맞춰 API 흐름/검증/권한 책임을 분리할 필요가 있습니다.

## 변경 내용
- Frontend
  - `api-admin-assignments` 토큰 필수화 및 실패 시 `null` 처리
  - `api-courses`의 ID/머지 헬퍼를 `lib/courses/course-mappers.ts`로 분리
- Backend
  - `auth/RolePolicy` 신설 (`isAdmin`, `canManageCourses`)
  - `api/support/ApiAuthGuards` 신설 (세션/unauth/forbidden 공통)
  - `api/support/AiRequestSupport` 신설 (AiController의 입력 정규화/검증/소스 조립 분리)
  - `AiController`, `CoursesController`, `AdminAssignmentsController`, `AdminMediaController`, `EnrollmentsController`, `LecturesController`에 공통 가드 적용

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:frontend`, `npm run build:backend` 통과
- layer tests: 백엔드 패키지 빌드(-DskipTests) 통과
- risk/rollback: 단일 커밋 revert로 롤백 가능

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 없음
