### PR TITLE
refactor(feature): split extraction read support from feature store

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreExtractionReadSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreExtractionReadSupport.java
@@ -1,0 +1,36 @@
+package com.myway.backendspring.feature;
+
+import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class FeatureStoreExtractionReadSupport {
+    public List<Map<String, Object>> extractions(
+            FeatureJdbcStore store,
+            String extractionScope,
+            String lectureId,
+            FeatureStorePipelineSupport pipelineSupport
+    ) {
+        List<Map<String, Object>> rows = store.listEventsByOwner(extractionScope, lectureId);
+        List<Map<String, Object>> merged = new ArrayList<>();
+        for (Map<String, Object> row : rows) {
+            merged.add(hydrateExtractionRow(store, extractionScope, row, pipelineSupport));
+        }
+        return merged;
+    }
+
+    private Map<String, Object> hydrateExtractionRow(
+            FeatureJdbcStore store,
+            String extractionScope,
+            Map<String, Object> row,
+            FeatureStorePipelineSupport pipelineSupport
+    ) {
+        String extractionId = String.valueOf(row.getOrDefault("id", "")).trim();
+        Map<String, Object> latest = extractionId.isBlank() ? null : store.getKv(extractionScope, extractionId);
+        return pipelineSupport.hydrateExtractionRow(row, latest);
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -42,6 +41,7 @@ public class FeatureStoreService {
     private final FeatureStoreDomainOpsSupport domainOpsSupport;
     private final FeatureStoreAssetSupport assetSupport;
     private final FeatureStoreReadSupport readSupport;
+    private final FeatureStoreExtractionReadSupport extractionReadSupport;
 
     @Autowired
     public FeatureStoreService(
@@ -61,7 +61,8 @@ public class FeatureStoreService {
             FeatureStoreMediaOpsSupport mediaOpsSupport,
             FeatureStoreDomainOpsSupport domainOpsSupport,
             FeatureStoreAssetSupport assetSupport,
-            FeatureStoreReadSupport readSupport
+            FeatureStoreReadSupport readSupport,
+            FeatureStoreExtractionReadSupport extractionReadSupport
     ) {
         this.store = store;
         this.ragService = ragService;
@@ -80,6 +81,7 @@ public class FeatureStoreService {
         this.domainOpsSupport = domainOpsSupport;
         this.assetSupport = assetSupport;
         this.readSupport = readSupport;
+        this.extractionReadSupport = extractionReadSupport;
     }
 
     // Backward-compatible constructor for tests instantiating service directly.
@@ -101,7 +103,8 @@ public class FeatureStoreService {
                 new FeatureStoreMediaOpsSupport(),
                 new FeatureStoreDomainOpsSupport(),
                 new FeatureStoreAssetSupport(),
-                new FeatureStoreReadSupport()
+                new FeatureStoreReadSupport(),
+                new FeatureStoreExtractionReadSupport()
         );
     }
 
@@ -233,18 +236,7 @@ public class FeatureStoreService {
     }
 
     public List<Map<String, Object>> extractions(String lectureId) {
-        List<Map<String, Object>> rows = store.listEventsByOwner(EXTRACTION_SCOPE, lectureId);
-        List<Map<String, Object>> merged = new ArrayList<>();
-        for (Map<String, Object> row : rows) {
-            merged.add(hydrateExtractionRow(row));
-        }
-        return merged;
-    }
-
-    private Map<String, Object> hydrateExtractionRow(Map<String, Object> row) {
-        String extractionId = String.valueOf(row.getOrDefault("id", "")).trim();
-        Map<String, Object> latest = extractionId.isBlank() ? null : store.getKv(EXTRACTION_SCOPE, extractionId);
-        return pipelineSupport.hydrateExtractionRow(row, latest);
+        return extractionReadSupport.extractions(store, EXTRACTION_SCOPE, lectureId, pipelineSupport);
     }
 
     public Map<String, Object> completeExtractionCallback(String extractionId, String status, String errorMessage, long eventVersion) {


### PR DESCRIPTION
## Summary
- extract extraction list/hydration logic from FeatureStoreService into FeatureStoreExtractionReadSupport
- keep service focused on orchestration/delegation
- reduce service branching and helper clutter

## Validation
- CI checks required (local maven unavailable in this environment)
