### PR TITLE
fix(media): normalize source urls and align processor auth headers

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/LegacyAiBridgeController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/LegacyAiBridgeController.java
@@ -1,0 +1,181 @@
+package com.myway.backendspring.api;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.myway.backendspring.auth.SessionService;
+import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.feature.FeatureStoreService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@RestController
+@RequestMapping("/api/v1/legacy/ai")
+public class LegacyAiBridgeController {
+    public static final class LegacyBody {
+        private final Map<String, Object> payload = new HashMap<>();
+
+        @JsonAnySetter
+        public void put(String key, Object value) {
+            payload.put(key, value);
+        }
+
+        public Map<String, Object> payload() {
+            return payload;
+        }
+    }
+
+    private final AiController aiController;
+    private final SessionService sessionService;
+    private final FeatureStoreService featureStore;
+
+    public LegacyAiBridgeController(
+            AiController aiController,
+            SessionService sessionService,
+            FeatureStoreService featureStore
+    ) {
+        this.aiController = aiController;
+        this.sessionService = sessionService;
+        this.featureStore = featureStore;
+    }
+
+    @GetMapping("/settings")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiSettings(@RequestHeader(value = "Authorization", required = false) String auth) {
+        return withUserId(auth, userId ->
+                ResponseEntity.ok(ApiResponse.success(featureStore.aiSettings(userId), "legacy ai settings 응답을 /api/v1/ai/settings와 동일하게 반환했습니다."))
+        );
+    }
+
+    @GetMapping("/providers")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiProviders(@RequestHeader(value = "Authorization", required = false) String auth) {
+        return withUserId(auth, userId ->
+                ResponseEntity.ok(ApiResponse.success(featureStore.aiProviders(userId), "legacy ai providers 응답을 /api/v1/ai/providers와 동일하게 반환했습니다."))
+        );
+    }
+
+    @GetMapping("/insights")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiInsights(@RequestHeader(value = "Authorization", required = false) String auth) {
+        return withUserId(auth, userId ->
+                ResponseEntity.ok(ApiResponse.success(featureStore.aiInsights(userId), "legacy ai insights 응답을 /api/v1/ai/insights와 동일하게 반환했습니다."))
+        );
+    }
+
+    @GetMapping("/recommendations")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiRecommendations(@RequestHeader(value = "Authorization", required = false) String auth) {
+        return withUserId(auth, userId ->
+                ResponseEntity.ok(ApiResponse.success(featureStore.aiRecommendations(userId), "legacy ai recommendations 응답을 /api/v1/ai/recommendations와 동일하게 반환했습니다."))
+        );
+    }
+
+    @GetMapping("/logs")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiLogs(@RequestHeader(value = "Authorization", required = false) String auth) {
+        return withUserId(auth, userId ->
+                ResponseEntity.ok(ApiResponse.success(featureStore.aiLogs(userId), "legacy ai logs 응답을 /api/v1/ai/logs와 동일하게 반환했습니다."))
+        );
+    }
+
+    @PostMapping("/settings")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiUpdateSettings(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        return aiController.updateSettings(auth, new AiController.AiSettingsUpdateRequest(payloadOf(body)));
+    }
+
+    @PutMapping("/settings")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiPutSettings(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        return aiController.putSettings(auth, new AiController.AiSettingsUpdateRequest(payloadOf(body)));
+    }
+
+    @PostMapping("/intent")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiIntent(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return aiController.intent(auth, new AiController.IntentRequest(
+                text(payload, "message"),
+                text(payload, "lecture_id")
+        ));
+    }
+
+    @PostMapping("/search")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiSearch(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return aiController.search(auth, new AiController.SearchRequest(
+                text(payload, "query"),
+                text(payload, "lecture_id")
+        ));
+    }
+
+    @PostMapping("/answer")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiAnswer(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return aiController.answer(auth, new AiController.AnswerRequest(
+                text(payload, "question"),
+                text(payload, "lecture_id")
+        ));
+    }
+
+    @PostMapping("/summary")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiSummary(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return aiController.summary(auth, new AiController.SummaryRequest(
+                text(payload, "lecture_id"),
+                text(payload, "style"),
+                text(payload, "language")
+        ));
+    }
+
+    @PostMapping("/quiz")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiQuiz(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return aiController.quiz(auth, new AiController.QuizRequest(text(payload, "lecture_id")));
+    }
+
+    private Map<String, Object> payloadOf(LegacyBody body) {
+        return body == null ? Map.of() : body.payload();
+    }
+
+    private String text(Map<String, Object> body, String key) {
+        if (body == null || body.get(key) == null) return "";
+        return String.valueOf(body.get(key)).trim();
+    }
+
+    private String requireUserId(String auth) {
+        var session = sessionService.me(auth);
+        return session == null ? null : session.user().id();
+    }
+
+    private <T> ResponseEntity<ApiResponse<T>> withUserId(String auth, Function<String, ResponseEntity<ApiResponse<T>>> action) {
+        String userId = requireUserId(auth);
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
+        return action.apply(userId);
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/api/LegacyMediaBridgeController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/LegacyMediaBridgeController.java
@@ -1,0 +1,214 @@
+package com.myway.backendspring.api;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.myway.backendspring.auth.SessionService;
+import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.feature.FeatureStoreService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+@RestController
+@RequestMapping("/api/v1/legacy/media")
+public class LegacyMediaBridgeController {
+    public static final class LegacyBody {
+        private final Map<String, Object> payload = new HashMap<>();
+
+        @JsonAnySetter
+        public void put(String key, Object value) {
+            payload.put(key, value);
+        }
+
+        public Map<String, Object> payload() {
+            return payload;
+        }
+    }
+
+    private final MediaController mediaController;
+    private final MediaSttOrchestrationController mediaSttOrchestrationController;
+    private final FeatureStoreService featureStore;
+    private final SessionService sessionService;
+
+    public LegacyMediaBridgeController(
+            MediaController mediaController,
+            MediaSttOrchestrationController mediaSttOrchestrationController,
+            FeatureStoreService featureStore,
+            SessionService sessionService
+    ) {
+        this.mediaController = mediaController;
+        this.mediaSttOrchestrationController = mediaSttOrchestrationController;
+        this.featureStore = featureStore;
+        this.sessionService = sessionService;
+    }
+
+    @GetMapping("/providers")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaProviders(@RequestHeader(value = "Authorization", required = false) String auth) {
+        return withUserId(auth, userId ->
+                ResponseEntity.ok(ApiResponse.success(featureStore.sttProviders(), "legacy media providers 응답을 /api/v1/media/providers와 동일하게 반환했습니다."))
+        );
+    }
+
+    @GetMapping("/processor-health")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaProcessorHealth(@RequestHeader(value = "Authorization", required = false) String auth) {
+        return withUserId(auth, userId ->
+                ResponseEntity.ok(ApiResponse.success(featureStore.processorHealth(), "legacy media processor health 응답을 /api/v1/media/processor-health와 동일하게 반환했습니다."))
+        );
+    }
+
+    @GetMapping("/pipeline/{lectureId}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaPipeline(
+            @PathVariable String lectureId,
+            @RequestHeader(value = "Authorization", required = false) String auth
+    ) {
+        return withUserId(auth, userId ->
+                ResponseEntity.ok(ApiResponse.success(featureStore.pipeline(lectureId), "legacy media pipeline 응답을 /api/v1/media/pipeline/{lectureId}와 동일하게 반환했습니다."))
+        );
+    }
+
+    @PostMapping("/extract-audio")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaExtractAudio(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return mediaController.extract(auth, new MediaController.ExtractAudioRequest(
+                text(payload, "lecture_id"),
+                text(payload, "audio_url")
+        ));
+    }
+
+    @PostMapping("/transcribe")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaTranscribe(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return mediaController.transcribe(auth, new MediaController.TranscribeRequest(
+                text(payload, "lecture_id"),
+                text(payload, "language"),
+                intOrNull(payload, "duration_ms"),
+                text(payload, "stt_provider"),
+                text(payload, "stt_model"),
+                text(payload, "audio_url")
+        ));
+    }
+
+    @PostMapping("/summarize")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaSummarize(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return mediaController.summarize(auth, new MediaController.SummarizeRequest(
+                text(payload, "lecture_id"),
+                text(payload, "style"),
+                text(payload, "language")
+        ));
+    }
+
+    @GetMapping("/audio-extractions/{lectureId}")
+    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyMediaAudioExtractions(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String lectureId
+    ) {
+        return mediaController.audioExtractions(auth, lectureId);
+    }
+
+    @GetMapping("/transcript/{lectureId}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaTranscript(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String lectureId
+    ) {
+        return mediaController.transcript(auth, lectureId);
+    }
+
+    @GetMapping("/notes/{lectureId}")
+    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyMediaNotes(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String lectureId
+    ) {
+        return mediaController.notes(auth, lectureId);
+    }
+
+    @PostMapping("/extract-audio/callback")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaExtractAudioCallback(
+            @RequestHeader(value = "X-Callback-Token", required = false) String token,
+            @RequestHeader(value = "x-myway-media-callback-secret", required = false) String callbackSecret,
+            @RequestBody MediaSttOrchestrationController.ExtractionCallbackRequest body
+    ) {
+        return mediaSttOrchestrationController.callback(token, callbackSecret, body);
+    }
+
+    @PostMapping("/upload-video")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaUploadVideo(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestParam("lecture_id") String lectureId,
+            @RequestParam(value = "video_file", required = false) MultipartFile file
+    ) {
+        return mediaController.upload(auth, lectureId, file);
+    }
+
+    @GetMapping("/assets/**")
+    public ResponseEntity<?> legacyMediaAssets(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestHeader(value = "X-Processor-Token", required = false) String processorToken,
+            HttpServletRequest request
+    ) {
+        String path = String.valueOf(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE));
+        String legacyPrefix = "/api/v1/legacy/media/assets/";
+        if (path.startsWith(legacyPrefix)) {
+            String suffix = path.substring(legacyPrefix.length());
+            request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/api/v1/media/assets/" + suffix);
+        }
+        return mediaController.assets(auth, processorToken, request);
+    }
+
+    private String text(Map<String, Object> body, String key) {
+        if (body == null || body.get(key) == null) return "";
+        return String.valueOf(body.get(key)).trim();
+    }
+
+    private Map<String, Object> payloadOf(LegacyBody body) {
+        return body == null ? Map.of() : body.payload();
+    }
+
+    private Integer intOrNull(Map<String, Object> body, String key) {
+        if (body == null) return null;
+        Object raw = body.get(key);
+        if (raw instanceof Number number) return number.intValue();
+        if (raw == null) return null;
+        try {
+            return Integer.parseInt(String.valueOf(raw));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private String requireUserId(String auth) {
+        var session = sessionService.me(auth);
+        return session == null ? null : session.user().id();
+    }
+
+    private <T> ResponseEntity<ApiResponse<T>> withUserId(String auth, Function<String, ResponseEntity<ApiResponse<T>>> action) {
+        String userId = requireUserId(auth);
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+        }
+        return action.apply(userId);
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/api/LegacyShortformBridgeController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/LegacyShortformBridgeController.java
@@ -1,0 +1,198 @@
+package com.myway.backendspring.api;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.myway.backendspring.auth.SessionService;
+import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.feature.FeatureStoreService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/legacy/shortform")
+public class LegacyShortformBridgeController {
+    public static final class LegacyBody {
+        private final Map<String, Object> payload = new HashMap<>();
+
+        @JsonAnySetter
+        public void put(String key, Object value) {
+            payload.put(key, value);
+        }
+
+        public Map<String, Object> payload() {
+            return payload;
+        }
+    }
+
+    private final ShortformController shortformController;
+    private final FeatureStoreService featureStore;
+    private final SessionService sessionService;
+
+    public LegacyShortformBridgeController(
+            ShortformController shortformController,
+            FeatureStoreService featureStore,
+            SessionService sessionService
+    ) {
+        this.shortformController = shortformController;
+        this.featureStore = featureStore;
+        this.sessionService = sessionService;
+    }
+
+    @GetMapping("/library")
+    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyShortformLibrary(@RequestHeader(value = "Authorization", required = false) String auth) {
+        String userId = requireUserId(auth);
+        if (userId == null) return unauthenticated();
+        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformLibrary(userId), "legacy shortform library 응답을 /api/v1/shortform/library와 동일하게 반환했습니다."));
+    }
+
+    @GetMapping("/community")
+    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyShortformCommunity(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestParam(value = "course_id", required = false) String courseId
+    ) {
+        if (requireUserId(auth) == null) return unauthenticated();
+        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformCommunity(courseId), "legacy shortform community 응답을 /api/v1/shortform/community와 동일하게 반환했습니다."));
+    }
+
+    @GetMapping("/videos/my")
+    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyShortformVideos(@RequestHeader(value = "Authorization", required = false) String auth) {
+        String userId = requireUserId(auth);
+        if (userId == null) return unauthenticated();
+        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformVideos(userId), "legacy shortform videos 응답을 /api/v1/shortform/videos/my와 동일하게 반환했습니다."));
+    }
+
+    @PostMapping("/generate")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformGenerate(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return shortformController.generate(auth, new ShortformController.GenerateRequest(
+                text(payload, "course_id"),
+                text(payload, "mode")
+        ));
+    }
+
+    @PutMapping("/candidates/select")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformSelect(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return shortformController.select(auth, new ShortformController.SelectCandidatesRequest(
+                text(payload, "extraction_id"),
+                listOfString(payload, "candidate_ids")
+        ));
+    }
+
+    @GetMapping("/extraction/{id}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformExtraction(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String id
+    ) {
+        return shortformController.extraction(auth, id);
+    }
+
+    @PostMapping("/compose")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformCompose(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return shortformController.compose(auth, new ShortformController.ComposeRequest(
+                text(payload, "title"),
+                text(payload, "description"),
+                text(payload, "course_id")
+        ));
+    }
+
+    @GetMapping("/video/{id}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformVideo(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String id
+    ) {
+        return shortformController.video(auth, id);
+    }
+
+    @PostMapping("/share")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformShare(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return shortformController.share(auth, new ShortformController.ShareRequest(
+                text(payload, "video_id"),
+                text(payload, "course_id"),
+                text(payload, "visibility"),
+                text(payload, "message")
+        ));
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformSave(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return shortformController.save(auth, new ShortformController.SaveRequest(
+                text(payload, "video_id"),
+                text(payload, "note"),
+                text(payload, "folder")
+        ));
+    }
+
+    @PostMapping("/like")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformLike(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @RequestBody(required = false) LegacyBody body
+    ) {
+        Map<String, Object> payload = payloadOf(body);
+        return shortformController.like(auth, new ShortformController.LikeRequest(text(payload, "video_id")));
+    }
+
+    @PostMapping("/{shortformId}/export/retry")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformRetry(
+            @RequestHeader(value = "Authorization", required = false) String auth,
+            @PathVariable String shortformId
+    ) {
+        return shortformController.retry(auth, shortformId);
+    }
+
+    private String requireUserId(String auth) {
+        var session = sessionService.me(auth);
+        return session == null ? null : session.user().id();
+    }
+
+    private ResponseEntity<ApiResponse<List<Map<String, Object>>>> unauthenticated() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
+    }
+
+    private String text(Map<String, Object> body, String key) {
+        if (body == null || body.get(key) == null) return "";
+        return String.valueOf(body.get(key)).trim();
+    }
+
+    private Map<String, Object> payloadOf(LegacyBody body) {
+        return body == null ? Map.of() : body.payload();
+    }
+
+    private List<String> listOfString(Map<String, Object> body, String key) {
+        if (body == null) return List.of();
+        Object raw = body.get(key);
+        if (!(raw instanceof List<?> items)) return List.of();
+        return items.stream().map(String::valueOf).toList();
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/NotImplementedController.java
@@ -1,6 +1,5 @@
 package com.myway.backendspring.api;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.domain.CourseCard;
@@ -8,67 +7,29 @@ import com.myway.backendspring.domain.CourseDetail;
 import com.myway.backendspring.domain.DemoLearningService;
 import com.myway.backendspring.domain.EnrollmentItem;
 import com.myway.backendspring.domain.LectureItem;
-import com.myway.backendspring.feature.FeatureStoreService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.servlet.HandlerMapping;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 @RestController
 @RequestMapping("/api/v1")
 public class NotImplementedController {
-    public static final class LegacyBody {
-        private final Map<String, Object> payload = new java.util.HashMap<>();
-
-        @JsonAnySetter
-        public void put(String key, Object value) {
-            payload.put(key, value);
-        }
-
-        public Map<String, Object> payload() {
-            return payload;
-        }
-    }
-
-    private final AiController aiController;
-    private final MediaController mediaController;
-    private final MediaSttOrchestrationController mediaSttOrchestrationController;
-    private final ShortformController shortformController;
     private final DemoLearningService learningService;
     private final SessionService sessionService;
-    private final FeatureStoreService featureStore;
 
     public NotImplementedController(
-            AiController aiController,
-            MediaController mediaController,
-            MediaSttOrchestrationController mediaSttOrchestrationController,
-            ShortformController shortformController,
             DemoLearningService learningService,
-            SessionService sessionService,
-            FeatureStoreService featureStore
+            SessionService sessionService
     ) {
-        this.aiController = aiController;
-        this.mediaController = mediaController;
-        this.mediaSttOrchestrationController = mediaSttOrchestrationController;
-        this.shortformController = shortformController;
         this.learningService = learningService;
         this.sessionService = sessionService;
-        this.featureStore = featureStore;
     }
 
     @GetMapping("/legacy/courses")
@@ -99,367 +60,6 @@ public class NotImplementedController {
                     .body(ApiResponse.failure("COURSE_NOT_FOUND", "강의를 찾을 수 없습니다."));
         }
         return ResponseEntity.ok(ApiResponse.success(lectures, "legacy course lectures 응답을 /api/v1/courses/{courseId}/lectures와 동일하게 반환했습니다."));
-    }
-
-    @GetMapping("/legacy/ai/settings")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiSettings(@RequestHeader(value = "Authorization", required = false) String auth) {
-        return withUserId(auth, userId ->
-                ResponseEntity.ok(ApiResponse.success(featureStore.aiSettings(userId), "legacy ai settings 응답을 /api/v1/ai/settings와 동일하게 반환했습니다."))
-        );
-    }
-
-    @GetMapping("/legacy/ai/providers")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiProviders(@RequestHeader(value = "Authorization", required = false) String auth) {
-        return withUserId(auth, userId ->
-                ResponseEntity.ok(ApiResponse.success(featureStore.aiProviders(userId), "legacy ai providers 응답을 /api/v1/ai/providers와 동일하게 반환했습니다."))
-        );
-    }
-
-    @GetMapping("/legacy/ai/insights")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiInsights(@RequestHeader(value = "Authorization", required = false) String auth) {
-        return withUserId(auth, userId ->
-                ResponseEntity.ok(ApiResponse.success(featureStore.aiInsights(userId), "legacy ai insights 응답을 /api/v1/ai/insights와 동일하게 반환했습니다."))
-        );
-    }
-
-    @GetMapping("/legacy/ai/recommendations")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiRecommendations(@RequestHeader(value = "Authorization", required = false) String auth) {
-        return withUserId(auth, userId ->
-                ResponseEntity.ok(ApiResponse.success(featureStore.aiRecommendations(userId), "legacy ai recommendations 응답을 /api/v1/ai/recommendations와 동일하게 반환했습니다."))
-        );
-    }
-
-    @GetMapping("/legacy/ai/logs")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiLogs(@RequestHeader(value = "Authorization", required = false) String auth) {
-        return withUserId(auth, userId ->
-                ResponseEntity.ok(ApiResponse.success(featureStore.aiLogs(userId), "legacy ai logs 응답을 /api/v1/ai/logs와 동일하게 반환했습니다."))
-        );
-    }
-
-    @PostMapping("/legacy/ai/settings")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiUpdateSettings(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        return aiController.updateSettings(auth, new AiController.AiSettingsUpdateRequest(payloadOf(body)));
-    }
-
-    @PutMapping("/legacy/ai/settings")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiPutSettings(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        return aiController.putSettings(auth, new AiController.AiSettingsUpdateRequest(payloadOf(body)));
-    }
-
-    @PostMapping("/legacy/ai/intent")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiIntent(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return aiController.intent(auth, new AiController.IntentRequest(
-                text(payload, "message"),
-                text(payload, "lecture_id")
-        ));
-    }
-
-    @PostMapping("/legacy/ai/search")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiSearch(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return aiController.search(auth, new AiController.SearchRequest(
-                text(payload, "query"),
-                text(payload, "lecture_id")
-        ));
-    }
-
-    @PostMapping("/legacy/ai/answer")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiAnswer(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return aiController.answer(auth, new AiController.AnswerRequest(
-                text(payload, "question"),
-                text(payload, "lecture_id")
-        ));
-    }
-
-    @PostMapping("/legacy/ai/summary")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiSummary(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return aiController.summary(auth, new AiController.SummaryRequest(
-                text(payload, "lecture_id"),
-                text(payload, "style"),
-                text(payload, "language")
-        ));
-    }
-
-    @PostMapping("/legacy/ai/quiz")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyAiQuiz(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return aiController.quiz(auth, new AiController.QuizRequest(
-                text(payload, "lecture_id")
-        ));
-    }
-
-    @GetMapping("/legacy/media/providers")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaProviders(@RequestHeader(value = "Authorization", required = false) String auth) {
-        return withUserId(auth, userId ->
-                ResponseEntity.ok(ApiResponse.success(featureStore.sttProviders(), "legacy media providers 응답을 /api/v1/media/providers와 동일하게 반환했습니다."))
-        );
-    }
-
-    @GetMapping("/legacy/media/processor-health")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaProcessorHealth(@RequestHeader(value = "Authorization", required = false) String auth) {
-        return withUserId(auth, userId ->
-                ResponseEntity.ok(ApiResponse.success(featureStore.processorHealth(), "legacy media processor health 응답을 /api/v1/media/processor-health와 동일하게 반환했습니다."))
-        );
-    }
-
-    @GetMapping("/legacy/media/pipeline/{lectureId}")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaPipeline(
-            @PathVariable String lectureId,
-            @RequestHeader(value = "Authorization", required = false) String auth
-    ) {
-        return withUserId(auth, userId ->
-                ResponseEntity.ok(ApiResponse.success(featureStore.pipeline(lectureId), "legacy media pipeline 응답을 /api/v1/media/pipeline/{lectureId}와 동일하게 반환했습니다."))
-        );
-    }
-
-    @PostMapping("/legacy/media/extract-audio")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaExtractAudio(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return mediaController.extract(auth, new MediaController.ExtractAudioRequest(
-                text(payload, "lecture_id"),
-                text(payload, "audio_url")
-        ));
-    }
-
-    @PostMapping("/legacy/media/transcribe")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaTranscribe(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return mediaController.transcribe(auth, new MediaController.TranscribeRequest(
-                text(payload, "lecture_id"),
-                text(payload, "language"),
-                intOrNull(payload, "duration_ms"),
-                text(payload, "stt_provider"),
-                text(payload, "stt_model"),
-                text(payload, "audio_url")
-        ));
-    }
-
-    @PostMapping("/legacy/media/summarize")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaSummarize(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return mediaController.summarize(auth, new MediaController.SummarizeRequest(
-                text(payload, "lecture_id"),
-                text(payload, "style"),
-                text(payload, "language")
-        ));
-    }
-
-    @GetMapping("/legacy/media/audio-extractions/{lectureId}")
-    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyMediaAudioExtractions(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @PathVariable String lectureId
-    ) {
-        return mediaController.audioExtractions(auth, lectureId);
-    }
-
-    @GetMapping("/legacy/media/transcript/{lectureId}")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaTranscript(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @PathVariable String lectureId
-    ) {
-        return mediaController.transcript(auth, lectureId);
-    }
-
-    @GetMapping("/legacy/media/notes/{lectureId}")
-    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyMediaNotes(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @PathVariable String lectureId
-    ) {
-        return mediaController.notes(auth, lectureId);
-    }
-
-    @PostMapping("/legacy/media/extract-audio/callback")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaExtractAudioCallback(
-            @RequestHeader(value = "X-Callback-Token", required = false) String token,
-            @RequestHeader(value = "x-myway-media-callback-secret", required = false) String callbackSecret,
-            @RequestBody MediaSttOrchestrationController.ExtractionCallbackRequest body
-    ) {
-        return mediaSttOrchestrationController.callback(token, callbackSecret, body);
-    }
-
-    @PostMapping("/legacy/media/upload-video")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyMediaUploadVideo(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestParam("lecture_id") String lectureId,
-            @RequestParam(value = "video_file", required = false) MultipartFile file
-    ) {
-        return mediaController.upload(auth, lectureId, file);
-    }
-
-    @GetMapping("/legacy/media/assets/**")
-    public ResponseEntity<?> legacyMediaAssets(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestHeader(value = "X-Processor-Token", required = false) String processorToken,
-            HttpServletRequest request
-    ) {
-        String path = String.valueOf(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE));
-        String legacyPrefix = "/api/v1/legacy/media/assets/";
-        if (path.startsWith(legacyPrefix)) {
-            String suffix = path.substring(legacyPrefix.length());
-            request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/api/v1/media/assets/" + suffix);
-        }
-        return mediaController.assets(auth, processorToken, request);
-    }
-
-    @GetMapping("/legacy/shortform/library")
-    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyShortformLibrary(@RequestHeader(value = "Authorization", required = false) String auth) {
-        String userId = requireUserId(auth);
-        if (userId == null) {
-            return unauthenticated();
-        }
-        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformLibrary(userId), "legacy shortform library 응답을 /api/v1/shortform/library와 동일하게 반환했습니다."));
-    }
-
-    @GetMapping("/legacy/shortform/community")
-    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyShortformCommunity(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestParam(value = "course_id", required = false) String courseId
-    ) {
-        if (requireUserId(auth) == null) {
-            return unauthenticated();
-        }
-        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformCommunity(courseId), "legacy shortform community 응답을 /api/v1/shortform/community와 동일하게 반환했습니다."));
-    }
-
-    @GetMapping("/legacy/shortform/videos/my")
-    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> legacyShortformVideos(@RequestHeader(value = "Authorization", required = false) String auth) {
-        String userId = requireUserId(auth);
-        if (userId == null) {
-            return unauthenticated();
-        }
-        return ResponseEntity.ok(ApiResponse.success(featureStore.shortformVideos(userId), "legacy shortform videos 응답을 /api/v1/shortform/videos/my와 동일하게 반환했습니다."));
-    }
-
-    @PostMapping("/legacy/shortform/generate")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformGenerate(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return shortformController.generate(auth, new ShortformController.GenerateRequest(
-                text(payload, "course_id"),
-                text(payload, "mode")
-        ));
-    }
-
-    @PutMapping("/legacy/shortform/candidates/select")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformSelect(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return shortformController.select(auth, new ShortformController.SelectCandidatesRequest(
-                text(payload, "extraction_id"),
-                listOfString(payload, "candidate_ids")
-        ));
-    }
-
-    @GetMapping("/legacy/shortform/extraction/{id}")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformExtraction(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @PathVariable String id
-    ) {
-        return shortformController.extraction(auth, id);
-    }
-
-    @PostMapping("/legacy/shortform/compose")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformCompose(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return shortformController.compose(auth, new ShortformController.ComposeRequest(
-                text(payload, "title"),
-                text(payload, "description"),
-                text(payload, "course_id")
-        ));
-    }
-
-    @GetMapping("/legacy/shortform/video/{id}")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformVideo(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @PathVariable String id
-    ) {
-        return shortformController.video(auth, id);
-    }
-
-    @PostMapping("/legacy/shortform/share")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformShare(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return shortformController.share(auth, new ShortformController.ShareRequest(
-                text(payload, "video_id"),
-                text(payload, "course_id"),
-                text(payload, "visibility"),
-                text(payload, "message")
-        ));
-    }
-
-    @PostMapping("/legacy/shortform/save")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformSave(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return shortformController.save(auth, new ShortformController.SaveRequest(
-                text(payload, "video_id"),
-                text(payload, "note"),
-                text(payload, "folder")
-        ));
-    }
-
-    @PostMapping("/legacy/shortform/like")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformLike(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @RequestBody(required = false) LegacyBody body
-    ) {
-        Map<String, Object> payload = payloadOf(body);
-        return shortformController.like(auth, new ShortformController.LikeRequest(
-                text(payload, "video_id")
-        ));
-    }
-
-    @PostMapping("/legacy/shortform/{shortformId}/export/retry")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> legacyShortformRetry(
-            @RequestHeader(value = "Authorization", required = false) String auth,
-            @PathVariable String shortformId
-    ) {
-        return shortformController.retry(auth, shortformId);
     }
 
     @GetMapping("/legacy/dashboard")
