### PR TITLE
refactor(media): split MediaTranscription persistence support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaTranscriptionPersistenceSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaTranscriptionPersistenceSupport.java
@@ -1,0 +1,164 @@
+package com.myway.backendspring.feature.media;
+
+import com.myway.backendspring.feature.repository.FeatureStoreRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class MediaTranscriptionPersistenceSupport {
+
+    Map<String, Object> markExtractionInProgress(FeatureStoreRepository repository, String extractionScope, Map<String, Object> extraction, String now) {
+        Map<String, Object> payload = new HashMap<>(extraction);
+        applyExtractionStatusUpdate(payload, new ExtractionStatusUpdate(
+                MediaStatus.PROCESSING.name(),
+                MediaStatus.PROCESSING.name(),
+                PipelineStage.TRANSCRIBING.value(),
+                "stt_started",
+                null,
+                null,
+                now
+        ));
+        String extractionId = String.valueOf(payload.getOrDefault("id", ""));
+        repository.upsertKv(extractionScope, extractionId, payload);
+        return payload;
+    }
+
+    Map<String, Object> persistPipeline(FeatureStoreRepository repository, String pipelineScope, String lectureId, Object extractionId, String transcriptId, String now) {
+        PipelinePayload payload = PipelinePayload.completed(lectureId, transcriptId, extractionId, now);
+        repository.upsertKv(pipelineScope, lectureId, payload.toMap());
+        return payload.toMap();
+    }
+
+    void persistCompletedExtraction(FeatureStoreRepository repository, String extractionScope, Map<String, Object> extractionInProgress, String transcriptId, int durationMs, String language, String provider, String model, String audioUrl, Map<String, Object> quality, String now) {
+        Map<String, Object> extractionPayload = new HashMap<>(extractionInProgress);
+        applyExtractionStatusUpdate(extractionPayload, new ExtractionStatusUpdate(
+                MediaStatus.COMPLETED.name(),
+                MediaStatus.COMPLETED.name(),
+                PipelineStage.COMPLETED.value(),
+                "stt_completed",
+                null,
+                null,
+                now
+        ));
+        extractionPayload.put("transcript_id", transcriptId);
+        extractionPayload.put("audio_duration_ms", durationMs);
+        extractionPayload.put("processed_at", now);
+        extractionPayload.put("language", language);
+        extractionPayload.put("requested_stt_provider", provider);
+        extractionPayload.put("requested_stt_model", model);
+        extractionPayload.put("audio_url", audioUrl);
+        extractionPayload.put("stt_quality", quality);
+        repository.upsertKv(extractionScope, transcriptId, extractionPayload);
+    }
+
+    ExtractionSnapshot findExtraction(FeatureStoreRepository repository, String extractionScope, String extractionId) {
+        Map<String, Object> extraction = repository.getKv(extractionScope, extractionId);
+        if (extraction != null) return ExtractionSnapshot.from(extraction);
+        for (Map<String, Object> row : repository.listEventsByScope(extractionScope)) {
+            if (extractionId.equals(String.valueOf(row.getOrDefault("id", "")))) return ExtractionSnapshot.from(row);
+        }
+        return null;
+    }
+
+    Map<String, Object> normalizeExtractionForResponse(Map<String, Object> extraction) {
+        Map<String, Object> hydrated = new HashMap<>(extraction);
+        hydrated.putIfAbsent("processing_stage", PipelineStage.QUEUED.value());
+        hydrated.putIfAbsent("processing_step", "job_requested");
+        hydrated.putIfAbsent("processing_error_code", null);
+        hydrated.putIfAbsent("processing_error", null);
+        hydrated.putIfAbsent("stt_status", MediaStatus.PENDING.name());
+        hydrated.putIfAbsent("error_message", null);
+        hydrated.putIfAbsent("callback_ignored", false);
+        hydrated.putIfAbsent("callback_status", "APPLIED");
+        hydrated.putIfAbsent("last_event_version", 0L);
+        return hydrated;
+    }
+
+    private void applyExtractionStatusUpdate(Map<String, Object> extraction, ExtractionStatusUpdate update) {
+        extraction.put("status", update.status());
+        extraction.put("stt_status", update.sttStatus());
+        extraction.put("processing_stage", update.processingStage());
+        extraction.put("processing_step", update.processingStep());
+        extraction.put("processing_error_code", update.processingErrorCode());
+        extraction.put("processing_error", update.processingError());
+        extraction.put("updated_at", update.updatedAt());
+    }
+
+    record ExtractionStatusUpdate(
+            String status,
+            String sttStatus,
+            String processingStage,
+            String processingStep,
+            Object processingErrorCode,
+            Object processingError,
+            String updatedAt
+    ) {
+    }
+
+    record PipelinePayload(
+            String lectureId,
+            String transcriptStatus,
+            String summaryStatus,
+            String audioStatus,
+            String processingStage,
+            String processingStep,
+            Object processingErrorCode,
+            Object processingError,
+            String transcriptId,
+            Object noteId,
+            Object extractionId,
+            String updatedAt
+    ) {
+        static PipelinePayload completed(String lectureId, String transcriptId, Object extractionId, String now) {
+            return new PipelinePayload(
+                    lectureId,
+                    MediaStatus.COMPLETED.name(),
+                    MediaStatus.PENDING.name(),
+                    MediaStatus.COMPLETED.name(),
+                    PipelineStage.COMPLETED.value(),
+                    "stt_completed",
+                    null,
+                    null,
+                    transcriptId,
+                    null,
+                    extractionId,
+                    now
+            );
+        }
+
+        Map<String, Object> toMap() {
+            Map<String, Object> map = new HashMap<>();
+            map.put("lecture_id", lectureId);
+            map.put("transcript_status", transcriptStatus);
+            map.put("summary_status", summaryStatus);
+            map.put("audio_status", audioStatus);
+            map.put("processing_stage", processingStage);
+            map.put("processing_step", processingStep);
+            map.put("processing_error_code", processingErrorCode);
+            map.put("processing_error", processingError);
+            map.put("transcript_id", transcriptId);
+            map.put("note_id", noteId);
+            map.put("extraction_id", extractionId);
+            map.put("updated_at", updatedAt);
+            return map;
+        }
+    }
+
+    record ExtractionSnapshot(String id, String lectureId, String transcriptId, Map<String, Object> raw) {
+        static ExtractionSnapshot from(Map<String, Object> row) {
+            Map<String, Object> copy = new HashMap<>(row);
+            return new ExtractionSnapshot(
+                    String.valueOf(copy.getOrDefault("id", "")).trim(),
+                    String.valueOf(copy.getOrDefault("lecture_id", "")).trim(),
+                    copy.get("transcript_id") == null ? null : String.valueOf(copy.get("transcript_id")).trim(),
+                    copy
+            );
+        }
+
+        Map<String, Object> toMap() {
+            return new HashMap<>(raw);
+        }
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaTranscriptionService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaTranscriptionService.java
@@ -27,6 +27,7 @@ public class MediaTranscriptionService {
     private final MediaTranscriptionMetrics metrics;
     private final MediaExtractionCallbackSupport callbackSupport;
     private final MediaTranscriptionDraftSupport draftSupport;
+    private final MediaTranscriptionPersistenceSupport persistenceSupport;
 
     public MediaTranscriptionService(
             FeatureStoreRepository repository,
@@ -36,7 +37,8 @@ public class MediaTranscriptionService {
             TranscriptSegmenter segmenter,
             MediaTranscriptionMetrics metrics,
             MediaExtractionCallbackSupport callbackSupport,
-            MediaTranscriptionDraftSupport draftSupport
+            MediaTranscriptionDraftSupport draftSupport,
+            MediaTranscriptionPersistenceSupport persistenceSupport
     ) {
         this.repository = repository;
         this.learningService = learningService;
@@ -46,6 +48,7 @@ public class MediaTranscriptionService {
         this.metrics = metrics;
         this.callbackSupport = callbackSupport;
         this.draftSupport = draftSupport;
+        this.persistenceSupport = persistenceSupport;
     }
 
     public Map<String, Object> transcribe(
@@ -58,11 +61,14 @@ public class MediaTranscriptionService {
             String audioUrl
     ) {
         String now = Instant.now().toString();
-        Map<String, Object> extractionInProgress = markExtractionInProgress(extraction, now);
+        Map<String, Object> extractionInProgress = persistenceSupport.markExtractionInProgress(repository, EXTRACTION_SCOPE, extraction, now);
         TranscriptionDraft draft = buildDraft(extractionInProgress, lectureId, language, durationMsInput, sttProvider, sttModel, audioUrl);
         persistTranscript(lectureId, draft);
-        Map<String, Object> pipelinePayload = persistPipeline(lectureId, extractionInProgress, draft, now);
-        persistCompletedExtraction(extractionInProgress, draft, now);
+        Map<String, Object> pipelinePayload = persistenceSupport.persistPipeline(repository, PIPELINE_SCOPE, lectureId, extractionInProgress.get("id"), draft.transcriptId(), now);
+        persistenceSupport.persistCompletedExtraction(
+                repository, EXTRACTION_SCOPE, extractionInProgress, draft.transcriptId(), draft.durationMs(), draft.language(),
+                draft.provider(), draft.model(), draft.audioUrl(), draft.quality(), now
+        );
         Map<String, Object> ragIndex = ragService == null ? Map.of() : ragService.rebuildRagIndex(lectureId, null);
         return assembleTranscribeResponse(draft, audioUrl, pipelinePayload, ragIndex);
     }
@@ -84,10 +90,10 @@ public class MediaTranscriptionService {
             String approvalState,
             String notificationChannel
     ) {
-        ExtractionSnapshot extraction = findExtraction(extractionId);
+        MediaTranscriptionPersistenceSupport.ExtractionSnapshot extraction = persistenceSupport.findExtraction(repository, EXTRACTION_SCOPE, extractionId);
         if (extraction == null) return null;
         if (callbackSupport.isStaleCallback(extraction.toMap(), eventVersion)) {
-            return normalizeExtractionForResponse(callbackSupport.staleCallbackResponse(extraction.toMap()));
+            return persistenceSupport.normalizeExtractionForResponse(callbackSupport.staleCallbackResponse(extraction.toMap()));
         }
 
         String now = Instant.now().toString();
@@ -113,7 +119,7 @@ public class MediaTranscriptionService {
                 now
         );
         repository.upsertKv(EXTRACTION_SCOPE, extractionId, mutable);
-        ExtractionSnapshot applied = ExtractionSnapshot.from(mutable);
+        MediaTranscriptionPersistenceSupport.ExtractionSnapshot applied = MediaTranscriptionPersistenceSupport.ExtractionSnapshot.from(mutable);
 
         String lectureId = applied.lectureId();
         if (!lectureId.isBlank()) {
@@ -124,23 +130,7 @@ public class MediaTranscriptionService {
             );
         }
         appendActivity(mutable, extractionId, lectureId, callbackStatus);
-        return normalizeExtractionForResponse(mutable);
-    }
-
-    private Map<String, Object> markExtractionInProgress(Map<String, Object> extraction, String now) {
-        Map<String, Object> payload = new HashMap<>(extraction);
-        applyExtractionStatusUpdate(payload, new ExtractionStatusUpdate(
-                MediaStatus.PROCESSING.name(),
-                MediaStatus.PROCESSING.name(),
-                PipelineStage.TRANSCRIBING.value(),
-                "stt_started",
-                null,
-                null,
-                now
-        ));
-        String extractionId = String.valueOf(payload.getOrDefault("id", ""));
-        repository.upsertKv(EXTRACTION_SCOPE, extractionId, payload);
-        return payload;
+        return persistenceSupport.normalizeExtractionForResponse(mutable);
     }
 
     private TranscriptionDraft buildDraft(Map<String, Object> extraction, String lectureId, String language, Integer durationMsInput, String sttProvider, String sttModel, String audioUrl) {
@@ -172,34 +162,6 @@ public class MediaTranscriptionService {
     private void persistTranscript(String lectureId, TranscriptionDraft draft) {
         TranscriptPayload payload = createTranscriptPayload(lectureId, draft);
         repository.upsertKv(TRANSCRIPT_SCOPE, lectureId, payload.toMap());
-    }
-
-    private Map<String, Object> persistPipeline(String lectureId, Map<String, Object> extraction, TranscriptionDraft draft, String now) {
-        PipelinePayload payload = PipelinePayload.completed(lectureId, draft.transcriptId(), extraction.get("id"), now);
-        repository.upsertKv(PIPELINE_SCOPE, lectureId, payload.toMap());
-        return payload.toMap();
-    }
-
-    private void persistCompletedExtraction(Map<String, Object> extractionInProgress, TranscriptionDraft draft, String now) {
-        Map<String, Object> extractionPayload = new HashMap<>(extractionInProgress);
-        applyExtractionStatusUpdate(extractionPayload, new ExtractionStatusUpdate(
-                MediaStatus.COMPLETED.name(),
-                MediaStatus.COMPLETED.name(),
-                PipelineStage.COMPLETED.value(),
-                "stt_completed",
-                null,
-                null,
-                now
-        ));
-        extractionPayload.put("transcript_id", draft.transcriptId());
-        extractionPayload.put("audio_duration_ms", draft.durationMs());
-        extractionPayload.put("processed_at", now);
-        extractionPayload.put("language", draft.language());
-        extractionPayload.put("requested_stt_provider", draft.provider());
-        extractionPayload.put("requested_stt_model", draft.model());
-        extractionPayload.put("audio_url", draft.audioUrl());
-        extractionPayload.put("stt_quality", draft.quality());
-        repository.upsertKv(EXTRACTION_SCOPE, draft.transcriptId(), extractionPayload);
     }
 
     private Map<String, Object> assembleTranscribeResponse(TranscriptionDraft draft, String audioUrl, Map<String, Object> pipelinePayload, Map<String, Object> ragIndex) {
@@ -253,46 +215,12 @@ public class MediaTranscriptionService {
         );
     }
 
-    private void applyExtractionStatusUpdate(Map<String, Object> extraction, ExtractionStatusUpdate update) {
-        extraction.put("status", update.status());
-        extraction.put("stt_status", update.sttStatus());
-        extraction.put("processing_stage", update.processingStage());
-        extraction.put("processing_step", update.processingStep());
-        extraction.put("processing_error_code", update.processingErrorCode());
-        extraction.put("processing_error", update.processingError());
-        extraction.put("updated_at", update.updatedAt());
-    }
-
-    private ExtractionSnapshot findExtraction(String extractionId) {
-        Map<String, Object> extraction = repository.getKv(EXTRACTION_SCOPE, extractionId);
-        if (extraction != null) return ExtractionSnapshot.from(extraction);
-        for (Map<String, Object> row : repository.listEventsByScope(EXTRACTION_SCOPE)) {
-            if (extractionId.equals(String.valueOf(row.getOrDefault("id", "")))) return ExtractionSnapshot.from(row);
-        }
-        return null;
-    }
-
     private void appendActivity(Map<String, Object> extraction, String extractionId, String lectureId, MediaStatus status) {
         if (activityEventService == null) return;
         String userId = String.valueOf(extraction.getOrDefault("user_id", "")).trim();
         if (userId.isBlank()) return;
         activityEventService.append(userId, "media_extraction_" + status.name().toLowerCase(), "extraction", extractionId, Map.of("lecture_id", lectureId, "status", status.name()));
     }
-
-    private Map<String, Object> normalizeExtractionForResponse(Map<String, Object> extraction) {
-        Map<String, Object> hydrated = new HashMap<>(extraction);
-        hydrated.putIfAbsent("processing_stage", PipelineStage.QUEUED.value());
-        hydrated.putIfAbsent("processing_step", "job_requested");
-        hydrated.putIfAbsent("processing_error_code", null);
-        hydrated.putIfAbsent("processing_error", null);
-        hydrated.putIfAbsent("stt_status", MediaStatus.PENDING.name());
-        hydrated.putIfAbsent("error_message", null);
-        hydrated.putIfAbsent("callback_ignored", false);
-        hydrated.putIfAbsent("callback_status", "APPLIED");
-        hydrated.putIfAbsent("last_event_version", 0L);
-        return hydrated;
-    }
-
 
     private record TranscriptionDraft(
             String transcriptId,
@@ -324,17 +252,6 @@ public class MediaTranscriptionService {
         List<Map<String, Object>> toSegments(TranscriptSegmenter segmenter) {
             return segmenter.split(text, durationMs);
         }
-    }
-
-    private record ExtractionStatusUpdate(
-            String status,
-            String sttStatus,
-            String processingStage,
-            String processingStep,
-            Object processingErrorCode,
-            Object processingError,
-            String updatedAt
-    ) {
     }
 
     private record TranscriptPayload(
@@ -373,70 +290,4 @@ public class MediaTranscriptionService {
         }
     }
 
-    private record PipelinePayload(
-            String lectureId,
-            String transcriptStatus,
-            String summaryStatus,
-            String audioStatus,
-            String processingStage,
-            String processingStep,
-            Object processingErrorCode,
-            Object processingError,
-            String transcriptId,
-            Object noteId,
-            Object extractionId,
-            String updatedAt
-    ) {
-        static PipelinePayload completed(String lectureId, String transcriptId, Object extractionId, String now) {
-            return new PipelinePayload(
-                    lectureId,
-                    MediaStatus.COMPLETED.name(),
-                    MediaStatus.PENDING.name(),
-                    MediaStatus.COMPLETED.name(),
-                    PipelineStage.COMPLETED.value(),
-                    "stt_completed",
-                    null,
-                    null,
-                    transcriptId,
-                    null,
-                    extractionId,
-                    now
-            );
-        }
-
-        Map<String, Object> toMap() {
-            Map<String, Object> map = new HashMap<>();
-            map.put("lecture_id", lectureId);
-            map.put("transcript_status", transcriptStatus);
-            map.put("summary_status", summaryStatus);
-            map.put("audio_status", audioStatus);
-            map.put("processing_stage", processingStage);
-            map.put("processing_step", processingStep);
-            map.put("processing_error_code", processingErrorCode);
-            map.put("processing_error", processingError);
-            map.put("transcript_id", transcriptId);
-            map.put("note_id", noteId);
-            map.put("extraction_id", extractionId);
-            map.put("updated_at", updatedAt);
-            return map;
-        }
-    }
-
-    private record ExtractionSnapshot(String id, String lectureId, String transcriptId, Map<String, Object> raw) {
-        static ExtractionSnapshot from(Map<String, Object> row) {
-            Map<String, Object> copy = new HashMap<>(row);
-            return new ExtractionSnapshot(
-                    String.valueOf(copy.getOrDefault("id", "")).trim(),
-                    String.valueOf(copy.getOrDefault("lecture_id", "")).trim(),
-                    copy.get("transcript_id") == null ? null : String.valueOf(copy.get("transcript_id")).trim(),
-                    copy
-            );
-        }
-
-        Map<String, Object> toMap() {
-            return new HashMap<>(raw);
-        }
-    }
-
-    
 }


### PR DESCRIPTION
## Summary\n- Extract extraction/pipeline persistence responsibilities from MediaTranscriptionService\n- Add MediaTranscriptionPersistenceSupport for status update, persistence, lookup, and response normalization\n- Keep transcription behavior and callback flow unchanged\n\n## Verification\n- npm run build:backend\n- npm run test:backend