### PR TITLE
refactor(api): dedupe ai controller runtime/auth flow

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/AiController.java
@@ -111,6 +111,28 @@ public class AiController {
     }
 
     private SessionView require(String auth) { return aiControllerAuthSupport.requireSession(sessionService, auth); }
+    private ResponseEntity<ApiResponse<Map<String, Object>>> requireAiGuard(SessionView session) {
+        return aiControllerRuntimeSupport.requireAiEligible(featureStore, session, aiControllerSupport, aiControllerAuthSupport);
+    }
+
+    private ResponseEntity<ApiResponse<Map<String, Object>>> validateLectureExists(String lectureId) {
+        if (learningService.getLecture(lectureId) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        }
+        return null;
+    }
+
+    private Map<String, Object> generateAndRecord(String userId, String feature, String prompt, String usageInput) {
+        Map<String, Object> runtime = aiControllerRuntimeSupport.generate(
+                aiRuntimeService,
+                featureStore,
+                userId,
+                feature,
+                prompt
+        );
+        aiControllerRuntimeSupport.recordUsage(featureStore, userId, feature, usageInput);
+        return runtime;
+    }
 
     @GetMapping("/insights")
     public ResponseEntity<ApiResponse<Map<String, Object>>> insights(@RequestHeader(value = "Authorization", required = false) String auth) {
@@ -163,7 +185,7 @@ public class AiController {
     @PostMapping("/rag")
     public ResponseEntity<ApiResponse<Map<String, Object>>> rag(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody RagRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = aiControllerRuntimeSupport.requireAiEligible(featureStore, session, aiControllerSupport, aiControllerAuthSupport);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
         if (guard != null) return guard;
 
         String query = aiRequestSupport.normalize(body.query());
@@ -252,105 +274,92 @@ public class AiController {
     @PostMapping("/intent")
     public ResponseEntity<ApiResponse<Map<String, Object>>> intent(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody IntentRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = aiControllerRuntimeSupport.requireAiEligible(featureStore, session, aiControllerSupport, aiControllerAuthSupport);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
         if (guard != null) return guard;
         String message = aiRequestSupport.normalize(body.message());
-        Map<String, Object> runtime = aiControllerRuntimeSupport.generate(
-                aiRuntimeService,
-                featureStore,
+        Map<String, Object> runtime = generateAndRecord(
                 session.user().id(),
                 "intent",
-                "메시지 의도를 한 단어로 분류하고 이유를 한 줄로 설명하세요: " + message
+                "메시지 의도를 한 단어로 분류하고 이유를 한 줄로 설명하세요: " + message,
+                message
         );
         Map<String, Object> data = aiControllerSupport.intentResponse(runtime, aiRequestSupport.optionalNormalized(body.lecture_id()));
-        aiControllerRuntimeSupport.recordUsage(featureStore, session.user().id(), "intent", message);
         return ResponseEntity.ok(ApiResponse.success(data, "인텐트가 분류되었습니다."));
     }
 
     @PostMapping("/search")
     public ResponseEntity<ApiResponse<Map<String, Object>>> search(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody SearchRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = aiControllerRuntimeSupport.requireAiEligible(featureStore, session, aiControllerSupport, aiControllerAuthSupport);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
         if (guard != null) return guard;
         String query = aiRequestSupport.normalize(body.query());
         String lectureId = aiRequestSupport.optionalNormalized(body.lecture_id());
         ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = aiRequestSupport.validateLecture(body.lecture_id());
         if (lectureError != null) return lectureError;
-        Map<String, Object> runtime = aiControllerRuntimeSupport.generate(
-                aiRuntimeService,
-                featureStore,
+        Map<String, Object> runtime = generateAndRecord(
                 session.user().id(),
                 "search",
-                "다음 질의와 관련된 강의 검색 결과를 요약하세요: " + query
+                "다음 질의와 관련된 강의 검색 결과를 요약하세요: " + query,
+                query
         );
         Map<String, Object> data = aiControllerSupport.searchResponse(
                 query,
                 aiRequestSupport.resolveRagSources(query, lectureId, null, 4),
                 runtime
         );
-        aiControllerRuntimeSupport.recordUsage(featureStore, session.user().id(), "search", query);
         return ResponseEntity.ok(ApiResponse.success(data, "검색 결과를 조회했습니다."));
     }
 
     @PostMapping("/answer")
     public ResponseEntity<ApiResponse<Map<String, Object>>> answer(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody AnswerRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = aiControllerRuntimeSupport.requireAiEligible(featureStore, session, aiControllerSupport, aiControllerAuthSupport);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
         if (guard != null) return guard;
         String question = aiRequestSupport.normalize(body.question());
         String lectureId = aiRequestSupport.optionalNormalized(body.lecture_id());
         ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = aiRequestSupport.validateLecture(body.lecture_id());
         if (lectureError != null) return lectureError;
-        Map<String, Object> runtime = aiControllerRuntimeSupport.generate(
-                aiRuntimeService,
-                featureStore,
-                session.user().id(),
-                "answer",
-                question
-        );
+        Map<String, Object> runtime = generateAndRecord(session.user().id(), "answer", question, question);
         List<Map<String, Object>> sources = aiRequestSupport.resolveRagSources(question, lectureId, null, 4);
         Map<String, Object> data = aiControllerSupport.answerResponse(question, lectureId, sources, runtime);
-        aiControllerRuntimeSupport.recordUsage(featureStore, session.user().id(), "answer", question);
         return ResponseEntity.ok(ApiResponse.success(data, "답변을 생성했습니다."));
     }
 
     @PostMapping("/summary")
     public ResponseEntity<ApiResponse<Map<String, Object>>> summary(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody SummaryRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = aiControllerRuntimeSupport.requireAiEligible(featureStore, session, aiControllerSupport, aiControllerAuthSupport);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
         if (guard != null) return guard;
         String lectureId = aiRequestSupport.requireLectureId(body.lecture_id());
-        if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
+        ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLectureExists(lectureId);
+        if (lectureError != null) return lectureError;
         String style = aiRequestSupport.defaultIfBlank(body.style(), "brief");
         String language = aiRequestSupport.defaultIfBlank(body.language(), "ko");
-        Map<String, Object> runtime = aiControllerRuntimeSupport.generate(
-                aiRuntimeService,
-                featureStore,
+        Map<String, Object> runtime = generateAndRecord(
                 session.user().id(),
                 "summary",
-                lectureId + " 강의 내용을 " + style + " 스타일로 " + language + " 요약"
+                lectureId + " 강의 내용을 " + style + " 스타일로 " + language + " 요약",
+                lectureId
         );
         Map<String, Object> data = aiControllerSupport.summaryResponse(lectureId, style, language, runtime);
-        aiControllerRuntimeSupport.recordUsage(featureStore, session.user().id(), "summary", lectureId);
         return ResponseEntity.ok(ApiResponse.success(data, "요약이 생성되었습니다."));
     }
 
     @PostMapping("/quiz")
     public ResponseEntity<ApiResponse<Map<String, Object>>> quiz(@RequestHeader(value = "Authorization", required = false) String auth, @Valid @RequestBody QuizRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = aiControllerRuntimeSupport.requireAiEligible(featureStore, session, aiControllerSupport, aiControllerAuthSupport);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
         if (guard != null) return guard;
         String lectureId = aiRequestSupport.requireLectureId(body.lecture_id());
-        if (learningService.getLecture(lectureId) == null) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("LECTURE_NOT_FOUND", "강의를 찾을 수 없습니다."));
-        Map<String, Object> runtime = aiControllerRuntimeSupport.generate(
-                aiRuntimeService,
-                featureStore,
+        ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLectureExists(lectureId);
+        if (lectureError != null) return lectureError;
+        Map<String, Object> runtime = generateAndRecord(
                 session.user().id(),
                 "quiz",
-                lectureId + " 강의 기반 객관식 퀴즈 1문항 생성"
+                lectureId + " 강의 기반 객관식 퀴즈 1문항 생성",
+                lectureId
         );
         Map<String, Object> data = aiControllerSupport.quizResponse(lectureId, runtime);
-        aiControllerRuntimeSupport.recordUsage(featureStore, session.user().id(), "quiz", lectureId);
         return ResponseEntity.ok(ApiResponse.success(data, "퀴즈가 생성되었습니다."));
     }
 


### PR DESCRIPTION
## Summary
- extract common AI eligibility guard helper in AiController
- extract lecture-exists validation helper
- extract runtime generation + usage recording helper to reduce per-endpoint duplication

## Validation
- local backend test not executable in this env (maven wrapper download blocked)
- CI checks required
