### PR TITLE
refactor(feature): split extraction callback support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreExtractionCallbackSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreExtractionCallbackSupport.java
@@ -1,0 +1,50 @@
+package com.myway.backendspring.feature;
+
+import com.myway.backendspring.feature.media.MediaTranscriptionService;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class FeatureStoreExtractionCallbackSupport {
+
+    public Map<String, Object> complete(
+            FeatureStoreTranscribeSupport transcribeSupport,
+            MediaTranscriptionService mediaTranscriptionService,
+            String extractionId,
+            String status,
+            String errorMessage,
+            long eventVersion,
+            String audioUrl,
+            String processingJobId,
+            String processingStage,
+            String processingStep,
+            String audioFormat,
+            Integer sampleRate,
+            Integer channels,
+            String syncMode,
+            String overwritePolicy,
+            String approvalState,
+            String notificationChannel
+    ) {
+        if (mediaTranscriptionService == null) return null;
+        return transcribeSupport.completeExtractionCallback(
+                mediaTranscriptionService,
+                extractionId,
+                status,
+                errorMessage,
+                eventVersion,
+                audioUrl,
+                processingJobId,
+                processingStage,
+                processingStep,
+                audioFormat,
+                sampleRate,
+                channels,
+                syncMode,
+                overwritePolicy,
+                approvalState,
+                notificationChannel
+        );
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -42,6 +42,7 @@ public class FeatureStoreService {
     private final FeatureStoreAssetSupport assetSupport;
     private final FeatureStoreReadSupport readSupport;
     private final FeatureStoreExtractionReadSupport extractionReadSupport;
+    private final FeatureStoreExtractionCallbackSupport extractionCallbackSupport;
 
     @Autowired
     public FeatureStoreService(
@@ -62,7 +63,8 @@ public class FeatureStoreService {
             FeatureStoreDomainOpsSupport domainOpsSupport,
             FeatureStoreAssetSupport assetSupport,
             FeatureStoreReadSupport readSupport,
-            FeatureStoreExtractionReadSupport extractionReadSupport
+            FeatureStoreExtractionReadSupport extractionReadSupport,
+            FeatureStoreExtractionCallbackSupport extractionCallbackSupport
     ) {
         this.store = store;
         this.ragService = ragService;
@@ -82,6 +84,7 @@ public class FeatureStoreService {
         this.assetSupport = assetSupport;
         this.readSupport = readSupport;
         this.extractionReadSupport = extractionReadSupport;
+        this.extractionCallbackSupport = extractionCallbackSupport;
     }
 
     // Backward-compatible constructor for tests instantiating service directly.
@@ -104,7 +107,8 @@ public class FeatureStoreService {
                 new FeatureStoreDomainOpsSupport(),
                 new FeatureStoreAssetSupport(),
                 new FeatureStoreReadSupport(),
-                new FeatureStoreExtractionReadSupport()
+                new FeatureStoreExtractionReadSupport(),
+                new FeatureStoreExtractionCallbackSupport()
         );
     }
 
@@ -267,8 +271,8 @@ public class FeatureStoreService {
             String approvalState,
             String notificationChannel
     ) {
-        if (mediaTranscriptionService == null) return null;
-        return transcribeSupport.completeExtractionCallback(
+        return extractionCallbackSupport.complete(
+                transcribeSupport,
                 mediaTranscriptionService,
                 extractionId,
                 status,


### PR DESCRIPTION
## Summary
- extract FeatureStoreService extraction-callback delegation into FeatureStoreExtractionCallbackSupport
- keep service method focused on orchestration wiring
- preserve callback parameter handling and behavior

## Validation
- CI checks required (local maven unavailable in this environment)
