### PR TITLE
refactor(domain): split enrollment store support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -29,18 +29,21 @@ public class DemoLearningService {
     private final ActivityEventService activityEventService;
     private final LearningProgressCalculator progressCalculator;
     private final LectureMetadataSyncSupport lectureMetadataSyncSupport;
+    private final LearningEnrollmentStoreSupport learningEnrollmentStoreSupport;
 
     @Autowired
     public DemoLearningService(
             FeatureJdbcStore store,
             ActivityEventService activityEventService,
             LearningProgressCalculator progressCalculator,
-            LectureMetadataSyncSupport lectureMetadataSyncSupport
+            LectureMetadataSyncSupport lectureMetadataSyncSupport,
+            LearningEnrollmentStoreSupport learningEnrollmentStoreSupport
     ) {
         this.store = store;
         this.activityEventService = activityEventService;
         this.progressCalculator = progressCalculator;
         this.lectureMetadataSyncSupport = lectureMetadataSyncSupport;
+        this.learningEnrollmentStoreSupport = learningEnrollmentStoreSupport;
         initSeedData();
     }
 
@@ -50,6 +53,7 @@ public class DemoLearningService {
         this.activityEventService = null;
         this.progressCalculator = new LearningProgressCalculator();
         this.lectureMetadataSyncSupport = new LectureMetadataSyncSupport();
+        this.learningEnrollmentStoreSupport = new LearningEnrollmentStoreSupport();
         initSeedData();
     }
 
@@ -187,12 +191,7 @@ public class DemoLearningService {
         if (existing != null) return existing;
         EnrollmentItem item = new EnrollmentItem(UUID.randomUUID().toString(), userId, courseId);
         if (useStore()) {
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("id", item.id());
-            payload.put("user_id", item.user_id());
-            payload.put("course_id", item.course_id());
-            payload.put("created_at", Instant.now().toString());
-            store.upsertKv(ENROLLMENT_SCOPE, enrollmentKey(userId, courseId), payload);
+            learningEnrollmentStoreSupport.upsertEnrollment(store, ENROLLMENT_SCOPE, item);
         } else {
             enrollments.add(item);
         }
@@ -204,15 +203,7 @@ public class DemoLearningService {
         if (!useStore()) {
             return enrollments.stream().filter(e -> e.user_id().equals(userId)).toList();
         }
-        return store.listKvByScope(ENROLLMENT_SCOPE).stream()
-                .filter(item -> userId.equals(String.valueOf(item.getOrDefault("user_id", ""))))
-                .map(item -> new EnrollmentItem(
-                        String.valueOf(item.getOrDefault("id", "")),
-                        String.valueOf(item.getOrDefault("user_id", "")),
-                        String.valueOf(item.getOrDefault("course_id", ""))
-                ))
-                .filter(item -> !item.id().isBlank() && !item.course_id().isBlank())
-                .toList();
+        return learningEnrollmentStoreSupport.listEnrollments(store, ENROLLMENT_SCOPE, userId);
     }
 
     public Map<String, Object> completeLecture(String userId, String lectureId) {
@@ -223,13 +214,13 @@ public class DemoLearningService {
         if (!enrolled) return Map.of("reason", "enrollment_required");
 
         if (useStore()) {
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("id", completionKey(userId, lectureId));
-            payload.put("user_id", userId);
-            payload.put("lecture_id", lectureId);
-            payload.put("course_id", lecture.course_id());
-            payload.put("completed_at", Instant.now().toString());
-            store.upsertKv(LECTURE_COMPLETION_SCOPE, completionKey(userId, lectureId), payload);
+            learningEnrollmentStoreSupport.upsertLectureCompletion(
+                    store,
+                    LECTURE_COMPLETION_SCOPE,
+                    userId,
+                    lectureId,
+                    lecture.course_id()
+            );
         } else {
             completedLectureKeys.add(completionKey(userId, lectureId));
         }
@@ -273,15 +264,7 @@ public class DemoLearningService {
                     .findFirst()
                     .orElse(null);
         }
-        Map<String, Object> found = store.getKv(ENROLLMENT_SCOPE, enrollmentKey(userId, courseId));
-        if (found == null) {
-            return null;
-        }
-        return new EnrollmentItem(
-                String.valueOf(found.getOrDefault("id", "")),
-                String.valueOf(found.getOrDefault("user_id", "")),
-                String.valueOf(found.getOrDefault("course_id", ""))
-        );
+        return learningEnrollmentStoreSupport.findEnrollment(store, ENROLLMENT_SCOPE, userId, courseId);
     }
 
     private Set<String> listCompletedLectureIds(String userId) {
@@ -291,19 +274,11 @@ public class DemoLearningService {
                     .map(key -> key.substring((userId + ":").length()))
                     .collect(java.util.stream.Collectors.toSet());
         }
-        return store.listKvByScope(LECTURE_COMPLETION_SCOPE).stream()
-                .filter(item -> userId.equals(String.valueOf(item.getOrDefault("user_id", ""))))
-                .map(item -> String.valueOf(item.getOrDefault("lecture_id", "")))
-                .filter(lectureId -> !lectureId.isBlank())
-                .collect(java.util.stream.Collectors.toSet());
-    }
-
-    private String enrollmentKey(String userId, String courseId) {
-        return userId + ":" + courseId;
+        return learningEnrollmentStoreSupport.listCompletedLectureIds(store, LECTURE_COMPLETION_SCOPE, userId);
     }
 
     private String completionKey(String userId, String lectureId) {
-        return userId + ":" + lectureId;
+        return learningEnrollmentStoreSupport.completionKey(userId, lectureId);
     }
 
     private boolean useStore() {
@@ -320,15 +295,12 @@ public class DemoLearningService {
 
     private void ensureDefaultDemoStudentEnrollmentsInStore() {
         for (CourseDetail course : listAllCourses()) {
-            if (findEnrollment(DEFAULT_DEMO_STUDENT_ID, course.id()) != null) {
-                continue;
-            }
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("id", UUID.randomUUID().toString());
-            payload.put("user_id", DEFAULT_DEMO_STUDENT_ID);
-            payload.put("course_id", course.id());
-            payload.put("created_at", Instant.now().toString());
-            store.upsertKv(ENROLLMENT_SCOPE, enrollmentKey(DEFAULT_DEMO_STUDENT_ID, course.id()), payload);
+            learningEnrollmentStoreSupport.ensureDefaultEnrollment(
+                    store,
+                    ENROLLMENT_SCOPE,
+                    DEFAULT_DEMO_STUDENT_ID,
+                    course.id()
+            );
         }
     }
 

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/LearningEnrollmentStoreSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/LearningEnrollmentStoreSupport.java
@@ -1,0 +1,76 @@
+package com.myway.backendspring.domain;
+
+import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+public class LearningEnrollmentStoreSupport {
+    public EnrollmentItem findEnrollment(FeatureJdbcStore store, String scope, String userId, String courseId) {
+        Map<String, Object> found = store.getKv(scope, enrollmentKey(userId, courseId));
+        if (found == null) return null;
+        return new EnrollmentItem(
+                String.valueOf(found.getOrDefault("id", "")),
+                String.valueOf(found.getOrDefault("user_id", "")),
+                String.valueOf(found.getOrDefault("course_id", ""))
+        );
+    }
+
+    public List<EnrollmentItem> listEnrollments(FeatureJdbcStore store, String scope, String userId) {
+        return store.listKvByScope(scope).stream()
+                .filter(item -> userId.equals(String.valueOf(item.getOrDefault("user_id", ""))))
+                .map(item -> new EnrollmentItem(
+                        String.valueOf(item.getOrDefault("id", "")),
+                        String.valueOf(item.getOrDefault("user_id", "")),
+                        String.valueOf(item.getOrDefault("course_id", ""))
+                ))
+                .filter(item -> !item.id().isBlank() && !item.course_id().isBlank())
+                .toList();
+    }
+
+    public void upsertEnrollment(FeatureJdbcStore store, String scope, EnrollmentItem item) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("id", item.id());
+        payload.put("user_id", item.user_id());
+        payload.put("course_id", item.course_id());
+        payload.put("created_at", java.time.Instant.now().toString());
+        store.upsertKv(scope, enrollmentKey(item.user_id(), item.course_id()), payload);
+    }
+
+    public Set<String> listCompletedLectureIds(FeatureJdbcStore store, String scope, String userId) {
+        return store.listKvByScope(scope).stream()
+                .filter(item -> userId.equals(String.valueOf(item.getOrDefault("user_id", ""))))
+                .map(item -> String.valueOf(item.getOrDefault("lecture_id", "")))
+                .filter(lectureId -> !lectureId.isBlank())
+                .collect(Collectors.toSet());
+    }
+
+    public void upsertLectureCompletion(FeatureJdbcStore store, String scope, String userId, String lectureId, String courseId) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("id", completionKey(userId, lectureId));
+        payload.put("user_id", userId);
+        payload.put("lecture_id", lectureId);
+        payload.put("course_id", courseId);
+        payload.put("completed_at", java.time.Instant.now().toString());
+        store.upsertKv(scope, completionKey(userId, lectureId), payload);
+    }
+
+    public void ensureDefaultEnrollment(FeatureJdbcStore store, String scope, String userId, String courseId) {
+        if (findEnrollment(store, scope, userId, courseId) != null) return;
+        upsertEnrollment(store, scope, new EnrollmentItem(UUID.randomUUID().toString(), userId, courseId));
+    }
+
+    public String enrollmentKey(String userId, String courseId) {
+        return userId + ":" + courseId;
+    }
+
+    public String completionKey(String userId, String lectureId) {
+        return userId + ":" + lectureId;
+    }
+}


### PR DESCRIPTION
# 변경 요약
`DemoLearningService`의 수강/수료 저장소 접근 책임을 `LearningEnrollmentStoreSupport`로 분리했습니다.

## 배경
도메인 서비스에 저장소 키 생성/조회/업서트 로직이 집중되어 책임이 과도했습니다.

## 변경 내용
- 신규 컴포넌트: `LearningEnrollmentStoreSupport`
  - 수강 조회/목록/저장
  - 수료 강의 목록 조회/저장
  - 기본 데모 수강 보장
- `DemoLearningService`
  - store 접근 세부 구현을 신규 컴포넌트에 위임
  - 외부 API/응답 계약은 유지

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수
- [x] 트랜잭션 규칙 준수
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료

## 검증 로그 요약
- verify: `npm run build:backend` 통과
- layer tests: `npm run test:backend` 통과 (70/70)
- risk/rollback: 내부 책임 분리로 외부 계약 변경 없음. 문제 시 커밋 revert로 롤백 가능.

## ADR 링크
- ADR: 해당 없음
- 상태 변경: 해당 없음
