### PR TITLE
refactor(domain): split demo learning dashboard support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningDashboardSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningDashboardSupport.java
@@ -1,0 +1,55 @@
+package com.myway.backendspring.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class DemoLearningDashboardSupport {
+    public List<CourseCard> listCourseCards(
+            String userId,
+            List<CourseDetail> courses,
+            ProgressPercentResolver progressPercentResolver
+    ) {
+        return courses.stream()
+                .map(course -> new CourseCard(
+                        course.id(),
+                        course.title(),
+                        course.instructor_id(),
+                        progressPercentResolver.resolve(userId, course.id())
+                ))
+                .toList();
+    }
+
+    public List<CourseCard> listManagedCourseCards(
+            String userId,
+            String role,
+            List<CourseDetail> courses,
+            ProgressPercentResolver progressPercentResolver
+    ) {
+        return courses.stream()
+                .filter(course -> "admin".equals(role) || course.instructor_id().equals(userId))
+                .map(course -> new CourseCard(
+                        course.id(),
+                        course.title(),
+                        course.instructor_id(),
+                        progressPercentResolver.resolve(userId, course.id())
+                ))
+                .toList();
+    }
+
+    public DashboardView buildDashboard(
+            String userId,
+            List<CourseCard> cards,
+            List<EnrollmentItem> enrollments,
+            Set<String> completedLectureIds
+    ) {
+        return new DashboardView(cards, enrollments.size(), completedLectureIds.size());
+    }
+
+    @FunctionalInterface
+    public interface ProgressPercentResolver {
+        int resolve(String userId, String courseId);
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -39,6 +39,7 @@ public class DemoLearningService {
     private final DemoLearningMetadataSupport demoLearningMetadataSupport;
     private final DemoLearningBootstrapSupport demoLearningBootstrapSupport;
     private final DemoLearningCourseAccessSupport demoLearningCourseAccessSupport;
+    private final DemoLearningDashboardSupport demoLearningDashboardSupport;
 
     @Autowired
     public DemoLearningService(
@@ -55,7 +56,8 @@ public class DemoLearningService {
             DemoLearningProgressSupport demoLearningProgressSupport,
             DemoLearningMetadataSupport demoLearningMetadataSupport,
             DemoLearningBootstrapSupport demoLearningBootstrapSupport,
-            DemoLearningCourseAccessSupport demoLearningCourseAccessSupport
+            DemoLearningCourseAccessSupport demoLearningCourseAccessSupport,
+            DemoLearningDashboardSupport demoLearningDashboardSupport
     ) {
         this.store = store;
         this.activityEventService = activityEventService;
@@ -71,6 +73,7 @@ public class DemoLearningService {
         this.demoLearningMetadataSupport = demoLearningMetadataSupport;
         this.demoLearningBootstrapSupport = demoLearningBootstrapSupport;
         this.demoLearningCourseAccessSupport = demoLearningCourseAccessSupport;
+        this.demoLearningDashboardSupport = demoLearningDashboardSupport;
         initSeedData();
     }
 
@@ -90,6 +93,7 @@ public class DemoLearningService {
         this.demoLearningMetadataSupport = new DemoLearningMetadataSupport();
         this.demoLearningBootstrapSupport = new DemoLearningBootstrapSupport();
         this.demoLearningCourseAccessSupport = new DemoLearningCourseAccessSupport();
+        this.demoLearningDashboardSupport = new DemoLearningDashboardSupport();
         initSeedData();
     }
 
@@ -121,14 +125,20 @@ public class DemoLearningService {
     }
 
     public List<CourseCard> listCourseCards(String userId) {
-        return listAllCourses().stream().map(c -> new CourseCard(c.id(), c.title(), c.instructor_id(), progressPercent(userId, c.id()))).toList();
+        return demoLearningDashboardSupport.listCourseCards(
+                userId,
+                listAllCourses(),
+                this::progressPercent
+        );
     }
 
     public List<CourseCard> listManagedCourseCards(String userId, String role) {
-        return listAllCourses().stream()
-                .filter(c -> "admin".equals(role) || c.instructor_id().equals(userId))
-                .map(c -> new CourseCard(c.id(), c.title(), c.instructor_id(), progressPercent(userId, c.id())))
-                .toList();
+        return demoLearningDashboardSupport.listManagedCourseCards(
+                userId,
+                role,
+                listAllCourses(),
+                this::progressPercent
+        );
     }
 
     public CourseDetail createCourse(String instructorId, String title, List<String> lectureTitles) {
@@ -175,9 +185,12 @@ public class DemoLearningService {
 
     public DashboardView getDashboard(String userId) {
         List<CourseCard> cards = listCourseCards(userId);
-        int enrolled = listEnrollments(userId).size();
-        int completed = listCompletedLectureIds(userId).size();
-        return new DashboardView(cards, enrolled, completed);
+        return demoLearningDashboardSupport.buildDashboard(
+                userId,
+                cards,
+                listEnrollments(userId),
+                listCompletedLectureIds(userId)
+        );
     }
 
     public List<MaterialItem> getMaterials(String courseId) {


### PR DESCRIPTION
## Summary\n- split course-card/dashboard aggregation out of DemoLearningService into DemoLearningDashboardSupport\n- keep existing response semantics while reducing service responsibilities\n\n## Verification\n- npm run build:backend\n- npm run test:backend