### PR TITLE
refactor(domain): split demo learning lecture query support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningLectureQuerySupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningLectureQuerySupport.java
@@ -1,0 +1,31 @@
+package com.myway.backendspring.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+@Component
+public class DemoLearningLectureQuerySupport {
+
+    public LectureItem getLecture(String lectureId, Supplier<List<CourseDetail>> coursesSupplier) {
+        return coursesSupplier.get().stream()
+                .flatMap(course -> course.lectures().stream())
+                .filter(lecture -> lecture.id().equals(lectureId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public LectureItem getCourseLecture(String courseId, String lectureId, Supplier<List<LectureItem>> courseLecturesSupplier) {
+        return courseLecturesSupplier.get().stream()
+                .filter(lecture -> lecture.id().equals(lectureId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public List<LectureItem> listAllLectures(Supplier<List<CourseDetail>> coursesSupplier) {
+        return coursesSupplier.get().stream()
+                .flatMap(course -> course.lectures().stream())
+                .toList();
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -40,6 +40,7 @@ public class DemoLearningService {
     private final DemoLearningBootstrapSupport demoLearningBootstrapSupport;
     private final DemoLearningCourseAccessSupport demoLearningCourseAccessSupport;
     private final DemoLearningDashboardSupport demoLearningDashboardSupport;
+    private final DemoLearningLectureQuerySupport demoLearningLectureQuerySupport;
 
     @Autowired
     public DemoLearningService(
@@ -57,7 +58,8 @@ public class DemoLearningService {
             DemoLearningMetadataSupport demoLearningMetadataSupport,
             DemoLearningBootstrapSupport demoLearningBootstrapSupport,
             DemoLearningCourseAccessSupport demoLearningCourseAccessSupport,
-            DemoLearningDashboardSupport demoLearningDashboardSupport
+            DemoLearningDashboardSupport demoLearningDashboardSupport,
+            DemoLearningLectureQuerySupport demoLearningLectureQuerySupport
     ) {
         this.store = store;
         this.activityEventService = activityEventService;
@@ -74,6 +76,7 @@ public class DemoLearningService {
         this.demoLearningBootstrapSupport = demoLearningBootstrapSupport;
         this.demoLearningCourseAccessSupport = demoLearningCourseAccessSupport;
         this.demoLearningDashboardSupport = demoLearningDashboardSupport;
+        this.demoLearningLectureQuerySupport = demoLearningLectureQuerySupport;
         initSeedData();
     }
 
@@ -94,6 +97,7 @@ public class DemoLearningService {
         this.demoLearningBootstrapSupport = new DemoLearningBootstrapSupport();
         this.demoLearningCourseAccessSupport = new DemoLearningCourseAccessSupport();
         this.demoLearningDashboardSupport = new DemoLearningDashboardSupport();
+        this.demoLearningLectureQuerySupport = new DemoLearningLectureQuerySupport();
         initSeedData();
     }
 
@@ -170,17 +174,15 @@ public class DemoLearningService {
     }
 
     public LectureItem getLecture(String lectureId) {
-        return listAllCourses().stream().flatMap(c -> c.lectures().stream()).filter(l -> l.id().equals(lectureId)).findFirst().orElse(null);
+        return demoLearningLectureQuerySupport.getLecture(lectureId, this::listAllCourses);
     }
 
     public LectureItem getCourseLecture(String courseId, String lectureId) {
-        return getCourseLectures(courseId).stream().filter(l -> l.id().equals(lectureId)).findFirst().orElse(null);
+        return demoLearningLectureQuerySupport.getCourseLecture(courseId, lectureId, () -> getCourseLectures(courseId));
     }
 
     public List<LectureItem> listAllLectures() {
-        return listAllCourses().stream()
-                .flatMap(course -> course.lectures().stream())
-                .toList();
+        return demoLearningLectureQuerySupport.listAllLectures(this::listAllCourses);
     }
 
     public DashboardView getDashboard(String userId) {


### PR DESCRIPTION
## Summary
- extract lecture query methods from DemoLearningService into DemoLearningLectureQuerySupport
- delegate getLecture/getCourseLecture/listAllLectures to support
- keep service focused on orchestration and domain flow

## Validation
- CI checks required (local maven unavailable in this environment)
