### PR TITLE
refactor(domain,docs): split course catalog store support and refresh readme

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -5,13 +5,13 @@
   <img src="https://img.shields.io/badge/TypeScript-5.8-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black" alt="React 19" />
   <img src="https://img.shields.io/badge/Vite-6-646CFF?logo=vite&logoColor=white" alt="Vite" />
-  <img src="https://img.shields.io/badge/Cloudflare_Workers-ready-F38020?logo=cloudflare&logoColor=white" alt="Cloudflare Workers" />
+  <img src="https://img.shields.io/badge/Spring_Boot-3.4-6DB33F?logo=springboot&logoColor=white" alt="Spring Boot" />
 </p>
 
 [한국어 README](./README.md)
 
 MyWayClass is an LMS platform that restructures lectures into personalized short-form learning flows.  
-It was built for the 2026 KIT Vibecoding Competition to help learners focus on the exact part they need, while giving instructors and operators tools to repurpose and manage lecture content.
+It helps learners focus on the exact part they need while giving instructors and operators tools to repurpose and manage lecture content.
 
 ## Table of Contents
 
@@ -25,6 +25,7 @@ It was built for the 2026 KIT Vibecoding Competition to help learners focus on t
 - [Key Screens](#key-screens)
 - [Getting Started](#getting-started)
 - [Scripts](#scripts)
+- [CI Operations](#ci-operations)
 - [Docs](#docs)
 - [Design Principles](#design-principles)
 
@@ -42,18 +43,16 @@ MyWayClass is designed to solve that problem by:
 - helping users find only the relevant segment
 - restructuring lectures into purpose-driven learning materials
 - reducing repetitive review through short-form clips, summaries, quizzes, and Q&A
-- creating a content flow that instructors and learners can reuse
+- creating a reusable content flow for instructors and learners
 
 ## Core Features
 
-- lecture viewing and learning dashboard
-- lecture studio and course management
-- short-form generation from lecture content
-- AI summaries, AI chat, and quiz generation
-- RAG-based Q&A and context lookup
-- media upload, audio extraction, and processing pipeline
-- separate experiences for students, instructors, and admins
-- short-form community and sharing flows
+- Role-based learning experiences (student/instructor/admin)
+- Course/lecture/enrollment management and learning dashboard
+- STT transcript pipeline, timeline summary, and RAG-based Q&A
+- Short-form generation/retry/share/library flows
+- AI summary/chat and operational AI logs/insights
+- Media upload/processing pipeline and asset mapping
 
 ## Workflow
 
@@ -63,12 +62,12 @@ The system is built around lecture fragments rather than a single full-length vi
 2. Chunk the transcript into meaningful segments
 3. Use RAG to find evidence segments for a question or learning goal
 4. Generate summaries, quizzes, Q&A, and intent classification with AI
-5. Connect the selected segments into a learning-focused short-form clip
-6. Keep the generated result linked to the original lecture for context
+5. Connect selected segments into learning-focused short-form clips
+6. Keep generated results linked to original lectures for context
 
 ## Screenshots
 
-> The repository does not include real capture assets yet, so the section below uses placeholders that can be replaced later.
+> The repository does not include real capture assets yet, so placeholders are kept.
 
 | Screen | Recommended file name | Description |
 |------|------------------------|------|
@@ -84,9 +83,10 @@ The system is built around lecture fragments rather than a single full-length vi
 | Area | Technology |
 |------|------------|
 | Frontend | React 19, TypeScript, Vite, Tailwind CSS |
-| Backend | Hono, TypeScript, Cloudflare Workers tooling |
-| Shared | Common types, data, and AI/LMS logic under `packages/shared` |
-| Build | npm workspaces, esbuild, wrangler, TypeScript |
+| Backend (Primary) | Spring Boot (Java 21), Maven Wrapper |
+| Backend (Legacy) | Hono, TypeScript, Cloudflare Workers tooling |
+| Shared | Common types and domain logic under `packages/shared` |
+| Build/Test | npm workspaces, Vite, Maven, Playwright, Vitest |
 | Media | `ffmpeg-static` based media processing |
 
 ## Project Structure
@@ -94,12 +94,14 @@ The system is built around lecture fragments rather than a single full-length vi
 ```text
 myway-class/
 ├── frontend/           # User-facing UI
-├── backend/            # API, AI, media processing
+├── backend-spring/     # Primary backend (Spring Boot)
+├── backend/            # Legacy backend (Hono/Workers)
 ├── packages/shared/    # Shared logic across frontend and backend
 ├── docs/               # Common documentation hub
 ├── scripts/            # Developer helper scripts
+├── tools/              # Orchestrator/agent runtime tools
 ├── agent.md            # AI collaboration rules
-└── README.md           # This file
+└── README.en.md
 ```
 
 ## Key Screens
@@ -108,7 +110,7 @@ myway-class/
 - learner dashboard
 - course list and lecture viewing
 - lecture studio
-- short-form hub and my short-forms
+- short-form hub and personal short-form management
 - AI summary page
 - AI chat page
 - quiz generation page
@@ -129,14 +131,16 @@ npm install
 npm run dev
 ```
 
-This is the main entry point for running the full local environment.
+`npm run dev` currently runs the frontend dev server (`dev:frontend`).
 
-If you want to run the frontend and backend separately:
+If you want to run frontend and backend separately:
 
 ```bash
 npm run dev:frontend
 npm run dev:backend
 ```
+
+Use `npm run dev:backend:legacy` only when you need the legacy TypeScript backend.
 
 ### Verification and Build
 
@@ -144,37 +148,53 @@ npm run dev:backend
 npm run check:deps
 npm run verify
 npm run build
+npm run test:backend
+npm run test:frontend
 ```
 
-- `npm run check:deps` checks frontend/backend workspace dependency integrity.
-- `npm run verify` runs dependency checks, frontend build, and Spring backend packaging in sequence.
-- `npm run build` builds both the frontend and backend.
+- `npm run check:deps`: checks frontend/backend workspace dependency integrity
+- `npm run verify`: dependency checks + frontend build + Spring backend tests
+- `npm run build`: frontend build + Spring backend package (`-DskipTests`)
 
 ## Scripts
 
 | Command | Description |
 |------|------|
-| `npm run dev` | Run the full local development environment |
-| `npm run dev:frontend` | Run only the frontend |
-| `npm run dev:backend` | Run only the backend |
+| `npm run dev` | Run frontend dev server |
+| `npm run dev:frontend` | Run frontend only |
+| `npm run dev:backend` | Run Spring backend |
+| `npm run dev:backend:legacy` | Run legacy TypeScript backend |
 | `npm run check:frontend-deps` | Check frontend workspace dependencies |
 | `npm run check:backend-deps` | Check backend workspace dependencies |
 | `npm run check:deps` | Check frontend/backend dependencies |
-| `npm run build` | Build frontend and backend |
-| `npm run verify` | Run dependency checks and frontend/backend build verification |
+| `npm run verify` | Dependency checks + frontend build + Spring tests |
+| `npm run build` | Build frontend and Spring backend |
+| `npm run test:backend` | Run Spring backend tests |
+| `npm run test:frontend` | Run frontend unit tests (Vitest) |
+| `npm run test:e2e:demo-student` | Playwright demo student journey E2E |
+| `npm run smoke:media-ai-shortform` | Media/AI/shortform smoke test |
+| `npm run orch:run` | Run orchestrator |
+| `npm run orch:checks` | Validate orchestrator policy/results |
+
+## CI Operations
+
+- Manual run: `backend-spring-tests` workflow supports `workflow_dispatch`.
+- Concurrency: previous runs on the same branch/workflow are auto-canceled (`cancel-in-progress: true`).
+- Timeout: `backend-spring-tests` job is limited to 15 minutes (`timeout-minutes: 15`).
 
 ## Docs
 
-- [`docs/README.md`](./docs/README.md): full documentation hub
-- [`agent.md`](./agent.md): AI collaboration rules
-- [`backend/docs/README.md`](./backend/docs/README.md): backend documentation hub
-- [`README.md`](./README.md): Korean README
+- [docs/README.md](./docs/README.md): documentation hub
+- [docs/project/20-status-and-next-steps.md](./docs/project/20-status-and-next-steps.md): current status and next steps
+- [backend-spring/README.md](./backend-spring/README.md): Spring backend runtime/baseline
+- [backend/docs/README.md](./backend/docs/README.md): backend docs hub
+- [agent.md](./agent.md): AI collaboration rules
 
 ## Design Principles
 
 - AI is an assistant, not a replacement.
 - Keep outputs structured and provide fallback paths.
-- Keep the code and docs aligned, and make decisions traceable.
+- Keep code and docs aligned, and keep decisions traceable.
 - Treat lectures as reusable learning assets, not just playback content.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [English README](./README.en.md)
 
 강의를 개인화된 숏폼과 학습 흐름으로 다시 구성하는 LMS 플랫폼입니다.  
-2026 KIT 바이브코딩 공모전 제출용 프로젝트로, 학습자에게는 필요한 구간만 빠르게 학습할 수 있는 경험을, 운영자와 강사에게는 강의 콘텐츠를 재가공하고 관리할 수 있는 도구를 제공합니다.
+학습자에게는 필요한 구간만 빠르게 학습할 수 있는 경험을, 운영자와 강사에게는 강의 콘텐츠를 재가공하고 관리할 수 있는 도구를 제공합니다.
 
 ## 목차
 
@@ -36,7 +36,7 @@
 ## 문제 정의
 
 온라인 강의는 짧게 쪼개져 보여도, 실제로 다시 확인해야 하는 핵심은 보통 2~3분 정도에 불과한 경우가 많습니다.  
-하지만 기존 LMS에서는 여전히 전체 영상을 다시 재생하며 원하는 구간을 직접 찾아야 하고, 강의가 쌓일수록 탐색 비용이 커집니다.
+기존 LMS에서는 전체 영상을 다시 재생하며 원하는 구간을 직접 찾아야 해 탐색 비용이 커집니다.
 
 `내맘대로클래스`는 이 문제를 해결하기 위해 다음을 목표로 합니다.
 
@@ -58,8 +58,6 @@
 
 ## 동작 흐름
 
-이 프로젝트는 “강의 하나를 통째로 소비하는 방식”이 아니라, “강의 안의 유용한 조각들”을 다시 묶는 방식으로 설계했습니다.
-
 기본 흐름은 아래와 같습니다.
 
 1. 강의 오디오를 STT로 텍스트화한다
@@ -71,7 +69,7 @@
 
 ## 스크린샷
 
-> 현재 저장소에는 실제 캡처 이미지가 없어서, 나중에 이미지만 교체하면 되는 자리표시자 형태로 정리했습니다.
+> 현재 저장소에는 실제 캡처 이미지가 없어 자리표시자 기준으로 유지합니다.
 
 | 화면 | 권장 파일명 | 설명 |
 |------|------------|------|
@@ -87,9 +85,10 @@
 | 구분 | 기술 |
 |------|------|
 | Frontend | React 19, TypeScript, Vite, Tailwind CSS |
-| Backend | Spring Boot (Java 21), Maven |
-| Shared | `packages/shared` 기반 공용 타입, 데이터, AI/LMS 로직 |
-| Build | npm workspaces, Vite, Maven, TypeScript |
+| Backend (Primary) | Spring Boot (Java 21), Maven Wrapper |
+| Backend (Legacy) | Hono, TypeScript, Cloudflare Workers tooling |
+| Shared | `packages/shared` 기반 공용 타입/도메인 로직 |
+| Build/Test | npm workspaces, Vite, Maven, Playwright, Vitest |
 | Media | `ffmpeg-static` 기반 미디어 처리 |
 
 ## 프로젝트 구조
@@ -97,10 +96,12 @@
 ```text
 myway-class/
 ├── frontend/           # 사용자 화면
-├── backend/            # API, AI, 미디어 처리
+├── backend-spring/     # 기본 백엔드(Spring Boot)
+├── backend/            # 레거시 백엔드(Hono/Workers)
 ├── packages/shared/    # 프론트/백엔드 공용 로직
 ├── docs/               # 공통 문서 허브
 ├── scripts/            # 개발 보조 스크립트
+├── tools/              # 오케스트레이터/에이전트 런타임 도구
 ├── agent.md            # AI 협업 규칙
 └── README.md           # 이 문서
 ```
@@ -132,14 +133,16 @@ npm install
 npm run dev
 ```
 
-전체 개발 환경을 함께 띄우는 진입점입니다.
+현재 `npm run dev`는 프론트엔드 개발 서버(`dev:frontend`)를 실행합니다.
 
-프론트엔드와 백엔드를 분리해서 실행하고 싶다면 아래 명령을 사용합니다.
+프론트엔드와 백엔드를 분리해 실행하려면:
 
 ```bash
 npm run dev:frontend
 npm run dev:backend
 ```
+
+레거시 백엔드가 필요하면 `npm run dev:backend:legacy`를 사용합니다.
 
 ### 검증 및 빌드
 
@@ -148,27 +151,32 @@ npm run check:deps
 npm run verify
 npm run build
 npm run test:backend
+npm run test:frontend
 ```
 
-- `npm run check:deps`는 frontend/backend(workspace) 의존성 누락을 점검합니다.
-- `npm run verify`는 의존성 점검 후 프론트엔드 빌드와 Spring 백엔드 패키징을 연속 실행합니다.
-- `npm run build`는 프론트엔드 빌드 + Spring 백엔드 패키징을 수행합니다.
-- `npm run test:backend`는 Spring 백엔드 테스트를 실행합니다.
+- `npm run check:deps`: frontend/backend(workspace) 의존성 점검
+- `npm run verify`: 의존성 점검 후 프론트 빌드 + Spring 백엔드 테스트 실행
+- `npm run build`: 프론트엔드 빌드 + Spring 백엔드 패키징(`-DskipTests`)
 
 ## 스크립트
 
 | 명령어 | 설명 |
 |------|------|
 | `npm run dev` | 프론트엔드 개발 서버 실행 |
-| `npm run dev:frontend` | 프론트엔드만 실행 |
+| `npm run dev:frontend` | frontend만 실행 |
 | `npm run dev:backend` | Spring 백엔드 실행 |
 | `npm run dev:backend:legacy` | 레거시(TypeScript) 백엔드 실행 |
 | `npm run check:frontend-deps` | frontend workspace 의존성 점검 |
 | `npm run check:backend-deps` | backend workspace 의존성 점검 |
 | `npm run check:deps` | frontend/backend 의존성 점검 |
-| `npm run verify` | 의존성 점검 + 프론트/백엔드 빌드 |
-| `npm run build` | 프론트엔드 + 백엔드 빌드 |
+| `npm run verify` | 의존성 점검 + 프론트 빌드 + Spring 테스트 |
+| `npm run build` | 프론트엔드 + Spring 백엔드 빌드 |
 | `npm run test:backend` | Spring 백엔드 테스트 |
+| `npm run test:frontend` | 프론트엔드 단위 테스트(Vitest) |
+| `npm run test:e2e:demo-student` | Playwright 데모 학습자 여정 E2E |
+| `npm run smoke:media-ai-shortform` | 미디어/AI/숏폼 스모크 실행 |
+| `npm run orch:run` | 오케스트레이터 실행 |
+| `npm run orch:checks` | 오케스트레이터 정책/결과 검증 |
 
 ## CI 운영
 
@@ -179,7 +187,8 @@ npm run test:backend
 ## 문서
 
 - [`docs/README.md`](./docs/README.md): 전체 문서 허브
-- [`agent.md`](./agent.md): AI 협업 규칙
+- [`docs/project/20-status-and-next-steps.md`](./docs/project/20-status-and-next-steps.md): 최신 상태/다음 단계
+- [`backend-spring/README.md`](./backend-spring/README.md): Spring 백엔드 기준 문서
 - [`backend/docs/README.md`](./backend/docs/README.md): 백엔드 문서 허브
 - [`README.en.md`](./README.en.md): 영문 README
 

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/CourseCatalogStoreSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/CourseCatalogStoreSupport.java
@@ -1,0 +1,54 @@
+package com.myway.backendspring.domain;
+
+import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+public class CourseCatalogStoreSupport {
+    public List<CourseDetail> listAllCourses(FeatureJdbcStore store, String scope, LearningPayloadMapper mapper) {
+        return store.listKvByScope(scope).stream()
+                .map(mapper::fromCoursePayload)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    public CourseDetail findCourse(FeatureJdbcStore store, String scope, String courseId, LearningPayloadMapper mapper) {
+        return mapper.fromCoursePayload(store.getKv(scope, courseId));
+    }
+
+    public void seedStoreDataIfMissing(FeatureJdbcStore store, String courseScope, String materialScope, String noticeScope, LearningPayloadMapper mapper) {
+        if (!store.listKvByScope(courseScope).isEmpty()) {
+            return;
+        }
+        List<LectureItem> javaLectures = List.of(
+                new LectureItem("lec_java_01", "crs_java_01", "Spring Boot 시작", 25),
+                new LectureItem("lec_java_02", "crs_java_01", "REST API 설계", 35)
+        );
+        List<LectureItem> reactLectures = List.of(
+                new LectureItem("lec_react_01", "crs_react_01", "React 상태관리", 30),
+                new LectureItem("lec_react_02", "crs_react_01", "API 연동", 28)
+        );
+        CourseDetail java = new CourseDetail("crs_java_01", "Java Spring 백엔드", "usr_ins_001", javaLectures, 0);
+        CourseDetail react = new CourseDetail("crs_react_01", "React 프론트엔드", "usr_ins_001", reactLectures, 0);
+        store.upsertKv(courseScope, java.id(), mapper.toCoursePayload(java));
+        store.upsertKv(courseScope, react.id(), mapper.toCoursePayload(react));
+        store.upsertKv(materialScope, "mat_java_01", Map.of(
+                "id", "mat_java_01",
+                "course_id", "crs_java_01",
+                "title", "강의 자료집",
+                "summary", "Spring 핵심 요약",
+                "file_name", "spring-handbook.pdf"
+        ));
+        store.upsertKv(noticeScope, "not_java_01", Map.of(
+                "id", "not_java_01",
+                "course_id", "crs_java_01",
+                "title", "과제 공지",
+                "content", "1주차 과제를 제출하세요.",
+                "pinned", true
+        ));
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -32,6 +32,7 @@ public class DemoLearningService {
     private final LearningEnrollmentStoreSupport learningEnrollmentStoreSupport;
     private final LearningPayloadMapper learningPayloadMapper;
     private final LectureDurationResolver lectureDurationResolver;
+    private final CourseCatalogStoreSupport courseCatalogStoreSupport;
 
     @Autowired
     public DemoLearningService(
@@ -41,7 +42,8 @@ public class DemoLearningService {
             LectureMetadataSyncSupport lectureMetadataSyncSupport,
             LearningEnrollmentStoreSupport learningEnrollmentStoreSupport,
             LearningPayloadMapper learningPayloadMapper,
-            LectureDurationResolver lectureDurationResolver
+            LectureDurationResolver lectureDurationResolver,
+            CourseCatalogStoreSupport courseCatalogStoreSupport
     ) {
         this.store = store;
         this.activityEventService = activityEventService;
@@ -50,6 +52,7 @@ public class DemoLearningService {
         this.learningEnrollmentStoreSupport = learningEnrollmentStoreSupport;
         this.learningPayloadMapper = learningPayloadMapper;
         this.lectureDurationResolver = lectureDurationResolver;
+        this.courseCatalogStoreSupport = courseCatalogStoreSupport;
         initSeedData();
     }
 
@@ -62,12 +65,13 @@ public class DemoLearningService {
         this.learningEnrollmentStoreSupport = new LearningEnrollmentStoreSupport();
         this.learningPayloadMapper = new LearningPayloadMapper();
         this.lectureDurationResolver = new LectureDurationResolver();
+        this.courseCatalogStoreSupport = new CourseCatalogStoreSupport();
         initSeedData();
     }
 
     private void initSeedData() {
         if (useStore()) {
-            seedStoreDataIfMissing();
+            courseCatalogStoreSupport.seedStoreDataIfMissing(store, COURSE_SCOPE, MATERIAL_SCOPE, NOTICE_SCOPE, learningPayloadMapper);
             ensureDefaultDemoStudentEnrollmentsInStore();
             return;
         }
@@ -445,49 +449,14 @@ public class DemoLearningService {
         );
     }
 
-    private void seedStoreDataIfMissing() {
-        if (!store.listKvByScope(COURSE_SCOPE).isEmpty()) {
-            return;
-        }
-        List<LectureItem> javaLectures = List.of(
-                new LectureItem("lec_java_01", "crs_java_01", "Spring Boot 시작", 25),
-                new LectureItem("lec_java_02", "crs_java_01", "REST API 설계", 35)
-        );
-        List<LectureItem> reactLectures = List.of(
-                new LectureItem("lec_react_01", "crs_react_01", "React 상태관리", 30),
-                new LectureItem("lec_react_02", "crs_react_01", "API 연동", 28)
-        );
-        CourseDetail java = new CourseDetail("crs_java_01", "Java Spring 백엔드", "usr_ins_001", javaLectures, 0);
-        CourseDetail react = new CourseDetail("crs_react_01", "React 프론트엔드", "usr_ins_001", reactLectures, 0);
-        store.upsertKv(COURSE_SCOPE, java.id(), learningPayloadMapper.toCoursePayload(java));
-        store.upsertKv(COURSE_SCOPE, react.id(), learningPayloadMapper.toCoursePayload(react));
-        store.upsertKv(MATERIAL_SCOPE, "mat_java_01", Map.of(
-                "id", "mat_java_01",
-                "course_id", "crs_java_01",
-                "title", "강의 자료집",
-                "summary", "Spring 핵심 요약",
-                "file_name", "spring-handbook.pdf"
-        ));
-        store.upsertKv(NOTICE_SCOPE, "not_java_01", Map.of(
-                "id", "not_java_01",
-                "course_id", "crs_java_01",
-                "title", "과제 공지",
-                "content", "1주차 과제를 제출하세요.",
-                "pinned", true
-        ));
-    }
-
     private List<CourseDetail> listAllCourses() {
         if (!useStore()) return new ArrayList<>(courses.values());
-        return store.listKvByScope(COURSE_SCOPE).stream()
-                .map(learningPayloadMapper::fromCoursePayload)
-                .filter(Objects::nonNull)
-                .toList();
+        return courseCatalogStoreSupport.listAllCourses(store, COURSE_SCOPE, learningPayloadMapper);
     }
 
     private CourseDetail findCourse(String courseId) {
         if (!useStore()) return courses.get(courseId);
-        return learningPayloadMapper.fromCoursePayload(store.getKv(COURSE_SCOPE, courseId));
+        return courseCatalogStoreSupport.findCourse(store, COURSE_SCOPE, courseId, learningPayloadMapper);
     }
 
     private void appendActivity(String userId, String type, String resourceType, String resourceId, Map<String, Object> metadata) {


### PR DESCRIPTION
# 변경 요약
코스 카탈로그 저장소 책임을 `CourseCatalogStoreSupport`로 분리하고, README(국/영문)를 현재 구조/운영 스크립트 기준으로 갱신했습니다.

## 검증
- `npm run build:backend` 통과
- `npm run test:backend` 통과 (70/70)
