### PR TITLE
refactor(media): split stt orchestration and playback support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaController.java
@@ -1,5 +1,8 @@
 package com.myway.backendspring.api;
 
+import com.myway.backendspring.api.support.ApiAuthGuards;
+import com.myway.backendspring.api.support.MediaAssetPlaybackSupport;
+import com.myway.backendspring.auth.RolePolicy;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
@@ -9,74 +12,37 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.HandlerMapping;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @RestController
 @RequestMapping("/api/v1/media")
 public class MediaController {
-    private static final Set<String> ALLOWED_CALLBACK_STATUSES = Set.of("COMPLETED", "FAILED", "PROCESSING");
-    private static final Set<String> ALLOWED_SYNC_MODES = Set.of("AUTO", "APPROVAL");
-    private static final Set<String> ALLOWED_OVERWRITE_POLICIES = Set.of("OVERWRITE", "SKIP_IF_EXISTS");
-    private static final Set<String> ALLOWED_APPROVAL_STATES = Set.of("APPROVED", "PENDING");
     private final SessionService sessionService;
     private final MediaPipelineService mediaPipelineService;
     private final DemoLearningService learningService;
     private final String callbackToken;
-    private final String remoteAssetBaseUrl;
-    private final String remoteAssetToken;
+    private final MediaAssetPlaybackSupport playbackSupport;
 
     public MediaController(
             SessionService sessionService,
             MediaPipelineService mediaPipelineService,
             DemoLearningService learningService,
             @Value("${myway.media.callback.token:dev-media-callback-token}") String callbackToken,
-            @Value("${myway.media.asset-proxy.base-url:}") String remoteAssetBaseUrl,
-            @Value("${myway.media.asset-proxy.token:}") String remoteAssetToken
+            MediaAssetPlaybackSupport playbackSupport
     ) {
         this.sessionService = sessionService;
         this.mediaPipelineService = mediaPipelineService;
         this.learningService = learningService;
         this.callbackToken = callbackToken;
-        this.remoteAssetBaseUrl = normalizeRemoteAssetBaseUrl(remoteAssetBaseUrl);
-        this.remoteAssetToken = remoteAssetToken == null ? "" : remoteAssetToken.trim();
+        this.playbackSupport = playbackSupport;
     }
-
-    public record ExtractionCallbackRequest(
-            @NotBlank String extraction_id,
-            String lecture_id,
-            String status,
-            String error_message,
-            @Min(1) Long event_version,
-            String audio_url,
-            String processing_job_id,
-            String processing_stage,
-            String processing_step,
-            String audio_format,
-            Integer sample_rate,
-            Integer channels,
-            String sync_mode,
-            String overwrite_policy,
-            String approval_state,
-            String notification_channel
-    ) {}
 
     public record ExtractAudioRequest(
             @NotBlank String lecture_id,
@@ -113,14 +79,6 @@ public class MediaController {
             String stt_model
     ) {}
 
-    public record ApproveSttRequest(
-            @NotBlank String lecture_id,
-            String language,
-            Integer duration_ms,
-            String stt_provider,
-            String stt_model
-    ) {}
-
     public record SpeakerReviewRequest(
             String speaker_label,
             String instructor_name,
@@ -146,21 +104,15 @@ public class MediaController {
         return trimmed.isBlank() ? defaultValue : trimmed;
     }
 
-    private SessionView require(String auth) { return sessionService.me(auth); }
-    private <T> ResponseEntity<ApiResponse<T>> unauthenticated() {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
-    }
-    private boolean requireAuthenticated(String auth) {
-        return require(auth) != null;
-    }
+    private SessionView require(String auth) { return ApiAuthGuards.requireSession(sessionService, auth); }
+    private <T> ResponseEntity<ApiResponse<T>> unauthenticated() { return ApiAuthGuards.unauthenticated(); }
+    private boolean requireAuthenticated(String auth) { return require(auth) != null; }
     private boolean canManageMedia(SessionView session) {
-        if (session == null) return false;
-        String role = session.user().role();
-        return "admin".equals(role) || "instructor".equals(role);
+        return session != null && RolePolicy.canManageCourses(session.user().role());
     }
 
     private boolean isAdmin(SessionView session) {
-        return session != null && "admin".equals(session.user().role());
+        return session != null && RolePolicy.isAdmin(session.user().role());
     }
 
     @PostMapping("/upload-video")
@@ -308,39 +260,39 @@ public class MediaController {
         if (assetKey.isBlank()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("ASSET_NOT_FOUND", "미디어 파일을 찾을 수 없습니다."));
         }
-        String resolvedQueryToken = resolveQueryToken(queryToken, request);
+        String resolvedQueryToken = playbackSupport.resolveQueryToken(queryToken, request);
         String resolvedAuth = auth;
         if ((resolvedAuth == null || resolvedAuth.isBlank()) && resolvedQueryToken != null && !resolvedQueryToken.isBlank()) {
             resolvedAuth = "Bearer " + resolvedQueryToken;
         }
-        boolean playbackMode = isPlaybackRequest(request, resolvedQueryToken);
+        boolean playbackMode = playbackSupport.isPlaybackRequest(request, resolvedQueryToken);
         boolean processorBypass = processorToken != null && processorToken.equals(callbackToken);
         SessionView session = null;
         if (!processorBypass) {
             session = require(resolvedAuth);
             if (session == null) {
                 if (playbackMode) {
-                    return playbackFailure(HttpStatus.UNAUTHORIZED, "MEDIA_PLAYBACK_TOKEN_INVALID", "유효한 재생 토큰이 필요합니다.");
+                    return playbackSupport.playbackFailure(HttpStatus.UNAUTHORIZED, "MEDIA_PLAYBACK_TOKEN_INVALID", "유효한 재생 토큰이 필요합니다.");
                 }
                 return unauthenticated();
             }
         }
-        ResponseEntity<?> proxied = proxyRemoteAsset(assetKey);
+        ResponseEntity<?> proxied = playbackSupport.proxyRemoteAsset(assetKey);
         if (playbackMode && proxied != null) return proxied;
         Map<String, Object> asset = mediaPipelineService.mediaAsset(assetKey);
         if (asset != null) {
             if (playbackMode) {
-                ResponseEntity<?> localPlayback = fallbackLocalPlaybackAsset(assetKey);
+                ResponseEntity<?> localPlayback = playbackSupport.fallbackLocalPlaybackAsset(assetKey);
                 if (localPlayback != null) return localPlayback;
-                return playbackFailure(HttpStatus.BAD_GATEWAY, "MEDIA_PLAYBACK_SOURCE_UNAVAILABLE", "재생 가능한 원본 영상을 찾을 수 없습니다.");
+                return playbackSupport.playbackFailure(HttpStatus.BAD_GATEWAY, "MEDIA_PLAYBACK_SOURCE_UNAVAILABLE", "재생 가능한 원본 영상을 찾을 수 없습니다.");
             }
             return ResponseEntity.ok(ApiResponse.success(asset));
         }
         if (playbackMode) {
-            return playbackFailure(HttpStatus.BAD_GATEWAY, "MEDIA_ASSET_PROXY_UNAVAILABLE", "영상 원본 서버에 연결할 수 없습니다.");
+            return playbackSupport.playbackFailure(HttpStatus.BAD_GATEWAY, "MEDIA_ASSET_PROXY_UNAVAILABLE", "영상 원본 서버에 연결할 수 없습니다.");
         }
         if (proxied != null) return proxied;
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("ASSET_NOT_FOUND", "미디어 파일을 찾을 수 없습니다."));
+        return playbackSupport.assetNotFound();
     }
 
     public ResponseEntity<?> assets(
@@ -413,248 +365,6 @@ public class MediaController {
         return ResponseEntity.ok(ApiResponse.success(result, "STT/RAG 배치 파이프라인 실행이 완료되었습니다."));
     }
 
-    @PostMapping("/extract-audio/callback")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> callback(
-            @RequestHeader(value = "X-Callback-Token", required = false) String token,
-            @RequestHeader(value = "x-myway-media-callback-secret", required = false) String callbackSecret,
-            @Valid @RequestBody ExtractionCallbackRequest body
-    ) {
-        String resolvedToken = (token != null && !token.isBlank()) ? token : callbackSecret;
-        if (resolvedToken == null || resolvedToken.isBlank() || !resolvedToken.equals(callbackToken)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("CALLBACK_UNAUTHORIZED", "유효한 callback token이 필요합니다."));
-        }
-        String extractionId = trimRequired(body.extraction_id());
-        CallbackPolicyDecision decision = CallbackStateTransitionPolicy.decide(body);
-        if (!decision.valid()) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID_PAYLOAD", decision.errorMessage()));
-        }
-        SttSyncPolicyDecision sttPolicy = SttSyncPolicy.decide(body);
-        if (!sttPolicy.valid()) {
-            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID_PAYLOAD", sttPolicy.errorMessage()));
-        }
-        String errorMessage = body.error_message();
-        String audioUrl = optionalOrNull(body.audio_url());
-        Map<String, Object> result = mediaPipelineService.completeExtractionCallback(
-                extractionId,
-                decision.status(),
-                errorMessage,
-                decision.eventVersion(),
-                audioUrl,
-                body.processing_job_id(),
-                body.processing_stage(),
-                body.processing_step(),
-                body.audio_format(),
-                body.sample_rate(),
-                body.channels(),
-                sttPolicy.syncMode(),
-                sttPolicy.overwritePolicy(),
-                sttPolicy.approvalState(),
-                sttPolicy.notificationChannel()
-        );
-        if (result == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("CALLBACK_EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
-        }
-        if (Boolean.TRUE.equals(result.get("callback_ignored"))) {
-            return ResponseEntity.ok(ApiResponse.success(
-                    Map.of("extraction", result, "pipeline", mediaPipelineService.pipeline(String.valueOf(result.getOrDefault("lecture_id", "")))),
-                    "오래된 callback 이벤트를 무시했습니다."
-            ));
-        }
-        String lectureId = String.valueOf(result.getOrDefault("lecture_id", "")).trim();
-        Map<String, Object> transcribeResult = null;
-        boolean callbackWantsStt = "COMPLETED".equalsIgnoreCase(decision.status())
-                || "transcribing".equalsIgnoreCase(String.valueOf(result.getOrDefault("processing_stage", "")));
-        boolean hasTranscript = !lectureId.isBlank() && mediaPipelineService.transcript(lectureId) != null;
-        String syncDecision = "started";
-        if ("APPROVAL".equals(sttPolicy.syncMode()) && !"APPROVED".equals(sttPolicy.approvalState())) {
-            syncDecision = "awaiting_approval";
-        } else if ("SKIP_IF_EXISTS".equals(sttPolicy.overwritePolicy()) && hasTranscript) {
-            syncDecision = "skipped_existing_transcript";
-        }
-        boolean shouldStartStt = callbackWantsStt && "started".equals(syncDecision) && !lectureId.isBlank();
-        if (shouldStartStt) {
-            transcribeResult = mediaPipelineService.transcribe(
-                    lectureId,
-                    "ko",
-                    null,
-                    null,
-                    null,
-                    audioUrl,
-                    extractionId
-            );
-        }
-        Map<String, Object> syncPolicyPayload = Map.of(
-                "mode", sttPolicy.syncMode().toLowerCase(),
-                "approval_state", sttPolicy.approvalState().toLowerCase(),
-                "overwrite_policy", sttPolicy.overwritePolicy().toLowerCase(),
-                "notification_channel", sttPolicy.notificationChannel(),
-                "decision", syncDecision
-        );
-        Map<String, Object> syncMetricsPayload = Map.of(
-                "callback_events", 1,
-                "auto_started", shouldStartStt ? 1 : 0,
-                "approval_pending", "awaiting_approval".equals(syncDecision) ? 1 : 0,
-                "overwrite_skipped", "skipped_existing_transcript".equals(syncDecision) ? 1 : 0,
-                "notifications", 1
-        );
-
-        if (transcribeResult == null) {
-            return ResponseEntity.ok(ApiResponse.success(
-                    Map.of(
-                            "extraction", result,
-                            "pipeline", mediaPipelineService.pipeline(lectureId),
-                            "stt_sync_policy", syncPolicyPayload,
-                            "stt_sync_metrics", syncMetricsPayload
-                    ),
-                    "오디오 추출 callback이 반영되었습니다."
-            ));
-        }
-
-        Map<String, Object> transcribeWithMeta = triggerLectureMetadataAutoSync(lectureId, transcribeResult);
-        return ResponseEntity.ok(ApiResponse.success(
-                Map.of(
-                        "extraction", result,
-                        "pipeline", mediaPipelineService.pipeline(lectureId),
-                        "transcript", transcribeWithMeta,
-                        "stt_sync_policy", syncPolicyPayload,
-                        "stt_sync_metrics", syncMetricsPayload
-                ),
-                "오디오 추출 callback이 반영되어 STT가 자동 시작되었습니다."
-        ));
-    }
-
-    @PostMapping("/extract-audio/{extractionId}/approve-stt")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> approveStt(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @PathVariable String extractionId,
-            @Valid @RequestBody ApproveSttRequest body
-    ) {
-        SessionView session = require(auth);
-        if (session == null) return unauthenticated();
-        if (!canManageMedia(session)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(ApiResponse.failure("FORBIDDEN", "STT 승인 실행은 강사와 운영자만 사용할 수 있습니다."));
-        }
-        String lectureId = trimRequired(body.lecture_id());
-        Map<String, Object> extraction = mediaPipelineService.extractions(lectureId).stream()
-                .filter(item -> extractionId.equals(String.valueOf(item.getOrDefault("id", ""))))
-                .findFirst()
-                .orElse(null);
-        if (extraction == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
-        }
-        String approvalState = String.valueOf(extraction.getOrDefault("stt_approval_state", "pending"));
-        if (!"pending".equalsIgnoreCase(approvalState)) {
-            return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(ApiResponse.failure("STT_APPROVAL_NOT_PENDING", "승인 대기 상태가 아닌 STT입니다."));
-        }
-
-        String language = optionalOrDefault(body.language(), "ko");
-        Integer durationMs = body.duration_ms();
-        String sttProvider = optionalOrNull(body.stt_provider());
-        String sttModel = optionalOrNull(body.stt_model());
-        String audioUrl = optionalOrNull(String.valueOf(extraction.getOrDefault("audio_url", "")));
-
-        Map<String, Object> transcript = triggerLectureMetadataAutoSync(
-                lectureId,
-                mediaPipelineService.transcribe(
-                        lectureId,
-                        language,
-                        durationMs,
-                        sttProvider,
-                        sttModel,
-                        audioUrl,
-                        extractionId
-                )
-        );
-        Map<String, Object> syncPolicy = Map.of(
-                "mode", "approval",
-                "approval_state", "approved",
-                "overwrite_policy", String.valueOf(extraction.getOrDefault("stt_overwrite_policy", "overwrite")),
-                "notification_channel", String.valueOf(extraction.getOrDefault("stt_sync_notification_channel", "dashboard")),
-                "decision", "started_by_approval"
-        );
-        return ResponseEntity.ok(ApiResponse.success(
-                Map.of(
-                        "extraction_id", extractionId,
-                        "lecture_id", lectureId,
-                        "transcript", transcript,
-                        "pipeline", mediaPipelineService.pipeline(lectureId),
-                        "stt_sync_policy", syncPolicy
-                ),
-                "STT 승인 실행이 완료되었습니다."
-        ));
-    }
-
-    private Map<String, Object> triggerLectureMetadataAutoSync(String lectureId, Map<String, Object> transcribeResult) {
-        if (lectureId == null || lectureId.isBlank() || transcribeResult == null) {
-            return transcribeResult;
-        }
-        Map<String, Object> merged = new java.util.LinkedHashMap<>(transcribeResult);
-        merged.put("lecture_meta_sync", learningService.syncLectureMetadataForLectureFromTranscript(lectureId, false));
-        return merged;
-    }
-
-    private record CallbackPolicyDecision(boolean valid, String status, long eventVersion, String errorMessage) {
-        static CallbackPolicyDecision valid(String status, long eventVersion) {
-            return new CallbackPolicyDecision(true, status, eventVersion, null);
-        }
-
-        static CallbackPolicyDecision invalid(String errorMessage) {
-            return new CallbackPolicyDecision(false, null, 0L, errorMessage);
-        }
-    }
-
-    private record SttSyncPolicyDecision(
-            boolean valid,
-            String syncMode,
-            String overwritePolicy,
-            String approvalState,
-            String notificationChannel,
-            String errorMessage
-    ) {
-        static SttSyncPolicyDecision valid(String syncMode, String overwritePolicy, String approvalState, String notificationChannel) {
-            return new SttSyncPolicyDecision(true, syncMode, overwritePolicy, approvalState, notificationChannel, null);
-        }
-
-        static SttSyncPolicyDecision invalid(String errorMessage) {
-            return new SttSyncPolicyDecision(false, null, null, null, null, errorMessage);
-        }
-    }
-
-    private static final class CallbackStateTransitionPolicy {
-        private static CallbackPolicyDecision decide(ExtractionCallbackRequest body) {
-            long eventVersion = body.event_version() != null ? body.event_version() : 1L;
-            if (eventVersion < 1L) {
-                return CallbackPolicyDecision.invalid("event_version은 1 이상이어야 합니다.");
-            }
-            String status = body.status() == null ? "COMPLETED" : body.status().trim().toUpperCase();
-            if (!ALLOWED_CALLBACK_STATUSES.contains(status)) {
-                return CallbackPolicyDecision.invalid("status는 COMPLETED, FAILED, PROCESSING 중 하나여야 합니다.");
-            }
-            return CallbackPolicyDecision.valid(status, eventVersion);
-        }
-    }
-
-    private static final class SttSyncPolicy {
-        private static SttSyncPolicyDecision decide(ExtractionCallbackRequest body) {
-            String syncMode = body.sync_mode() == null ? "AUTO" : body.sync_mode().trim().toUpperCase();
-            String overwritePolicy = body.overwrite_policy() == null ? "OVERWRITE" : body.overwrite_policy().trim().toUpperCase();
-            String approvalState = body.approval_state() == null ? "PENDING" : body.approval_state().trim().toUpperCase();
-            String channel = body.notification_channel() == null ? "dashboard" : body.notification_channel().trim();
-            if (!ALLOWED_SYNC_MODES.contains(syncMode)) {
-                return SttSyncPolicyDecision.invalid("sync_mode는 auto 또는 approval 이어야 합니다.");
-            }
-            if (!ALLOWED_OVERWRITE_POLICIES.contains(overwritePolicy)) {
-                return SttSyncPolicyDecision.invalid("overwrite_policy는 overwrite 또는 skip_if_exists 이어야 합니다.");
-            }
-            if (!ALLOWED_APPROVAL_STATES.contains(approvalState)) {
-                return SttSyncPolicyDecision.invalid("approval_state는 approved 또는 pending 이어야 합니다.");
-            }
-            return SttSyncPolicyDecision.valid(syncMode, overwritePolicy, approvalState, channel.isBlank() ? "dashboard" : channel);
-        }
-    }
 
     private static final class SummaryResponseAssembler {
         private static Map<String, Object> assemble(Map<String, Object> note, String style, Map<String, Object> pipeline) {
@@ -672,117 +382,13 @@ public class MediaController {
         }
     }
 
-    private ResponseEntity<?> proxyRemoteAsset(String assetKey) {
-        if (remoteAssetBaseUrl.isBlank()) return null;
-        try {
-            String[] candidates = buildRemoteCandidates(assetKey);
-            for (String candidate : candidates) {
-                String encoded = java.net.URLEncoder.encode(candidate, StandardCharsets.UTF_8);
-                String target = remoteAssetBaseUrl.endsWith("/")
-                        ? remoteAssetBaseUrl + encoded
-                        : remoteAssetBaseUrl + "/" + encoded;
-                HttpRequest.Builder builder = HttpRequest.newBuilder()
-                        .uri(URI.create(target))
-                        .GET();
-                if (!remoteAssetToken.isBlank()) {
-                    builder.header("Authorization", "Bearer " + remoteAssetToken);
-                }
-                HttpResponse<byte[]> response = HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
-                if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                    continue;
-                }
-                ResponseEntity.BodyBuilder bodyBuilder = ResponseEntity.status(response.statusCode());
-                String contentType = response.headers().firstValue("content-type").orElse(null);
-                String contentDisposition = response.headers().firstValue("content-disposition").orElse(null);
-                if (contentType != null && !contentType.isBlank()) {
-                    bodyBuilder.header("Content-Type", contentType);
-                }
-                if (contentDisposition != null && !contentDisposition.isBlank()) {
-                    bodyBuilder.header("Content-Disposition", contentDisposition);
-                }
-                return bodyBuilder.body(response.body());
-            }
-        } catch (Exception ignored) {
-            return null;
+    private Map<String, Object> triggerLectureMetadataAutoSync(String lectureId, Map<String, Object> transcribeResult) {
+        if (lectureId == null || lectureId.isBlank() || transcribeResult == null) {
+            return transcribeResult;
         }
-        return null;
-    }
-
-    private String resolveQueryToken(String queryToken, HttpServletRequest request) {
-        String fromParam = trimOptional(queryToken);
-        if (!fromParam.isBlank()) return fromParam;
-        String fromRequestParam = trimOptional(request.getParameter("token"));
-        if (!fromRequestParam.isBlank()) return fromRequestParam;
-        String query = request.getQueryString();
-        if (query == null || query.isBlank()) return "";
-        for (String pair : query.split("&")) {
-            if (!pair.startsWith("token=")) continue;
-            String raw = pair.substring("token=".length());
-            if (raw.isBlank()) return "";
-            try {
-                return java.net.URLDecoder.decode(raw, StandardCharsets.UTF_8);
-            } catch (IllegalArgumentException ignored) {
-                return raw;
-            }
-        }
-        return "";
-    }
-
-    private boolean isPlaybackRequest(HttpServletRequest request, String queryToken) {
-        String range = trimOptional(request.getHeader("Range"));
-        String accept = trimOptional(request.getHeader("Accept")).toLowerCase();
-        return !range.isBlank() || accept.contains("video/") || !trimOptional(queryToken).isBlank();
-    }
-
-    private ResponseEntity<Void> playbackFailure(HttpStatus status, String code, String message) {
-        return ResponseEntity.status(status)
-                .header("X-Error-Code", code)
-                .header("X-Error-Message", message)
-                .build();
-    }
-
-    private ResponseEntity<Resource> fallbackLocalPlaybackAsset(String assetKey) {
-        Path[] candidates = new Path[] {
-                Path.of("temp-sample-10s.mp4"),
-                Path.of("..", "temp-sample-10s.mp4")
-        };
-        for (Path candidate : candidates) {
-            try {
-                if (!Files.exists(candidate) || !Files.isRegularFile(candidate)) {
-                    continue;
-                }
-                return ResponseEntity.ok()
-                        .contentType(MediaType.parseMediaType("video/mp4"))
-                        .header("Accept-Ranges", "bytes")
-                        .header("X-Playback-Fallback", "local-sample")
-                        .header("X-Playback-Asset-Key", assetKey)
-                        .body(new FileSystemResource(candidate.toFile()));
-            } catch (Exception ignored) {
-                return null;
-            }
-        }
-        return null;
-    }
-
-    private String[] buildRemoteCandidates(String assetKey) {
-        String trimmed = trimOptional(assetKey);
-        if (trimmed.isBlank()) return new String[0];
-        String[] segments = trimmed.split("/");
-        String last = segments[segments.length - 1];
-        if (last.endsWith(".mp4")) {
-            return new String[] {trimmed, last};
-        }
-        return new String[] {trimmed, last, last + ".mp4"};
-    }
-
-    private String normalizeRemoteAssetBaseUrl(String configuredBaseUrl) {
-        String trimmed = configuredBaseUrl == null ? "" : configuredBaseUrl.trim();
-        if (trimmed.isBlank()) return "";
-        String lowered = trimmed.toLowerCase();
-        if (lowered.contains("/api/v1/media/assets")) {
-            return "http://127.0.0.1:8788/assets";
-        }
-        return trimmed;
+        Map<String, Object> merged = new java.util.LinkedHashMap<>(transcribeResult);
+        merged.put("lecture_meta_sync", learningService.syncLectureMetadataForLectureFromTranscript(lectureId, false));
+        return merged;
     }
 
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/MediaSttOrchestrationController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/MediaSttOrchestrationController.java
@@ -1,0 +1,226 @@
+package com.myway.backendspring.api;
+
+import com.myway.backendspring.api.support.MediaCallbackPolicy;
+import com.myway.backendspring.auth.RolePolicy;
+import com.myway.backendspring.auth.SessionService;
+import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.DemoLearningService;
+import com.myway.backendspring.feature.media.MediaPipelineService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/media")
+public class MediaSttOrchestrationController {
+    public record ExtractionCallbackRequest(
+            @NotBlank String extraction_id,
+            String lecture_id,
+            String status,
+            String error_message,
+            Long event_version,
+            String audio_url,
+            String processing_job_id,
+            String processing_stage,
+            String processing_step,
+            String audio_format,
+            Integer sample_rate,
+            Integer channels,
+            String sync_mode,
+            String overwrite_policy,
+            String approval_state,
+            String notification_channel
+    ) {}
+
+    public record ApproveSttRequest(
+            @NotBlank String lecture_id,
+            String language,
+            Integer duration_ms,
+            String stt_provider,
+            String stt_model
+    ) {}
+
+    private final SessionService sessionService;
+    private final MediaPipelineService mediaPipelineService;
+    private final DemoLearningService learningService;
+    private final String callbackToken;
+
+    public MediaSttOrchestrationController(
+            SessionService sessionService,
+            MediaPipelineService mediaPipelineService,
+            DemoLearningService learningService,
+            @Value("${myway.media.callback.token:dev-media-callback-token}") String callbackToken
+    ) {
+        this.sessionService = sessionService;
+        this.mediaPipelineService = mediaPipelineService;
+        this.learningService = learningService;
+        this.callbackToken = callbackToken;
+    }
+
+    @PostMapping("/extract-audio/callback")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> callback(
+            @RequestHeader(value = "X-Callback-Token", required = false) String token,
+            @RequestHeader(value = "x-myway-media-callback-secret", required = false) String callbackSecret,
+            @Valid @RequestBody ExtractionCallbackRequest body
+    ) {
+        String resolvedToken = (token != null && !token.isBlank()) ? token : callbackSecret;
+        if (resolvedToken == null || resolvedToken.isBlank() || !resolvedToken.equals(callbackToken)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("CALLBACK_UNAUTHORIZED", "유효한 callback token이 필요합니다."));
+        }
+        String extractionId = body.extraction_id().trim();
+        MediaCallbackPolicy.CallbackPolicyDecision decision = MediaCallbackPolicy.decideCallback(body.event_version(), body.status());
+        if (!decision.valid()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID_PAYLOAD", decision.errorMessage()));
+        }
+        MediaCallbackPolicy.SttSyncPolicyDecision sttPolicy = MediaCallbackPolicy.decideSttSync(
+                body.sync_mode(), body.overwrite_policy(), body.approval_state(), body.notification_channel()
+        );
+        if (!sttPolicy.valid()) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure("CALLBACK_INVALID_PAYLOAD", sttPolicy.errorMessage()));
+        }
+        String errorMessage = body.error_message();
+        String audioUrl = optionalOrNull(body.audio_url());
+        Map<String, Object> result = mediaPipelineService.completeExtractionCallback(
+                extractionId,
+                decision.status(),
+                errorMessage,
+                decision.eventVersion(),
+                audioUrl,
+                body.processing_job_id(),
+                body.processing_stage(),
+                body.processing_step(),
+                body.audio_format(),
+                body.sample_rate(),
+                body.channels(),
+                sttPolicy.syncMode(),
+                sttPolicy.overwritePolicy(),
+                sttPolicy.approvalState(),
+                sttPolicy.notificationChannel()
+        );
+        if (result == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("CALLBACK_EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
+        }
+        if (Boolean.TRUE.equals(result.get("callback_ignored"))) {
+            return ResponseEntity.ok(ApiResponse.success(
+                    Map.of("extraction", result, "pipeline", mediaPipelineService.pipeline(String.valueOf(result.getOrDefault("lecture_id", "")))),
+                    "오래된 callback 이벤트를 무시했습니다."
+            ));
+        }
+        String lectureId = String.valueOf(result.getOrDefault("lecture_id", "")).trim();
+        Map<String, Object> transcribeResult = null;
+        boolean callbackWantsStt = "COMPLETED".equalsIgnoreCase(decision.status())
+                || "transcribing".equalsIgnoreCase(String.valueOf(result.getOrDefault("processing_stage", "")));
+        boolean hasTranscript = !lectureId.isBlank() && mediaPipelineService.transcript(lectureId) != null;
+        String syncDecision = "started";
+        if ("APPROVAL".equals(sttPolicy.syncMode()) && !"APPROVED".equals(sttPolicy.approvalState())) {
+            syncDecision = "awaiting_approval";
+        } else if ("SKIP_IF_EXISTS".equals(sttPolicy.overwritePolicy()) && hasTranscript) {
+            syncDecision = "skipped_existing_transcript";
+        }
+        boolean shouldStartStt = callbackWantsStt && "started".equals(syncDecision) && !lectureId.isBlank();
+        if (shouldStartStt) {
+            transcribeResult = mediaPipelineService.transcribe(lectureId, "ko", null, null, null, audioUrl, extractionId);
+        }
+        Map<String, Object> syncPolicyPayload = Map.of(
+                "mode", sttPolicy.syncMode().toLowerCase(),
+                "approval_state", sttPolicy.approvalState().toLowerCase(),
+                "overwrite_policy", sttPolicy.overwritePolicy().toLowerCase(),
+                "notification_channel", sttPolicy.notificationChannel(),
+                "decision", syncDecision
+        );
+        Map<String, Object> syncMetricsPayload = Map.of(
+                "callback_events", 1,
+                "auto_started", shouldStartStt ? 1 : 0,
+                "approval_pending", "awaiting_approval".equals(syncDecision) ? 1 : 0,
+                "overwrite_skipped", "skipped_existing_transcript".equals(syncDecision) ? 1 : 0,
+                "notifications", 1
+        );
+
+        if (transcribeResult == null) {
+            return ResponseEntity.ok(ApiResponse.success(
+                    Map.of("extraction", result, "pipeline", mediaPipelineService.pipeline(lectureId), "stt_sync_policy", syncPolicyPayload, "stt_sync_metrics", syncMetricsPayload),
+                    "오디오 추출 callback이 반영되었습니다."
+            ));
+        }
+
+        Map<String, Object> transcribeWithMeta = triggerLectureMetadataAutoSync(lectureId, transcribeResult);
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of("extraction", result, "pipeline", mediaPipelineService.pipeline(lectureId), "transcript", transcribeWithMeta, "stt_sync_policy", syncPolicyPayload, "stt_sync_metrics", syncMetricsPayload),
+                "오디오 추출 callback이 반영되어 STT가 자동 시작되었습니다."
+        ));
+    }
+
+    @PostMapping("/extract-audio/{extractionId}/approve-stt")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> approveStt(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String extractionId,
+            @Valid @RequestBody ApproveSttRequest body
+    ) {
+        SessionView session = sessionService.me(auth);
+        if (session == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
+        if (!RolePolicy.canManageCourses(session.user().role())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure("FORBIDDEN", "STT 승인 실행은 강사와 운영자만 사용할 수 있습니다."));
+        }
+        String lectureId = body.lecture_id().trim();
+        Map<String, Object> extraction = mediaPipelineService.extractions(lectureId).stream()
+                .filter(item -> extractionId.equals(String.valueOf(item.getOrDefault("id", ""))))
+                .findFirst()
+                .orElse(null);
+        if (extraction == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("EXTRACTION_NOT_FOUND", "오디오 추출 기록을 찾을 수 없습니다."));
+        }
+        String approvalState = String.valueOf(extraction.getOrDefault("stt_approval_state", "pending"));
+        if (!"pending".equalsIgnoreCase(approvalState)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.failure("STT_APPROVAL_NOT_PENDING", "승인 대기 상태가 아닌 STT입니다."));
+        }
+
+        String language = optionalOrDefault(body.language(), "ko");
+        Integer durationMs = body.duration_ms();
+        String sttProvider = optionalOrNull(body.stt_provider());
+        String sttModel = optionalOrNull(body.stt_model());
+        String audioUrl = optionalOrNull(String.valueOf(extraction.getOrDefault("audio_url", "")));
+
+        Map<String, Object> transcript = triggerLectureMetadataAutoSync(
+                lectureId,
+                mediaPipelineService.transcribe(lectureId, language, durationMs, sttProvider, sttModel, audioUrl, extractionId)
+        );
+        Map<String, Object> syncPolicy = Map.of(
+                "mode", "approval",
+                "approval_state", "approved",
+                "overwrite_policy", String.valueOf(extraction.getOrDefault("stt_overwrite_policy", "overwrite")),
+                "notification_channel", String.valueOf(extraction.getOrDefault("stt_sync_notification_channel", "dashboard")),
+                "decision", "started_by_approval"
+        );
+        return ResponseEntity.ok(ApiResponse.success(
+                Map.of("extraction_id", extractionId, "lecture_id", lectureId, "transcript", transcript, "pipeline", mediaPipelineService.pipeline(lectureId), "stt_sync_policy", syncPolicy),
+                "STT 승인 실행이 완료되었습니다."
+        ));
+    }
+
+    private Map<String, Object> triggerLectureMetadataAutoSync(String lectureId, Map<String, Object> transcribeResult) {
+        if (lectureId == null || lectureId.isBlank() || transcribeResult == null) return transcribeResult;
+        Map<String, Object> merged = new java.util.LinkedHashMap<>(transcribeResult);
+        merged.put("lecture_meta_sync", learningService.syncLectureMetadataForLectureFromTranscript(lectureId, false));
+        return merged;
+    }
+
+    private String optionalOrNull(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? null : trimmed;
+    }
+
+    private String optionalOrDefault(String value, String defaultValue) {
+        if (value == null) return defaultValue;
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? defaultValue : trimmed;
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
@@ -47,6 +47,7 @@ public class NotImplementedController {
 
     private final AiController aiController;
     private final MediaController mediaController;
+    private final MediaSttOrchestrationController mediaSttOrchestrationController;
     private final ShortformController shortformController;
     private final DemoLearningService learningService;
     private final SessionService sessionService;
@@ -55,6 +56,7 @@ public class NotImplementedController {
     public NotImplementedController(
             AiController aiController,
             MediaController mediaController,
+            MediaSttOrchestrationController mediaSttOrchestrationController,
             ShortformController shortformController,
             DemoLearningService learningService,
             SessionService sessionService,
@@ -62,6 +64,7 @@ public class NotImplementedController {
     ) {
         this.aiController = aiController;
         this.mediaController = mediaController;
+        this.mediaSttOrchestrationController = mediaSttOrchestrationController;
         this.shortformController = shortformController;
         this.learningService = learningService;
         this.sessionService = sessionService;
@@ -302,9 +305,9 @@ public class NotImplementedController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaExtractAudioCallback(
             @RequestHeader(value = "X-Callback-Token", required = false) String token,
             @RequestHeader(value = "x-myway-media-callback-secret", required = false) String callbackSecret,
-            @RequestBody MediaController.ExtractionCallbackRequest body
+            @RequestBody MediaSttOrchestrationController.ExtractionCallbackRequest body
     ) {
-        return mediaController.callback(token, callbackSecret, body);
+        return mediaSttOrchestrationController.callback(token, callbackSecret, body);
     }
 
     @PostMapping("/legacy/media/upload-video")

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/MediaAssetPlaybackSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/MediaAssetPlaybackSupport.java
@@ -1,0 +1,139 @@
+package com.myway.backendspring.api.support;
+
+import com.myway.backendspring.common.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component
+public class MediaAssetPlaybackSupport {
+    private final String remoteAssetBaseUrl;
+    private final String remoteAssetToken;
+
+    public MediaAssetPlaybackSupport(
+            @Value("${myway.media.asset-proxy.base-url:}") String remoteAssetBaseUrl,
+            @Value("${myway.media.asset-proxy.token:}") String remoteAssetToken
+    ) {
+        this.remoteAssetBaseUrl = normalizeRemoteAssetBaseUrl(remoteAssetBaseUrl);
+        this.remoteAssetToken = remoteAssetToken == null ? "" : remoteAssetToken.trim();
+    }
+
+    public ResponseEntity<?> proxyRemoteAsset(String assetKey) {
+        if (remoteAssetBaseUrl.isBlank()) return null;
+        try {
+            String[] candidates = buildRemoteCandidates(assetKey);
+            for (String candidate : candidates) {
+                String encoded = java.net.URLEncoder.encode(candidate, StandardCharsets.UTF_8);
+                String target = remoteAssetBaseUrl.endsWith("/")
+                        ? remoteAssetBaseUrl + encoded
+                        : remoteAssetBaseUrl + "/" + encoded;
+                HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create(target)).GET();
+                if (!remoteAssetToken.isBlank()) {
+                    builder.header("Authorization", "Bearer " + remoteAssetToken);
+                }
+                HttpResponse<byte[]> response = HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
+                if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                    continue;
+                }
+                ResponseEntity.BodyBuilder bodyBuilder = ResponseEntity.status(response.statusCode());
+                String contentType = response.headers().firstValue("content-type").orElse(null);
+                String contentDisposition = response.headers().firstValue("content-disposition").orElse(null);
+                if (contentType != null && !contentType.isBlank()) bodyBuilder.header("Content-Type", contentType);
+                if (contentDisposition != null && !contentDisposition.isBlank()) bodyBuilder.header("Content-Disposition", contentDisposition);
+                return bodyBuilder.body(response.body());
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+        return null;
+    }
+
+    public String resolveQueryToken(String queryToken, HttpServletRequest request) {
+        String fromParam = trimOptional(queryToken);
+        if (!fromParam.isBlank()) return fromParam;
+        String fromRequestParam = trimOptional(request.getParameter("token"));
+        if (!fromRequestParam.isBlank()) return fromRequestParam;
+        String query = request.getQueryString();
+        if (query == null || query.isBlank()) return "";
+        for (String pair : query.split("&")) {
+            if (!pair.startsWith("token=")) continue;
+            String raw = pair.substring("token=".length());
+            if (raw.isBlank()) return "";
+            try {
+                return java.net.URLDecoder.decode(raw, StandardCharsets.UTF_8);
+            } catch (IllegalArgumentException ignored) {
+                return raw;
+            }
+        }
+        return "";
+    }
+
+    public boolean isPlaybackRequest(HttpServletRequest request, String queryToken) {
+        String range = trimOptional(request.getHeader("Range"));
+        String accept = trimOptional(request.getHeader("Accept")).toLowerCase();
+        return !range.isBlank() || accept.contains("video/") || !trimOptional(queryToken).isBlank();
+    }
+
+    public ResponseEntity<Void> playbackFailure(HttpStatus status, String code, String message) {
+        return ResponseEntity.status(status)
+                .header("X-Error-Code", code)
+                .header("X-Error-Message", message)
+                .build();
+    }
+
+    public ResponseEntity<Resource> fallbackLocalPlaybackAsset(String assetKey) {
+        Path[] candidates = new Path[] {Path.of("temp-sample-10s.mp4"), Path.of("..", "temp-sample-10s.mp4")};
+        for (Path candidate : candidates) {
+            try {
+                if (!Files.exists(candidate) || !Files.isRegularFile(candidate)) continue;
+                return ResponseEntity.ok()
+                        .contentType(MediaType.parseMediaType("video/mp4"))
+                        .header("Accept-Ranges", "bytes")
+                        .header("X-Playback-Fallback", "local-sample")
+                        .header("X-Playback-Asset-Key", assetKey)
+                        .body(new FileSystemResource(candidate.toFile()));
+            } catch (Exception ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public ResponseEntity<ApiResponse<Object>> assetNotFound() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("ASSET_NOT_FOUND", "미디어 파일을 찾을 수 없습니다."));
+    }
+
+    private String[] buildRemoteCandidates(String assetKey) {
+        String trimmed = trimOptional(assetKey);
+        if (trimmed.isBlank()) return new String[0];
+        String[] segments = trimmed.split("/");
+        String last = segments[segments.length - 1];
+        if (last.endsWith(".mp4")) return new String[] {trimmed, last};
+        return new String[] {trimmed, last, last + ".mp4"};
+    }
+
+    private String normalizeRemoteAssetBaseUrl(String configuredBaseUrl) {
+        String trimmed = configuredBaseUrl == null ? "" : configuredBaseUrl.trim();
+        if (trimmed.isBlank()) return "";
+        String lowered = trimmed.toLowerCase();
+        if (lowered.contains("/api/v1/media/assets")) return "http://127.0.0.1:8788/assets";
+        return trimmed;
+    }
+
+    private String trimOptional(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/MediaCallbackPolicy.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/MediaCallbackPolicy.java
@@ -1,0 +1,74 @@
+package com.myway.backendspring.api.support;
+
+import java.util.Set;
+
+public final class MediaCallbackPolicy {
+    private static final Set<String> ALLOWED_CALLBACK_STATUSES = Set.of("COMPLETED", "FAILED", "PROCESSING");
+    private static final Set<String> ALLOWED_SYNC_MODES = Set.of("AUTO", "APPROVAL");
+    private static final Set<String> ALLOWED_OVERWRITE_POLICIES = Set.of("OVERWRITE", "SKIP_IF_EXISTS");
+    private static final Set<String> ALLOWED_APPROVAL_STATES = Set.of("APPROVED", "PENDING");
+
+    private MediaCallbackPolicy() {}
+
+    public record CallbackPolicyDecision(boolean valid, String status, long eventVersion, String errorMessage) {
+        public static CallbackPolicyDecision valid(String status, long eventVersion) {
+            return new CallbackPolicyDecision(true, status, eventVersion, null);
+        }
+
+        public static CallbackPolicyDecision invalid(String errorMessage) {
+            return new CallbackPolicyDecision(false, null, 0L, errorMessage);
+        }
+    }
+
+    public record SttSyncPolicyDecision(
+            boolean valid,
+            String syncMode,
+            String overwritePolicy,
+            String approvalState,
+            String notificationChannel,
+            String errorMessage
+    ) {
+        public static SttSyncPolicyDecision valid(String syncMode, String overwritePolicy, String approvalState, String notificationChannel) {
+            return new SttSyncPolicyDecision(true, syncMode, overwritePolicy, approvalState, notificationChannel, null);
+        }
+
+        public static SttSyncPolicyDecision invalid(String errorMessage) {
+            return new SttSyncPolicyDecision(false, null, null, null, null, errorMessage);
+        }
+    }
+
+    public static CallbackPolicyDecision decideCallback(Long eventVersion, String status) {
+        long resolvedEventVersion = eventVersion != null ? eventVersion : 1L;
+        if (resolvedEventVersion < 1L) {
+            return CallbackPolicyDecision.invalid("event_version은 1 이상이어야 합니다.");
+        }
+        String resolvedStatus = status == null ? "COMPLETED" : status.trim().toUpperCase();
+        if (!ALLOWED_CALLBACK_STATUSES.contains(resolvedStatus)) {
+            return CallbackPolicyDecision.invalid("status는 COMPLETED, FAILED, PROCESSING 중 하나여야 합니다.");
+        }
+        return CallbackPolicyDecision.valid(resolvedStatus, resolvedEventVersion);
+    }
+
+    public static SttSyncPolicyDecision decideSttSync(String syncMode, String overwritePolicy, String approvalState, String notificationChannel) {
+        String resolvedSyncMode = syncMode == null ? "AUTO" : syncMode.trim().toUpperCase();
+        String resolvedOverwritePolicy = overwritePolicy == null ? "OVERWRITE" : overwritePolicy.trim().toUpperCase();
+        String resolvedApprovalState = approvalState == null ? "PENDING" : approvalState.trim().toUpperCase();
+        String resolvedChannel = notificationChannel == null ? "dashboard" : notificationChannel.trim();
+
+        if (!ALLOWED_SYNC_MODES.contains(resolvedSyncMode)) {
+            return SttSyncPolicyDecision.invalid("sync_mode는 auto 또는 approval 이어야 합니다.");
+        }
+        if (!ALLOWED_OVERWRITE_POLICIES.contains(resolvedOverwritePolicy)) {
+            return SttSyncPolicyDecision.invalid("overwrite_policy는 overwrite 또는 skip_if_exists 이어야 합니다.");
+        }
+        if (!ALLOWED_APPROVAL_STATES.contains(resolvedApprovalState)) {
+            return SttSyncPolicyDecision.invalid("approval_state는 approved 또는 pending 이어야 합니다.");
+        }
+        return SttSyncPolicyDecision.valid(
+                resolvedSyncMode,
+                resolvedOverwritePolicy,
+                resolvedApprovalState,
+                resolvedChannel.isBlank() ? "dashboard" : resolvedChannel
+        );
+    }
+}


### PR DESCRIPTION
# 변경 요약
MediaController의 다중 책임을 분리해 컨트롤러를 슬림화하고, STT 콜백/승인 오케스트레이션과 재생 프록시 지원 로직을 별도 클래스로 이동했습니다.

## 배경
MediaController가 700줄+ 규모로 인증/검증/재생/콜백 오케스트레이션을 동시에 처리해 변경 영향 범위가 컸습니다. SRP 기준으로 책임을 분리해 유지보수성과 테스트 가능성을 개선해야 했습니다.

## 변경 내용
- `MediaController`에서 아래 책임을 분리
  - STT callback/approve 흐름 -> `MediaSttOrchestrationController`
  - 자산 프록시/재생 fallback/토큰 파싱 -> `MediaAssetPlaybackSupport`
  - callback 정책 검증 -> `MediaCallbackPolicy`
- `NotImplementedController`의 legacy callback 위임 대상 변경
  - `MediaController.ExtractionCallbackRequest` -> `MediaSttOrchestrationController.ExtractionCallbackRequest`

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:backend` 통과
- layer tests: 백엔드 패키지 빌드(-DskipTests) 통과
- risk/rollback: 단일 커밋 revert로 즉시 롤백 가능

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: 해당 없음
