### PR TITLE
refactor(domain): split lecture metadata sync support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -28,16 +28,19 @@ public class DemoLearningService {
     private final FeatureJdbcStore store;
     private final ActivityEventService activityEventService;
     private final LearningProgressCalculator progressCalculator;
+    private final LectureMetadataSyncSupport lectureMetadataSyncSupport;
 
     @Autowired
     public DemoLearningService(
             FeatureJdbcStore store,
             ActivityEventService activityEventService,
-            LearningProgressCalculator progressCalculator
+            LearningProgressCalculator progressCalculator,
+            LectureMetadataSyncSupport lectureMetadataSyncSupport
     ) {
         this.store = store;
         this.activityEventService = activityEventService;
         this.progressCalculator = progressCalculator;
+        this.lectureMetadataSyncSupport = lectureMetadataSyncSupport;
         initSeedData();
     }
 
@@ -46,6 +49,7 @@ public class DemoLearningService {
         this.store = null;
         this.activityEventService = null;
         this.progressCalculator = new LearningProgressCalculator();
+        this.lectureMetadataSyncSupport = new LectureMetadataSyncSupport();
         initSeedData();
     }
 
@@ -425,7 +429,7 @@ public class DemoLearningService {
                 continue;
             }
 
-            Map<String, Object> merged = mergeLectureMeta(current, suggested, overwriteExisting);
+            Map<String, Object> merged = lectureMetadataSyncSupport.mergeLectureMeta(current, suggested, overwriteExisting);
             store.upsertKv(LECTURE_META_SCOPE, lectureId, merged);
             updated += 1;
             items.add(Map.of("lecture_id", lectureId, "status", "UPDATED"));
@@ -482,7 +486,7 @@ public class DemoLearningService {
             );
         }
 