@@ -551,17 +151,6 @@ public class NotImplementedController {
                 .body(ApiResponse.failure("NOT_IMPLEMENTED", "Spring 백엔드 마이그레이션 중인 API입니다. /api/v1/legacy/mappings를 확인하세요."));
     }
 
-    private String text(Map<String, Object> body, String key) {
-        if (body == null || body.get(key) == null) {
-            return "";
-        }
-        return String.valueOf(body.get(key)).trim();
-    }
-
-    private Map<String, Object> payloadOf(LegacyBody body) {
-        return body == null ? Map.of() : body.payload();
-    }
-
     private String requireUserId(String auth) {
         var session = sessionService.me(auth);
         return session == null ? null : session.user().id();
@@ -572,45 +161,9 @@ public class NotImplementedController {
         return userId == null ? "guest" : userId;
     }
 
-    private <T> ResponseEntity<ApiResponse<T>> withUserId(String auth, Function<String, ResponseEntity<ApiResponse<T>>> action) {
-        String userId = requireUserId(auth);
-        if (userId == null) {
-            return unauthenticated();
-        }
-        return action.apply(userId);
-    }
-
     private <T> ResponseEntity<ApiResponse<T>> unauthenticated() {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.failure("UNAUTHENTICATED", "로그인이 필요합니다."));
     }
 
