### PR TITLE
refactor(frontend): split role page router by role renderers

### DIFF
--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
 import { getLectureDisplayDurationMinutes, type CourseDetail, type LectureDetail } from '@myway/shared';
 import { CourseSessionTimeline } from './CourseSessionTimeline';
 import { StatePanel } from './StatePanel';
 import { buildProtectedVideoUrl, resolveLectureVideoUrl } from '../../../lib/video-url';
-import { saveLectureVideoMappingDetailed } from '../../../lib/api-media';
+import { useLectureAssetRemap } from './useLectureAssetRemap';
 
 type CourseExploreDetailPanelProps = {
   course: CourseDetail | null;
@@ -175,9 +174,7 @@ export function CourseExploreDetailPanel({
   onTabChange,
   onNavigate,
 }: CourseExploreDetailPanelProps) {
-  const [remapAssetKey, setRemapAssetKey] = useState('');
-  const [remapBusy, setRemapBusy] = useState(false);
-  const [remapMessage, setRemapMessage] = useState<string | null>(null);
+  const { remapAssetKey, setRemapAssetKey, remapBusy, remapMessage, handleRemapAssetKey } = useLectureAssetRemap(sessionToken);
   const detailLecture = highlightedLecture;
   const isLocked = Boolean(course && !course.enrolled && !canManageCurrent);
   const resolvedLectureVideoUrl = detailLecture ? resolveLectureVideoUrl(detailLecture) : undefined;
@@ -188,22 +185,6 @@ export function CourseExploreDetailPanel({
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
       void navigator.clipboard.writeText(fileName);
     }
-  };
-
-  const handleRemapAssetKey = async () => {
-    if (!detailLecture?.id || !remapAssetKey.trim()) {
-      setRemapMessage('asset key를 입력해 주세요.');
-      return;
-    }
-
-    setRemapBusy(true);
-    setRemapMessage(null);
-    const response = await saveLectureVideoMappingDetailed({
-      lecture_id: detailLecture.id,
-      asset_key: remapAssetKey.trim(),
-    }, sessionToken);
-    setRemapBusy(false);
-    setRemapMessage(response?.success ? '재매핑 저장 완료' : (response?.error?.message ?? '재매핑 실패'));
   };
 
   return (
@@ -392,7 +373,7 @@ export function CourseExploreDetailPanel({
                                 <button
                                   type="button"
                                   disabled={remapBusy}
-                                  onClick={() => void handleRemapAssetKey()}
+                            onClick={() => void handleRemapAssetKey(detailLecture?.id)}
                                   className="rounded-xl border border-cyan-200 bg-cyan-50 px-3 py-2 text-[12px] font-semibold text-cyan-700 transition hover:bg-cyan-100 disabled:opacity-60"
                                 >
                                   R2 재매핑

--- a/frontend/src/features/lms/components/useLectureAssetRemap.ts
+++ b/frontend/src/features/lms/components/useLectureAssetRemap.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { saveLectureVideoMappingDetailed } from '../../../lib/api-media';
+
+export function useLectureAssetRemap(sessionToken?: string | null) {
+  const [remapAssetKey, setRemapAssetKey] = useState('');
+  const [remapBusy, setRemapBusy] = useState(false);
+  const [remapMessage, setRemapMessage] = useState<string | null>(null);
+
+  const handleRemapAssetKey = async (lectureId?: string | null) => {
+    if (!lectureId || !remapAssetKey.trim()) {
+      setRemapMessage('asset key를 입력해 주세요.');
+      return;
+    }
+
+    setRemapBusy(true);
+    setRemapMessage(null);
+    const response = await saveLectureVideoMappingDetailed(
+      { lecture_id: lectureId, asset_key: remapAssetKey.trim() },
+      sessionToken,
+    );
+    setRemapBusy(false);
+    setRemapMessage(response?.success ? '재매핑 저장 완료' : (response?.error?.message ?? '재매핑 실패'));
+  };
+
+  return {
+    remapAssetKey,
+    setRemapAssetKey,
+    remapBusy,
+    remapMessage,
+    handleRemapAssetKey,
+  };
+}

--- a/frontend/src/features/lms/pages/RolePageRouter.tsx
+++ b/frontend/src/features/lms/pages/RolePageRouter.tsx
@@ -42,45 +42,272 @@ type RolePageRouterProps = Pick<
   onNavigate: (page: LmsPageId) => void;
 };
 
-export function RolePageRouter({
-  session,
-  page,
-  dashboard,
-  aiLogs,
-  enrolledCourses,
-  highlightedLecture,
-  recommendations,
-  providers,
-  courseCards,
-  insights,
-  onSelectCourse,
-  onSelectLecture,
-  onCreateCourse,
-  onEnroll,
-  demoUsers,
-  selectedCourse,
-  selectedLectureId,
-  loading,
-  busy,
-  onNavigate,
-}: RolePageRouterProps) {
-  const sessionToken = session.session_token;
-  const shortformInitialTab = page === 'my-shortforms' ? 'library' : page === 'community' ? 'community' : 'create';
+type SharedRouteArgs = {
+  session: LoginResponse;
+  page: LmsPageId;
+  shortformInitialTab: 'create' | 'library' | 'community';
+  sessionToken: string;
+} & RolePageRouterProps;
 
-  if (page === 'home') {
+function renderMyCourses(args: SharedRouteArgs) {
+  return (
+    <MyCoursesPage
+      session={args.session}
+      courses={args.courseCards}
+      selectedCourse={args.selectedCourse}
+      onSelectCourse={args.onSelectCourse}
+      onNavigate={args.onNavigate}
+    />
+  );
+}
+
+function renderCourses(args: SharedRouteArgs, canManageCurrent: boolean) {
+  return (
+    <CoursesPage
+      courses={args.courseCards}
+      selectedCourse={args.selectedCourse}
+      highlightedLecture={args.highlightedLecture}
+      selectedLectureId={args.selectedLectureId}
+      canManageCurrent={canManageCurrent}
+      busy={args.busy}
+      sessionToken={args.sessionToken}
+      onCreateCourse={args.onCreateCourse}
+      onEnroll={args.onEnroll}
+      onNavigate={args.onNavigate}
+      onSelectCourse={args.onSelectCourse}
+      onSelectLecture={args.onSelectLecture}
+    />
+  );
+}
+
+function renderLectureWatch(args: SharedRouteArgs, canManageCurrent: boolean) {
+  return (
+    <LectureWatchPage
+      courses={args.courseCards}
+      selectedCourse={args.selectedCourse}
+      highlightedLecture={args.highlightedLecture}
+      selectedLectureId={args.selectedLectureId}
+      canManageCurrent={canManageCurrent}
+      sessionToken={args.sessionToken}
+      onEnroll={args.onEnroll}
+      onSelectCourse={args.onSelectCourse}
+      onSelectLecture={args.onSelectLecture}
+      onNavigate={args.onNavigate}
+    />
+  );
+}
+
+function renderCourseCreate(args: SharedRouteArgs) {
+  return (
+    <CourseCreatePage
+      courses={args.courseCards}
+      canManageCurrent={true}
+      busy={args.busy}
+      sessionToken={args.sessionToken}
+      selectedCourse={args.selectedCourse}
+      highlightedLecture={args.highlightedLecture}
+      onCreateCourse={args.onCreateCourse}
+      onSelectCourse={args.onSelectCourse}
+      onSelectLecture={args.onSelectLecture}
+      onNavigate={args.onNavigate}
+    />
+  );
+}
+
+function renderShortform(args: SharedRouteArgs) {
+  return withSuspense((
+    <ShortformHubPage
+      session={args.session}
+      highlightedLecture={args.highlightedLecture}
+      selectedCourse={args.selectedCourse}
+      courses={args.courseCards}
+      sessionToken={args.sessionToken}
+      recommendations={args.recommendations}
+      initialTab={args.shortformInitialTab}
+    />
+  ));
+}
+
+function renderAiChat(args: SharedRouteArgs, canManageCurrent: boolean) {
+  return <AIChatPage highlightedLecture={args.highlightedLecture} insights={args.insights} selectedCourse={args.selectedCourse} canManageCurrent={canManageCurrent} sessionToken={args.sessionToken} />;
+}
+
+function renderMediaPipeline(args: SharedRouteArgs) {
+  return withSuspense((
+    <MediaPipelinePage
+      selectedCourse={args.selectedCourse}
+      highlightedLecture={args.highlightedLecture}
+      sessionToken={args.sessionToken}
+      viewerRole={args.session.user.role}
+    />
+  ));
+}
+
+function renderAdminRoutes(args: SharedRouteArgs): ReactNode {
+  switch (args.page) {
+    case 'dashboard':
+      return withSuspense(<AdminDashboardPage dashboard={args.dashboard} users={args.demoUsers} courses={args.courseCards} insights={args.insights} />);
+    case 'my-courses':
+      return renderMyCourses(args);
+    case 'courses':
+      return renderCourses(args, true);
+    case 'lecture-watch':
+      return renderLectureWatch(args, true);
+    case 'course-create':
+      return renderCourseCreate(args);
+    case 'lecture-studio':
+      return (
+        <LectureStudioPage
+          courses={args.courseCards}
+          selectedCourse={args.selectedCourse}
+          highlightedLecture={args.highlightedLecture}
+          onSelectCourse={args.onSelectCourse}
+        />
+      );
+    case 'ai-chat':
+      return renderAiChat(args, true);
+    case 'ai-summary':
+      return <AISummaryPage highlightedLecture={args.highlightedLecture} insights={args.insights} />;
+    case 'quiz-gen':
+      return <QuizGenPage courses={args.courseCards} />;
+    case 'assignment-check':
+      return <AssignmentCheckPage courses={args.courseCards} />;
+    case 'admin-users':
+      return withSuspense(<AdminUsersPage users={args.demoUsers} />);
+    case 'admin-instructors':
+      return withSuspense(<AdminInstructorsPage instructors={args.demoUsers.filter((user) => user.role === 'INSTRUCTOR')} courses={args.courseCards} />);
+    case 'admin-assign':
+      return withSuspense(<AdminAssignPage users={args.demoUsers} courses={args.courseCards} />);
+    case 'admin-stats':
+      return withSuspense(<AdminStatsPage dashboard={args.dashboard} courses={args.courseCards} users={args.demoUsers} insights={args.insights} aiLogs={args.aiLogs} />);
+    case 'admin-automation':
+      return withSuspense(<AdminAutomationPage providerCatalog={args.providers} />);
+    case 'media-pipeline':
+      return renderMediaPipeline(args);
+    case 'shortform':
+    case 'my-shortforms':
+    case 'community':
+      return renderShortform(args);
+    default:
+      return (
+        <RolePageFallback
+          icon="ri-layout-grid-line"
+          title="운영 화면 준비 중"
+          description="사용자 관리, 통계, 강사 배정 화면은 이 디자인 시스템 위에서 다음 단계로 이어집니다."
+          actions={[
+            { label: '대시보드로 이동', onClick: () => args.onNavigate('dashboard') },
+            { label: '내 강의 보기', onClick: () => args.onNavigate('my-courses') },
+          ]}
+        />
+      );
+  }
+}
+
+function renderInstructorRoutes(args: SharedRouteArgs): ReactNode {
+  if (args.page === 'my-courses') return renderMyCourses(args);
+  if (args.page === 'courses') return renderCourses(args, true);
+  if (args.page === 'lecture-watch') return renderLectureWatch(args, true);
+  if (args.page === 'course-create') return renderCourseCreate(args);
+  if (args.page === 'lecture-studio') {
+    return (
+      <LectureStudioPage
+        courses={args.courseCards}
+        selectedCourse={args.selectedCourse}
+        highlightedLecture={args.highlightedLecture}
+        onSelectCourse={args.onSelectCourse}
+      />
+    );
+  }
+  if (args.page === 'ai-chat') return renderAiChat(args, true);
+  if (args.page === 'media-pipeline') return renderMediaPipeline(args);
+  if (args.page === 'quiz-gen') return <QuizGenPage courses={args.courseCards} />;
+  if (args.page === 'ai-summary' || args.page === 'dashboard') {
+    return args.page === 'ai-summary'
+      ? <AISummaryPage highlightedLecture={args.highlightedLecture} insights={args.insights} />
+      : <InstructorDashboardPage dashboard={args.dashboard} courses={args.courseCards} insights={args.insights} />;
+  }
+  if (args.page === 'assignment-check') return <AssignmentCheckPage courses={args.courseCards} />;
+  if (args.page === 'shortform' || args.page === 'my-shortforms' || args.page === 'community') return renderShortform(args);
+
+  return (
+    <RolePageFallback
+      icon="ri-tools-line"
+      title="교강사 도구 연결 준비 중"
+      description="현재 레이아웃과 정보 구조는 레퍼런스 기준으로 정리했고, 기능 연결은 다음 단계에서 이어집니다."
+      actions={[
+        { label: '내 강의로 이동', onClick: () => args.onNavigate('my-courses') },
+        { label: '강의 개설', onClick: () => args.onNavigate('course-create') },
+      ]}
+    />
+  );
+}
+
+function renderStudentRoutes(args: SharedRouteArgs): ReactNode {
+  if (args.page === 'courses') return renderCourses(args, false);
+  if (args.page === 'lecture-watch') return renderLectureWatch(args, false);
+  if (args.page === 'ai-chat') return renderAiChat(args, false);
+  if (args.page === 'ai-summary') return <AISummaryPage highlightedLecture={args.highlightedLecture} insights={args.insights} />;
+  if (args.page === 'quiz-gen') return <QuizGenPage courses={args.courseCards} />;
+  if (args.page === 'assignment-check') return <AssignmentCheckPage courses={args.courseCards} />;
+  if (args.page === 'shortform' || args.page === 'my-shortforms' || args.page === 'community') return renderShortform(args);
+  if (args.page === 'dashboard') {
+    return (
+      <StudentDashboardPage
+        session={args.session}
+        dashboard={args.dashboard}
+        courses={args.enrolledCourses}
+        highlightedLecture={args.highlightedLecture}
+        recommendations={args.recommendations}
+        onSelectCourse={args.onSelectCourse}
+        onNavigate={args.onNavigate}
+      />
+    );
+  }
+  if (args.page === 'my-courses') return renderMyCourses(args);
+  if (args.page === 'media-pipeline') {
+    return (
+      <RolePageFallback
+        icon="ri-lock-line"
+        title="업로드와 전사는 교강사 전용입니다."
+        description="학생은 강의 상세, 챗봇, 숏폼 제작만 사용할 수 있습니다. 영상 업로드와 자동 전사는 교수 또는 강사 계정에서만 가능합니다."
+        actions={[
+          { label: '강의 상세로', onClick: () => args.onNavigate('courses') },
+          { label: '내 강의로', onClick: () => args.onNavigate('my-courses') },
+        ]}
+      />
+    );
+  }
+  return (
+    <RolePageFallback
+      icon="ri-robot-line"
+      title="학습 도구 연결 준비 중"
+      description="숏폼, 커뮤니티, AI 채팅은 동일한 UI 체계에 맞춰 이어서 붙일 수 있게 정리한 상태입니다."
+      actions={[
+        { label: '대시보드로 이동', onClick: () => args.onNavigate('dashboard') },
+        { label: '내 숏폼 보기', onClick: () => args.onNavigate('my-shortforms') },
+      ]}
+    />
+  );
+}
+
+export function RolePageRouter(props: RolePageRouterProps) {
+  const sessionToken = props.session.session_token;
+  const shortformInitialTab = props.page === 'my-shortforms' ? 'library' : props.page === 'community' ? 'community' : 'create';
+
+  if (props.page === 'home') {
     return (
       <HomePage
-        session={session}
-        dashboard={dashboard}
-        courses={enrolledCourses}
-        highlightedLecture={highlightedLecture}
-        onNavigate={onNavigate}
-        onSelectCourse={onSelectCourse}
+        session={props.session}
+        dashboard={props.dashboard}
+        courses={props.enrolledCourses}
+        highlightedLecture={props.highlightedLecture}
+        onNavigate={props.onNavigate}
+        onSelectCourse={props.onSelectCourse}
       />
     );
   }
 
-  if (loading) {
+  if (props.loading) {
     return (
       <div className="space-y-5">
         <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 px-6 py-6 text-white shadow-sm">
@@ -102,380 +329,8 @@ export function RolePageRouter({
     );
   }
 
-  if (session.user.role === 'ADMIN') {
-    switch (page) {
-      case 'dashboard':
-        return withSuspense(<AdminDashboardPage dashboard={dashboard} users={demoUsers} courses={courseCards} insights={insights} />);
-      case 'my-courses':
-        return (
-          <MyCoursesPage
-            session={session}
-            courses={courseCards}
-            selectedCourse={selectedCourse}
-            onSelectCourse={onSelectCourse}
-            onNavigate={onNavigate}
-          />
-        );
-      case 'courses':
-        return (
-          <CoursesPage
-            courses={courseCards}
-            selectedCourse={selectedCourse}
-            highlightedLecture={highlightedLecture}
-            selectedLectureId={selectedLectureId}
-            canManageCurrent={true}
-            busy={busy}
-            sessionToken={sessionToken}
-            onCreateCourse={onCreateCourse}
-            onEnroll={onEnroll}
-            onNavigate={onNavigate}
-            onSelectCourse={onSelectCourse}
-            onSelectLecture={onSelectLecture}
-          />
-        );
-      case 'lecture-watch':
-        return (
-          <LectureWatchPage
-            courses={courseCards}
-            selectedCourse={selectedCourse}
-            highlightedLecture={highlightedLecture}
-            selectedLectureId={selectedLectureId}
-            canManageCurrent={true}
-            sessionToken={sessionToken}
-            onEnroll={onEnroll}
-            onSelectCourse={onSelectCourse}
-            onSelectLecture={onSelectLecture}
-            onNavigate={onNavigate}
-          />
-        );
-      case 'course-create':
-        return (
-          <CourseCreatePage
-            courses={courseCards}
-            canManageCurrent={true}
-            busy={busy}
-            sessionToken={sessionToken}
-            selectedCourse={selectedCourse}
-            highlightedLecture={highlightedLecture}
-            onCreateCourse={onCreateCourse}
-            onSelectCourse={onSelectCourse}
-            onSelectLecture={onSelectLecture}
-            onNavigate={onNavigate}
-          />
-        );
-      case 'lecture-studio':
-        return (
-          <LectureStudioPage
-            courses={courseCards}
-            selectedCourse={selectedCourse}
-            highlightedLecture={highlightedLecture}
-            onSelectCourse={onSelectCourse}
-          />
-        );
-      case 'ai-chat':
-        return <AIChatPage highlightedLecture={highlightedLecture} insights={insights} selectedCourse={selectedCourse} canManageCurrent={true} sessionToken={sessionToken} />;
-      case 'ai-summary':
-        return <AISummaryPage highlightedLecture={highlightedLecture} insights={insights} />;
-      case 'quiz-gen':
-        return <QuizGenPage courses={courseCards} />;
-      case 'assignment-check':
-        return <AssignmentCheckPage courses={courseCards} />;
-      case 'admin-users':
-        return withSuspense(<AdminUsersPage users={demoUsers} />);
-      case 'admin-instructors':
-        return withSuspense(<AdminInstructorsPage instructors={demoUsers.filter((user) => user.role === 'INSTRUCTOR')} courses={courseCards} />);
-      case 'admin-assign':
-        return withSuspense(<AdminAssignPage users={demoUsers} courses={courseCards} />);
-      case 'admin-stats':
-        return withSuspense(<AdminStatsPage dashboard={dashboard} courses={courseCards} users={demoUsers} insights={insights} aiLogs={aiLogs} />);
-      case 'admin-automation':
-        return withSuspense(<AdminAutomationPage providerCatalog={providers} />);
-      case 'media-pipeline':
-        return withSuspense((
-          <MediaPipelinePage
-            selectedCourse={selectedCourse}
-            highlightedLecture={highlightedLecture}
-            sessionToken={sessionToken}
-            viewerRole={session.user.role}
-          />
-        ));
-      case 'shortform':
-      case 'my-shortforms':
-      case 'community':
-        return withSuspense((
-          <ShortformHubPage
-            session={session}
-            highlightedLecture={highlightedLecture}
-            selectedCourse={selectedCourse}
-            courses={courseCards}
-            sessionToken={sessionToken}
-            recommendations={recommendations}
-            initialTab={shortformInitialTab}
-          />
-        ));
-      default:
-        return (
-          <RolePageFallback
-            icon="ri-layout-grid-line"
-            title="운영 화면 준비 중"
-            description="사용자 관리, 통계, 강사 배정 화면은 이 디자인 시스템 위에서 다음 단계로 이어집니다."
-            actions={[
-              { label: '대시보드로 이동', onClick: () => onNavigate('dashboard') },
-              { label: '내 강의 보기', onClick: () => onNavigate('my-courses') },
-            ]}
-          />
-        );
-    }
-  }
-
-  if (session.user.role === 'INSTRUCTOR') {
-    if (page === 'my-courses') {
-      return (
-        <MyCoursesPage
-          session={session}
-          courses={courseCards}
-          selectedCourse={selectedCourse}
-          onSelectCourse={onSelectCourse}
-          onNavigate={onNavigate}
-        />
-      );
-    }
-
-    if (page === 'courses') {
-      return (
-        <CoursesPage
-          courses={courseCards}
-          selectedCourse={selectedCourse}
-          highlightedLecture={highlightedLecture}
-          selectedLectureId={selectedLectureId}
-            canManageCurrent={true}
-            busy={busy}
-            sessionToken={sessionToken}
-            onCreateCourse={onCreateCourse}
-            onEnroll={onEnroll}
-            onNavigate={onNavigate}
-            onSelectCourse={onSelectCourse}
-            onSelectLecture={onSelectLecture}
-        />
-      );
-    }
-
-    if (page === 'lecture-watch') {
-      return (
-        <LectureWatchPage
-          courses={courseCards}
-          selectedCourse={selectedCourse}
-          highlightedLecture={highlightedLecture}
-          selectedLectureId={selectedLectureId}
-          canManageCurrent={true}
-          sessionToken={sessionToken}
-          onEnroll={onEnroll}
-          onSelectCourse={onSelectCourse}
-          onSelectLecture={onSelectLecture}
-          onNavigate={onNavigate}
-        />
-      );
-    }
-
-    if (page === 'course-create') {
-      return (
-        <CourseCreatePage
-          courses={courseCards}
-          canManageCurrent={true}
-          busy={busy}
-          sessionToken={sessionToken}
-          selectedCourse={selectedCourse}
-          highlightedLecture={highlightedLecture}
-          onCreateCourse={onCreateCourse}
-          onSelectCourse={onSelectCourse}
-          onSelectLecture={onSelectLecture}
-          onNavigate={onNavigate}
-        />
-      );
-    }
-
-    if (page === 'lecture-studio') {
-      return (
-        <LectureStudioPage
-          courses={courseCards}
-          selectedCourse={selectedCourse}
-          highlightedLecture={highlightedLecture}
-          onSelectCourse={onSelectCourse}
-        />
-      );
-    }
-
-    if (page === 'ai-chat') {
-      return <AIChatPage highlightedLecture={highlightedLecture} insights={insights} selectedCourse={selectedCourse} canManageCurrent={true} sessionToken={sessionToken} />;
-    }
-
-    if (page === 'media-pipeline') {
-      return withSuspense((
-        <MediaPipelinePage
-          selectedCourse={selectedCourse}
-          highlightedLecture={highlightedLecture}
-          sessionToken={sessionToken}
-          viewerRole={session.user.role}
-        />
-      ));
-    }
-
-    if (page === 'quiz-gen') {
-      return <QuizGenPage courses={courseCards} />;
-    }
-
-    if (page === 'ai-summary' || page === 'dashboard') {
-      return page === 'ai-summary'
-        ? <AISummaryPage highlightedLecture={highlightedLecture} insights={insights} />
-        : <InstructorDashboardPage dashboard={dashboard} courses={courseCards} insights={insights} />;
-    }
-
-    if (page === 'assignment-check') {
-      return <AssignmentCheckPage courses={courseCards} />;
-    }
-
-    if (page === 'shortform' || page === 'my-shortforms' || page === 'community') {
-      return withSuspense((
-        <ShortformHubPage
-          session={session}
-          highlightedLecture={highlightedLecture}
-          selectedCourse={selectedCourse}
-          courses={courseCards}
-          sessionToken={sessionToken}
-          recommendations={recommendations}
-          initialTab={shortformInitialTab}
-        />
-      ));
-    }
-
-    return (
-      <RolePageFallback
-        icon="ri-tools-line"
-        title="교강사 도구 연결 준비 중"
-        description="현재 레이아웃과 정보 구조는 레퍼런스 기준으로 정리했고, 기능 연결은 다음 단계에서 이어집니다."
-        actions={[
-          { label: '내 강의로 이동', onClick: () => onNavigate('my-courses') },
-          { label: '강의 개설', onClick: () => onNavigate('course-create') },
-        ]}
-      />
-    );
-  }
-
-  if (page === 'courses') {
-    return (
-      <CoursesPage
-        courses={courseCards}
-        selectedCourse={selectedCourse}
-        highlightedLecture={highlightedLecture}
-        selectedLectureId={selectedLectureId}
-        canManageCurrent={false}
-        busy={busy}
-        sessionToken={sessionToken}
-        onEnroll={onEnroll}
-        onCreateCourse={onCreateCourse}
-        onNavigate={onNavigate}
-        onSelectCourse={onSelectCourse}
-        onSelectLecture={onSelectLecture}
-      />
-    );
-  }
-
-  if (page === 'lecture-watch') {
-    return (
-      <LectureWatchPage
-        courses={courseCards}
-        selectedCourse={selectedCourse}
-        highlightedLecture={highlightedLecture}
-        selectedLectureId={selectedLectureId}
-        canManageCurrent={false}
-        sessionToken={sessionToken}
-        onEnroll={onEnroll}
-        onSelectCourse={onSelectCourse}
-        onSelectLecture={onSelectLecture}
-        onNavigate={onNavigate}
-      />
-    );
-  }
-
-  if (page === 'ai-chat') {
-    return <AIChatPage highlightedLecture={highlightedLecture} insights={insights} selectedCourse={selectedCourse} canManageCurrent={false} sessionToken={sessionToken} />;
-  }
-
-  if (page === 'ai-summary') {
-    return <AISummaryPage highlightedLecture={highlightedLecture} insights={insights} />;
-  }
-
-  if (page === 'quiz-gen') {
-    return <QuizGenPage courses={courseCards} />;
-  }
-
-  if (page === 'assignment-check') {
-    return <AssignmentCheckPage courses={courseCards} />;
-  }
-
-  if (page === 'shortform' || page === 'my-shortforms' || page === 'community') {
-    return withSuspense((
-      <ShortformHubPage
-        session={session}
-        highlightedLecture={highlightedLecture}
-        selectedCourse={selectedCourse}
-        courses={courseCards}
-        sessionToken={sessionToken}
-        recommendations={recommendations}
-        initialTab={shortformInitialTab}
-      />
-    ));
-  }
-
-  if (page === 'dashboard') {
-    return (
-      <StudentDashboardPage
-        session={session}
-        dashboard={dashboard}
-        courses={enrolledCourses}
-        highlightedLecture={highlightedLecture}
-        recommendations={recommendations}
-        onSelectCourse={onSelectCourse}
-        onNavigate={onNavigate}
-      />
-    );
-  }
-
-  if (page === 'my-courses') {
-    return (
-      <MyCoursesPage
-        session={session}
-        courses={courseCards}
-        selectedCourse={selectedCourse}
-        onSelectCourse={onSelectCourse}
-        onNavigate={onNavigate}
-      />
-    );
-  }
-
-  if (page === 'media-pipeline') {
-    return (
-      <RolePageFallback
-        icon="ri-lock-line"
-        title="업로드와 전사는 교강사 전용입니다."
-        description="학생은 강의 상세, 챗봇, 숏폼 제작만 사용할 수 있습니다. 영상 업로드와 자동 전사는 교수 또는 강사 계정에서만 가능합니다."
-        actions={[
-          { label: '강의 상세로', onClick: () => onNavigate('courses') },
-          { label: '내 강의로', onClick: () => onNavigate('my-courses') },
-        ]}
-      />
-    );
-  }
-
-  return (
-    <RolePageFallback
-      icon="ri-robot-line"
-      title="학습 도구 연결 준비 중"
-      description="숏폼, 커뮤니티, AI 채팅은 동일한 UI 체계에 맞춰 이어서 붙일 수 있게 정리한 상태입니다."
-      actions={[
-        { label: '대시보드로 이동', onClick: () => onNavigate('dashboard') },
-        { label: '내 숏폼 보기', onClick: () => onNavigate('my-shortforms') },
-      ]}
-    />
-  );
+  const args: SharedRouteArgs = { ...props, sessionToken, shortformInitialTab };
+  if (props.session.user.role === 'ADMIN') return renderAdminRoutes(args);
+  if (props.session.user.role === 'INSTRUCTOR') return renderInstructorRoutes(args);
+  return renderStudentRoutes(args);
 }


### PR DESCRIPTION
## Summary
- split RolePageRouter into role-specific render functions
- extract repeated course/watch/shortform render blocks
- keep route behavior unchanged while reducing branch complexity

## Validation
- npm --prefix frontend run build (pass)
- backend test: unavailable locally (maven wrapper download failure in env)