-        Map<String, Object> merged = mergeLectureMeta(current, suggested, overwriteExisting);
+        Map<String, Object> merged = lectureMetadataSyncSupport.mergeLectureMeta(current, suggested, overwriteExisting);
         store.upsertKv(LECTURE_META_SCOPE, normalizedLectureId, merged);
         return Map.of(
                 "lecture_id", normalizedLectureId,
@@ -656,27 +660,27 @@ public class DemoLearningService {
             return lecture;
         }
         Map<String, Object> currentMeta = store.getKv(LECTURE_META_SCOPE, lectureId);
-        if (isLectureMetaMissing(currentMeta)) {
+        if (lectureMetadataSyncSupport.isLectureMetaMissing(currentMeta)) {
             Map<String, Object> transcript = store.getKv(TRANSCRIPT_SCOPE, lectureId);
             if (transcript != null) {
                 Map<String, Object> suggested = buildLectureMetaFromTranscript(lecture, transcript);
-                Map<String, Object> merged = mergeLectureMeta(currentMeta, suggested, false);
+                Map<String, Object> merged = lectureMetadataSyncSupport.mergeLectureMeta(currentMeta, suggested, false);
                 store.upsertKv(LECTURE_META_SCOPE, lectureId, merged);
                 currentMeta = merged;
             }
         }
-        String content = chooseText(
-                asText(currentMeta == null ? null : currentMeta.get("content_text")),
+        String content = lectureMetadataSyncSupport.chooseText(
+                lectureMetadataSyncSupport.asText(currentMeta == null ? null : currentMeta.get("content_text")),
                 lecture.content_text(),
                 "강의 핵심 내용을 정리 중입니다."
         );
-        String excerpt = chooseText(
-                asText(currentMeta == null ? null : currentMeta.get("transcript_excerpt")),
+        String excerpt = lectureMetadataSyncSupport.chooseText(
+                lectureMetadataSyncSupport.asText(currentMeta == null ? null : currentMeta.get("transcript_excerpt")),
                 lecture.transcript_excerpt(),
                 ""
         );
-        String instructorName = chooseText(
-                asText(currentMeta == null ? null : currentMeta.get("instructor_name")),
+        String instructorName = lectureMetadataSyncSupport.chooseText(
+                lectureMetadataSyncSupport.asText(currentMeta == null ? null : currentMeta.get("instructor_name")),
                 lecture.instructor_name(),
                 ""
         );
@@ -691,90 +695,9 @@ public class DemoLearningService {
         );
     }
 
-    private boolean isLectureMetaMissing(Map<String, Object> meta) {
-        if (meta == null) return true;
-        return asText(meta.get("content_text")).isBlank()
-                && asText(meta.get("transcript_excerpt")).isBlank()
-                && asText(meta.get("instructor_name")).isBlank();
-    }
-
     private Map<String, Object> buildLectureMetaFromTranscript(LectureItem lecture, Map<String, Object> transcript) {
         String lectureId = lecture == null ? "" : lecture.id();
-        String fullText = asText(transcript.get("full_text"));
-        if (fullText.isBlank()) {
-            Object segmentsRaw = transcript.get("segments");
-            if (segmentsRaw instanceof List<?> segments) {
-                StringBuilder builder = new StringBuilder();
-                for (Object segment : segments) {
-                    if (!(segment instanceof Map<?, ?> map)) continue;
-                    Object textRaw = map.containsKey("text") ? map.get("text") : "";
-                    String text = String.valueOf(textRaw).trim();
-                    if (!text.isBlank()) {
-                        if (!builder.isEmpty()) builder.append(' ');
-                        builder.append(text);
-                    }
-                }
-                fullText = builder.toString();
-            }
-        }
-
         Map<String, Object> speakerReview = store.getKv(SPEAKER_REVIEW_SCOPE, lectureId);
-        String instructorName = asText(speakerReview == null ? null : speakerReview.get("instructor_name"));
-        if (instructorName.isBlank()) {
-            instructorName = asText(lecture == null ? null : lecture.instructor_name());
-        }
-        String excerpt = trimToLimit(fullText, 180);
-        String content = trimToLimit(fullText, 1200);
-        Map<String, Object> meta = new HashMap<>();
-        meta.put("lecture_id", lectureId);
-        meta.put("content_text", content);
-        meta.put("transcript_excerpt", excerpt);
-        meta.put("instructor_name", instructorName);
-        meta.put("updated_at", Instant.now().toString());
-        return meta;
-    }
-
-    private Map<String, Object> mergeLectureMeta(Map<String, Object> current, Map<String, Object> suggested, boolean overwriteExisting) {
-        Map<String, Object> merged = new HashMap<>();
-        if (current != null) {
-            merged.putAll(current);
-        }
-        for (String field : List.of("lecture_id", "updated_at")) {
-            if (suggested.containsKey(field)) {
-                merged.put(field, suggested.get(field));
-            }
-        }
-        for (String field : List.of("content_text", "transcript_excerpt", "instructor_name")) {
-            String currentText = asText(merged.get(field));
-            String nextText = asText(suggested.get(field));
-            if (overwriteExisting || currentText.isBlank()) {
-                if (!nextText.isBlank()) {
-                    merged.put(field, nextText);
-                }
-            }
-        }
-        merged.put("updated_at", Instant.now().toString());
-        return merged;
-    }
-
-    private String trimToLimit(String value, int limit) {
-        String normalized = asText(value);
-        if (normalized.length() <= limit) {
-            return normalized;
-        }
-        return normalized.substring(0, limit).trim();
-    }
-
-    private String chooseText(String first, String second, String fallback) {
-        String a = asText(first);
-        if (!a.isBlank()) return a;
-        String b = asText(second);
-        if (!b.isBlank()) return b;
-        return fallback == null ? "" : fallback;
-    }
-
-    private String asText(Object value) {
-        if (value == null) return "";
-        return String.valueOf(value).trim();
+        return lectureMetadataSyncSupport.buildLectureMetaFromTranscript(lecture, transcript, speakerReview);
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/LectureMetadataSyncSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/LectureMetadataSyncSupport.java
@@ -1,0 +1,103 @@
+package com.myway.backendspring.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class LectureMetadataSyncSupport {
+    public boolean isLectureMetaMissing(Map<String, Object> meta) {
+        if (meta == null) return true;
+        return asText(meta.get("content_text")).isBlank()
+                && asText(meta.get("transcript_excerpt")).isBlank()
+                && asText(meta.get("instructor_name")).isBlank();
+    }
+
+    public Map<String, Object> buildLectureMetaFromTranscript(
+            LectureItem lecture,
+            Map<String, Object> transcript,
+            Map<String, Object> speakerReview
+    ) {
+        String lectureId = lecture == null ? "" : lecture.id();
+        String fullText = asText(transcript.get("full_text"));
+        if (fullText.isBlank()) {
+            fullText = textFromSegments(transcript.get("segments"));
+        }
+
+        String instructorName = asText(speakerReview == null ? null : speakerReview.get("instructor_name"));
+        if (instructorName.isBlank()) {
+            instructorName = asText(lecture == null ? null : lecture.instructor_name());
+        }
+        String excerpt = trimToLimit(fullText, 180);
+        String content = trimToLimit(fullText, 1200);
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("lecture_id", lectureId);
+        meta.put("content_text", content);
+        meta.put("transcript_excerpt", excerpt);
+        meta.put("instructor_name", instructorName);
+        meta.put("updated_at", Instant.now().toString());
+        return meta;
+    }
+
+    public Map<String, Object> mergeLectureMeta(Map<String, Object> current, Map<String, Object> suggested, boolean overwriteExisting) {
+        Map<String, Object> merged = new HashMap<>();
+        if (current != null) {
+            merged.putAll(current);
+        }
+        for (String field : List.of("lecture_id", "updated_at")) {
+            if (suggested.containsKey(field)) {
+                merged.put(field, suggested.get(field));
+            }
+        }
+        for (String field : List.of("content_text", "transcript_excerpt", "instructor_name")) {
+            String currentText = asText(merged.get(field));
+            String nextText = asText(suggested.get(field));
+            if ((overwriteExisting || currentText.isBlank()) && !nextText.isBlank()) {
+                merged.put(field, nextText);
+            }
+        }
+        merged.put("updated_at", Instant.now().toString());
+        return merged;
+    }
+
+    public String chooseText(String first, String second, String fallback) {
+        String a = asText(first);
+        if (!a.isBlank()) return a;
+        String b = asText(second);
+        if (!b.isBlank()) return b;
+        return fallback == null ? "" : fallback;
+    }
+
+    public String asText(Object value) {
+        if (value == null) return "";
+        return String.valueOf(value).trim();
+    }
+
+    private String trimToLimit(String value, int limit) {
+        String normalized = asText(value);
+        if (normalized.length() <= limit) {
+            return normalized;
+        }
+        return normalized.substring(0, limit).trim();
+    }
+
+    private String textFromSegments(Object segmentsRaw) {
+        if (!(segmentsRaw instanceof List<?> segments)) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        for (Object segment : segments) {
+            if (!(segment instanceof Map<?, ?> map)) continue;
+            Object textRaw = map.containsKey("text") ? map.get("text") : "";
+            String text = String.valueOf(textRaw).trim();
+            if (!text.isBlank()) {
+                if (!builder.isEmpty()) builder.append(' ');
+                builder.append(text);
+            }
+        }
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
# 변경 요약
`DemoLearningService`에서 강의 메타 생성/병합 책임을 `LectureMetadataSyncSupport`로 분리해 도메인 서비스 복잡도를 낮췄습니다.

## 배경
`DemoLearningService`가 진도 계산 분리 이후에도 메타 동기화 텍스트 정규화/병합 규칙을 직접 포함하고 있어 변경 영향 범위가 넓었습니다.

## 변경 내용
- 신규 컴포넌트 추가: `LectureMetadataSyncSupport`
  - 메타 누락 판단
  - transcript 기반 meta 생성
  - overwrite 정책 기반 merge
  - 텍스트 정규화/선택 유틸
- `DemoLearningService`
  - 메타 동기화 시 신규 컴포넌트 위임
  - 서비스는 저장소 조회/업서트 오케스트레이션 중심으로 유지

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run build:backend` 통과
- layer tests: `npm run test:backend` 통과 (Tests run: 70, Failures: 0, Errors: 0, Skipped: 0)
- risk/rollback: 내부 책임 분리로 외부 API 계약 변경 없음. 문제 시 커밋 revert로 롤백 가능.

## ADR 링크
- ADR: 해당 없음
- 상태 변경: 해당 없음
