### PR TITLE
refactor(api): split shortform compose validation support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -1,13 +1,10 @@
 package com.myway.backendspring.api;
 
 import com.myway.backendspring.api.support.ShortformControllerSupport;
+import com.myway.backendspring.api.support.ShortformComposeValidationSupport;
 import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
-import com.myway.backendspring.domain.CourseDetail;
-import com.myway.backendspring.domain.DemoLearningService;
-import com.myway.backendspring.domain.EnrollmentItem;
-import com.myway.backendspring.domain.LectureItem;
 import com.myway.backendspring.feature.shortform.ShortformService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -43,26 +40,26 @@ public class ShortformController {
     public record RetryFailedExportsRequest(Boolean include_permanent, Integer limit) {}
 
     private final SessionService sessionService;
-    private final DemoLearningService learningService;
     private final ShortformService shortformService;
     private final String callbackToken;
     private final long maxClipDurationMs;
     private final ShortformControllerSupport support;
+    private final ShortformComposeValidationSupport composeSupport;
 
     public ShortformController(
             SessionService sessionService,
-            DemoLearningService learningService,
             ShortformService shortformService,
             @Value("${myway.shortform.callback.token:dev-shortform-callback-token}") String callbackToken,
             @Value("${myway.shortform.compose.max-clip-duration-ms:300000}") long maxClipDurationMs,
-            ShortformControllerSupport support
+            ShortformControllerSupport support,
+            ShortformComposeValidationSupport composeSupport
     ) {
         this.sessionService = sessionService;
-        this.learningService = learningService;
         this.shortformService = shortformService;
         this.callbackToken = callbackToken;
         this.maxClipDurationMs = Math.max(1000L, maxClipDurationMs);
         this.support = support;
+        this.composeSupport = composeSupport;
     }
 
     private SessionView require(String auth) { return sessionService.me(auth); }
@@ -113,38 +110,20 @@ public class ShortformController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> compose(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody ComposeRequest body) {
         SessionView s = require(auth);
         if (s == null) return support.unauthenticated();
-        List<Map<String, Object>> clips = new java.util.ArrayList<>();
         List<ComposeClipRequest> sourceClips = body.clips() == null ? List.of() : body.clips();
-        for (ComposeClipRequest clip : sourceClips) {
-            String lectureId = clip.lecture_id().trim();
-            long startMs = clip.start_ms();
-            long endMs = clip.end_ms();
-            if (endMs <= startMs) {
-                return support.badRequest("INVALID_CLIP_RANGE", "clip end_ms는 start_ms보다 커야 합니다.");
-            }
-            if ((endMs - startMs) > maxClipDurationMs) {
-                return support.badRequest("CLIP_DURATION_EXCEEDED", "clip 길이가 허용 최대치를 초과했습니다.");
-            }
-            LectureItem lecture = learningService.getLecture(lectureId);
-            if (lecture == null) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                        .body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다: " + lectureId));
-            }
-            if (!canComposeFromLecture(s, lecture)) {
-                return support.forbidden("해당 강의 클립을 조합할 권한이 없습니다.");
-            }
-            if (body.course_id() != null && !body.course_id().isBlank()) {
-                String requestedCourseId = body.course_id().trim();
-                if (!requestedCourseId.equals(lecture.course_id())) {
-                    return support.badRequest("COURSE_LECTURE_MISMATCH", "course_id와 clip lecture_id가 일치하지 않습니다.");
-                }
-            }
-            clips.add(Map.of(
-                    "lecture_id", lectureId,
-                    "start_ms", startMs,
-                    "end_ms", endMs
-            ));
+        List<ShortformComposeValidationSupport.ComposeClipInput> clipInputs = sourceClips.stream()
+                .map(clip -> new ShortformComposeValidationSupport.ComposeClipInput(clip.lecture_id(), clip.start_ms(), clip.end_ms()))
+                .toList();
+        ShortformComposeValidationSupport.ComposeValidationResult clipValidation = composeSupport.validateAndBuildClips(
+                s,
+                body.course_id(),
+                clipInputs,
+                maxClipDurationMs
+        );
+        if (!clipValidation.valid()) {
+            return clipValidation.errorResponse();
         }
+        List<Map<String, Object>> clips = clipValidation.clips();
         Map<String, Object> payload = Map.of(
                 "title", support.orEmpty(body.title()),
                 "description", support.orEmpty(body.description()),
@@ -153,18 +132,6 @@ public class ShortformController {
                 "extraction_id", support.orEmpty(body.extraction_id())
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.composeShortform(s.user().id(), payload), "숏폼이 생성되었습니다."));
-    }
-
-    private boolean canComposeFromLecture(SessionView session, LectureItem lecture) {
-        if (support.isAdmin(session)) {
-            return true;
-        }
-        if (support.isInstructor(session)) {
-            CourseDetail course = learningService.getCourseDetail(lecture.course_id(), session.user().id());
-            return course != null && session.user().id().equals(course.instructor_id());
-        }
-        List<EnrollmentItem> enrollments = learningService.listEnrollments(session.user().id());
-        return enrollments.stream().anyMatch(item -> lecture.course_id().equals(item.course_id()));
     }
 
     @GetMapping("/video/{id}")

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/ShortformComposeValidationSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/ShortformComposeValidationSupport.java
@@ -1,0 +1,98 @@
+package com.myway.backendspring.api.support;
+
+import com.myway.backendspring.auth.SessionView;
+import com.myway.backendspring.common.ApiResponse;
+import com.myway.backendspring.domain.CourseDetail;
+import com.myway.backendspring.domain.DemoLearningService;
+import com.myway.backendspring.domain.EnrollmentItem;
+import com.myway.backendspring.domain.LectureItem;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ShortformComposeValidationSupport {
+    private final DemoLearningService learningService;
+    private final ShortformControllerSupport support;
+
+    public ShortformComposeValidationSupport(
+            DemoLearningService learningService,
+            ShortformControllerSupport support
+    ) {
+        this.learningService = learningService;
+        this.support = support;
+    }
+
+    public ComposeValidationResult validateAndBuildClips(
+            SessionView session,
+            String requestedCourseId,
+            List<ComposeClipInput> sourceClips,
+            long maxClipDurationMs
+    ) {
+        List<Map<String, Object>> clips = new ArrayList<>();
+        for (ComposeClipInput clip : sourceClips) {
+            String lectureId = clip.lectureId().trim();
+            long startMs = clip.startMs();
+            long endMs = clip.endMs();
+            if (endMs <= startMs) {
+                return ComposeValidationResult.failure(support.badRequest("INVALID_CLIP_RANGE", "clip end_ms는 start_ms보다 커야 합니다."));
+            }
+            if ((endMs - startMs) > maxClipDurationMs) {
+                return ComposeValidationResult.failure(support.badRequest("CLIP_DURATION_EXCEEDED", "clip 길이가 허용 최대치를 초과했습니다."));
+            }
+            LectureItem lecture = learningService.getLecture(lectureId);
+            if (lecture == null) {
+                return ComposeValidationResult.failure(
+                        ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다: " + lectureId))
+                );
+            }
+            if (!canComposeFromLecture(session, lecture)) {
+                return ComposeValidationResult.failure(support.forbidden("해당 강의 클립을 조합할 권한이 없습니다."));
+            }
+            if (requestedCourseId != null && !requestedCourseId.isBlank() && !requestedCourseId.trim().equals(lecture.course_id())) {
+                return ComposeValidationResult.failure(
+                        support.badRequest("COURSE_LECTURE_MISMATCH", "course_id와 clip lecture_id가 일치하지 않습니다.")
+                );
+            }
+            clips.add(Map.of(
+                    "lecture_id", lectureId,
+                    "start_ms", startMs,
+                    "end_ms", endMs
+            ));
+        }
+        return ComposeValidationResult.success(clips);
+    }
+
+    private boolean canComposeFromLecture(SessionView session, LectureItem lecture) {
+        if (support.isAdmin(session)) {
+            return true;
+        }
+        if (support.isInstructor(session)) {
+            CourseDetail course = learningService.getCourseDetail(lecture.course_id(), session.user().id());
+            return course != null && session.user().id().equals(course.instructor_id());
+        }
+        List<EnrollmentItem> enrollments = learningService.listEnrollments(session.user().id());
+        return enrollments.stream().anyMatch(item -> lecture.course_id().equals(item.course_id()));
+    }
+
+    public record ComposeClipInput(String lectureId, long startMs, long endMs) {}
+
+    public record ComposeValidationResult(
+            boolean valid,
+            List<Map<String, Object>> clips,
+            ResponseEntity<ApiResponse<Map<String, Object>>> errorResponse
+    ) {
+        public static ComposeValidationResult success(List<Map<String, Object>> clips) {
+            return new ComposeValidationResult(true, clips, null);
+        }
+
+        public static ComposeValidationResult failure(ResponseEntity<ApiResponse<Map<String, Object>>> errorResponse) {
+            return new ComposeValidationResult(false, List.of(), errorResponse);
+        }
+    }
+}


### PR DESCRIPTION
## Summary\n- split shortform compose clip validation/authorization into dedicated support\n- slim down ShortformController compose path and keep response semantics\n\n## Verification\n- npm run build:backend\n- npm run test:backend