-    private Integer intOrNull(Map<String, Object> body, String key) {
-        if (body == null) {
-            return null;
-        }
-        Object raw = body.get(key);
-        if (raw instanceof Number number) {
-            return number.intValue();
-        }
-        if (raw == null) {
-            return null;
-        }
-        try {
-            return Integer.parseInt(String.valueOf(raw));
-        } catch (NumberFormatException ignored) {
-            return null;
-        }
-    }
-
-    private List<String> listOfString(Map<String, Object> body, String key) {
-        if (body == null) {
-            return List.of();
-        }
-        Object raw = body.get(key);
-        if (!(raw instanceof List<?> items)) {
-            return List.of();
-        }
-        return items.stream().map(String::valueOf).toList();
-    }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaProcessingService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaProcessingService.java
@@ -123,10 +123,11 @@ public class MediaProcessingService {
 
     private HttpResponse<String> dispatchRequest(String extractionId, String sourceVideoUrl, Map<String, Object> extraction) throws Exception {
         URI callbackUri = URI.create(mediaPublicBaseUrl + "/api/v1/media/extract-audio/callback");
+        String normalizedSourceVideoUrl = normalizeSourceVideoUrl(sourceVideoUrl);
         Map<String, Object> body = new HashMap<>();
         body.put("extraction_id", extractionId);
         body.put("lecture_id", String.valueOf(extraction.getOrDefault("lecture_id", "")));
-        body.put("source_video_url", sourceVideoUrl);
+        body.put("source_video_url", normalizedSourceVideoUrl);
         body.put("callback", Map.of("url", callbackUri.toString(), "secret", mediaCallbackSecret.isBlank() ? null : mediaCallbackSecret));
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(mediaProcessorUrl + "/jobs/audio-extraction"))
@@ -136,6 +137,20 @@ public class MediaProcessingService {
             builder.header("Authorization", "Bearer " + mediaProcessorToken);
         }
         return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private String normalizeSourceVideoUrl(String sourceVideoUrl) {
+        String trimmed = sourceVideoUrl == null ? "" : sourceVideoUrl.trim();
+        if (trimmed.isBlank()) {
+            return mediaPublicBaseUrl + "/api/v1/media/assets/unknown";
+        }
+        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+            return trimmed;
+        }
+        if (trimmed.startsWith("/")) {
+            return mediaPublicBaseUrl + trimmed;
+        }
+        return mediaPublicBaseUrl + "/" + trimmed;
     }
 
     private void applyDispatchSuccess(Map<String, Object> extraction, String responseBody) throws Exception {

--- a/scripts/media-processor/service.ts
+++ b/scripts/media-processor/service.ts
@@ -26,6 +26,7 @@ export async function processAudioExtractionJob(
     await ensureWorkDirs(config.workDir);
     await downloadSourceVideo(job.sourceVideoUrl, paths.videoPath, {
       Authorization: `Bearer ${config.token}`,
+      'X-Processor-Token': config.callbackSecret ?? config.token,
     });
     jobStore.updateJob(job.id, {
       stage: 'extracting',
@@ -130,6 +131,7 @@ export async function processShortformExportJob(
       });
       await downloadSourceVideo(clip.source_video_url, clipSourcePath, {
         Authorization: `Bearer ${config.token}`,
+        'X-Processor-Token': config.callbackSecret ?? config.token,
       });
 
       jobStore.updateJob(job.id, {


### PR DESCRIPTION
# 변경 요약
Media 처리 경계에서 소스 비디오 URL 정규화와 프로세서 인증 헤더 일관화를 적용해, 상대경로/절대경로 혼재 및 다운로드 인증 실패 가능성을 줄였습니다.

## 배경
일부 DB/요청 데이터는 `source_video_url`이 상대 경로로 들어와 잡 생성 이후 미디어 프로세서 측 접근 실패가 발생할 수 있었습니다. 또한 다운로드 요청에서 콜백 보안 토큰과 인증 헤더 사용 방식이 분리되어 있어 운영 정책 일관성이 떨어졌습니다.

## 변경 내용
- `MediaProcessingService`
  - `source_video_url` 디스패치 전에 `normalizeSourceVideoUrl()`로 정규화
  - 빈 값/상대 경로(`/...`, `...`)를 `mediaPublicBaseUrl` 기준 절대 URL로 변환
- `scripts/media-processor/service.ts`
  - 오디오 추출/숏폼 클립 다운로드 요청 시 `X-Processor-Token` 헤더 추가
  - `callbackSecret` 우선, 없으면 기존 `token` fallback

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:backend` 통과
- layer tests: `npm run test:backend` 통과 (Tests run: 70, Failures: 0, Errors: 0, Skipped: 0)
- risk/rollback: URL 정규화/헤더 추가로 기존 경로에 대한 호환성 영향은 낮음. 이슈 시 해당 커밋 revert로 즉시 롤백 가능.

## ADR 링크
- ADR: 해당 없음 (기능/정책 신규 설계 변경 없음)
- 상태 변경: 해당 없음
