### PR TITLE
refactor(frontend): split lecture studio editor controls/options

### DIFF
--- a/frontend/src/features/lms/components/lecture-studio/LectureStudioEditor.tsx
+++ b/frontend/src/features/lms/components/lecture-studio/LectureStudioEditor.tsx
@@ -4,14 +4,11 @@ import {
   lectureStudioAudienceLabel,
   lectureStudioModeLabel,
   lectureStudioQuizLabel,
-  type LectureStudioAssignmentMode,
-  type LectureStudioAudience,
-  type LectureStudioDeliveryMode,
   type LectureStudioDraft,
-  type LectureStudioExamMode,
-  type LectureStudioPace,
   type LectureStudioQuizMode,
 } from './types';
+import { ChoiceGrid, TogglePill, updateDraft } from './lectureStudioEditorControls';
+import { assignmentModes, audienceOptions, deliveryModes, examModes, paceOptions, quizModes } from './lectureStudioEditorOptions';
 
 type LectureStudioEditorProps = {
   courses: CourseCard[];
@@ -25,118 +22,6 @@ type LectureStudioEditorProps = {
   onMarkReady: () => void;
 };
 
-const deliveryModes: Array<{ value: LectureStudioDeliveryMode; label: string; hint: string }> = [
-  { value: 'online', label: '온라인', hint: '화상 강의 중심' },
-  { value: 'offline', label: '오프라인', hint: '교실 운영' },
-  { value: 'hybrid', label: '혼합형', hint: '온라인 + 오프라인 병행' },
-];
-
-const audienceOptions: Array<{ value: LectureStudioAudience; label: string; hint: string }> = [
-  { value: 'beginner', label: '입문', hint: '기초 개념 중심' },
-  { value: 'intermediate', label: '중급', hint: '실습과 응용 포함' },
-  { value: 'advanced', label: '심화', hint: '프로젝트와 토론 중심' },
-];
-
-const paceOptions: Array<{ value: LectureStudioPace; label: string; hint: string }> = [
-  { value: 'weekly', label: '주차형', hint: '정규 커리큘럼' },
-  { value: 'bootcamp', label: '집중형', hint: '짧고 빠른 몰입형' },
-  { value: 'self-paced', label: '자율형', hint: '개별 진도 허용' },
-];
-
-const assignmentModes: Array<{ value: LectureStudioAssignmentMode; label: string; hint: string }> = [
-  { value: 'none', label: '없음', hint: '과제 없이 운영' },
-  { value: 'light', label: '가벼운 과제', hint: '복습용 제출' },
-  { value: 'project', label: '프로젝트형', hint: '결과물 중심' },
-];
-
-const examModes: Array<{ value: LectureStudioExamMode; label: string; hint: string }> = [
-  { value: 'none', label: '없음', hint: '시험 미운영' },
-  { value: 'quiz-only', label: '퀴즈형', hint: '중간 점검 중심' },
-  { value: 'midterm-final', label: '중간/기말', hint: '정식 평가 운영' },
-];
-
-const quizModes: Array<{ value: LectureStudioQuizMode; label: string; hint: string }> = [
-  { value: 'none', label: '없음', hint: '퀴즈 미운영' },
-  { value: 'manual', label: '수동', hint: '직접 작성' },
-  { value: 'auto', label: '자동', hint: 'AI가 생성' },
-  { value: 'mixed', label: '혼합', hint: '수동 + 자동 병행' },
-];
-
-function updateDraft<K extends keyof LectureStudioDraft>(draft: LectureStudioDraft, onChange: (next: LectureStudioDraft) => void, key: K, value: LectureStudioDraft[K]) {
-  onChange({ ...draft, [key]: value });
-}
-
-type ChoiceGridProps<T extends string> = {
-  title: string;
-  description: string;
-  value: T;
-  options: Array<{ value: T; label: string; hint: string }>;
-  onChange: (value: T) => void;
-};
-
-function ChoiceGrid<T extends string>({ title, description, value, options, onChange }: ChoiceGridProps<T>) {
-  return (
-    <div className="space-y-3">
-      <div>
-        <h3 className="text-[14px] font-bold text-slate-900">{title}</h3>
-        <p className="mt-1 text-[12px] leading-6 text-slate-500">{description}</p>
-      </div>
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-        {options.map((option) => {
-          const active = option.value === value;
-          return (
-            <button
-              key={option.value}
-              type="button"
-              onClick={() => onChange(option.value)}
-              className={`rounded-2xl border px-4 py-3 text-left transition hover:-translate-y-0.5 hover:shadow-[0_12px_30px_rgba(15,23,42,0.08)] ${
-                active ? 'border-indigo-400 bg-indigo-50 ring-2 ring-indigo-100' : 'border-slate-200 bg-slate-50/70'
-              }`}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <div className="text-[13px] font-semibold text-slate-900">{option.label}</div>
-                  <div className="mt-1 text-[12px] text-slate-500">{option.hint}</div>
-                </div>
-                {active ? <i className="ri-checkbox-circle-fill text-[18px] text-indigo-600" /> : <i className="ri-checkbox-blank-circle-line text-[18px] text-slate-300" />}
-              </div>
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function TogglePill({
-  label,
-  checked,
-  hint,
-  onToggle,
-}: {
-  label: string;
-  checked: boolean;
-  hint: string;
-  onToggle: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      className={`flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition ${
-        checked ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-slate-50 text-slate-600'
-      }`}
-    >
-      <div>
-        <div className="text-[13px] font-semibold">{label}</div>
-        <div className="mt-1 text-[12px] leading-6 opacity-80">{hint}</div>
-      </div>
-      <div className={`flex h-6 w-11 items-center rounded-full p-1 transition ${checked ? 'bg-emerald-500' : 'bg-slate-300'}`}>
-        <span className={`h-4 w-4 rounded-full bg-white transition ${checked ? 'translate-x-5' : 'translate-x-0'}`} />
-      </div>
-    </button>
-  );
-}
 
 export function LectureStudioEditor({
   courses,

--- a/frontend/src/features/lms/components/lecture-studio/lectureStudioEditorControls.tsx
+++ b/frontend/src/features/lms/components/lecture-studio/lectureStudioEditorControls.tsx
@@ -1,0 +1,77 @@
+import type { LectureStudioDraft } from './types';
+
+type ChoiceGridProps<T extends string> = {
+  title: string;
+  description: string;
+  value: T;
+  options: Array<{ value: T; label: string; hint: string }>;
+  onChange: (value: T) => void;
+};
+
+export function ChoiceGrid<T extends string>({ title, description, value, options, onChange }: ChoiceGridProps<T>) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-[14px] font-bold text-slate-900">{title}</h3>
+        <p className="mt-1 text-[12px] leading-6 text-slate-500">{description}</p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {options.map((option) => {
+          const active = option.value === value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onChange(option.value)}
+              className={`rounded-2xl border px-4 py-3 text-left transition hover:-translate-y-0.5 hover:shadow-[0_12px_30px_rgba(15,23,42,0.08)] ${
+                active ? 'border-indigo-400 bg-indigo-50 ring-2 ring-indigo-100' : 'border-slate-200 bg-slate-50/70'
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-[13px] font-semibold text-slate-900">{option.label}</div>
+                  <div className="mt-1 text-[12px] text-slate-500">{option.hint}</div>
+                </div>
+                {active ? <i className="ri-checkbox-circle-fill text-[18px] text-indigo-600" /> : <i className="ri-checkbox-blank-circle-line text-[18px] text-slate-300" />}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function TogglePill({
+  label,
+  checked,
+  hint,
+  onToggle,
+}: {
+  label: string;
+  checked: boolean;
+  hint: string;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={`flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition ${
+        checked ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-slate-50 text-slate-600'
+      }`}
+    >
+      <div>
+        <div className="text-[13px] font-semibold">{label}</div>
+        <div className="mt-1 text-[12px] leading-6 opacity-80">{hint}</div>
+      </div>
+      <div className={`flex h-6 w-11 items-center rounded-full p-1 transition ${checked ? 'bg-emerald-500' : 'bg-slate-300'}`}>
+        <span className={`h-4 w-4 rounded-full bg-white transition ${checked ? 'translate-x-5' : 'translate-x-0'}`} />
+      </div>
+    </button>
+  );
+}
+
+export function updateDraft<K extends keyof LectureStudioDraft>(draft: LectureStudioDraft, onChange: (next: LectureStudioDraft) => void, key: K, value: LectureStudioDraft[K]) {
+  onChange({ ...draft, [key]: value });
+}

--- a/frontend/src/features/lms/components/lecture-studio/lectureStudioEditorOptions.ts
+++ b/frontend/src/features/lms/components/lecture-studio/lectureStudioEditorOptions.ts
@@ -1,0 +1,45 @@
+import type {
+  LectureStudioAssignmentMode,
+  LectureStudioAudience,
+  LectureStudioDeliveryMode,
+  LectureStudioExamMode,
+  LectureStudioPace,
+  LectureStudioQuizMode,
+} from './types';
+
+export const deliveryModes: Array<{ value: LectureStudioDeliveryMode; label: string; hint: string }> = [
+  { value: 'online', label: '온라인', hint: '화상 강의 중심' },
+  { value: 'offline', label: '오프라인', hint: '교실 운영' },
+  { value: 'hybrid', label: '혼합형', hint: '온라인 + 오프라인 병행' },
+];
+
+export const audienceOptions: Array<{ value: LectureStudioAudience; label: string; hint: string }> = [
+  { value: 'beginner', label: '입문', hint: '기초 개념 중심' },
+  { value: 'intermediate', label: '중급', hint: '실습과 응용 포함' },
+  { value: 'advanced', label: '심화', hint: '프로젝트와 토론 중심' },
+];
+
+export const paceOptions: Array<{ value: LectureStudioPace; label: string; hint: string }> = [
+  { value: 'weekly', label: '주차형', hint: '정규 커리큘럼' },
+  { value: 'bootcamp', label: '집중형', hint: '짧고 빠른 몰입형' },
+  { value: 'self-paced', label: '자율형', hint: '개별 진도 허용' },
+];
+
+export const assignmentModes: Array<{ value: LectureStudioAssignmentMode; label: string; hint: string }> = [
+  { value: 'none', label: '없음', hint: '과제 없이 운영' },
+  { value: 'light', label: '가벼운 과제', hint: '복습용 제출' },
+  { value: 'project', label: '프로젝트형', hint: '결과물 중심' },
+];
+
+export const examModes: Array<{ value: LectureStudioExamMode; label: string; hint: string }> = [
+  { value: 'none', label: '없음', hint: '시험 미운영' },
+  { value: 'quiz-only', label: '퀴즈형', hint: '중간 점검 중심' },
+  { value: 'midterm-final', label: '중간/기말', hint: '정식 평가 운영' },
+];
+
+export const quizModes: Array<{ value: LectureStudioQuizMode; label: string; hint: string }> = [
+  { value: 'none', label: '없음', hint: '퀴즈 미운영' },
+  { value: 'manual', label: '수동', hint: '직접 작성' },
+  { value: 'auto', label: '자동', hint: 'AI가 생성' },
+  { value: 'mixed', label: '혼합', hint: '수동 + 자동 병행' },
+];


### PR DESCRIPTION
## Summary
- extract lecture studio editor choice/toggle controls into dedicated component module
- extract lecture studio option catalogs into separate options module
- keep editor focused on layout and field wiring

## Validation
- npm --prefix frontend run build (pass)
