### PR TITLE
refactor(feature): split media note support from feature store

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreNoteSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreNoteSupport.java
@@ -1,0 +1,36 @@
+package com.myway.backendspring.feature;
+
+import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+public class FeatureStoreNoteSupport {
+
+    public Map<String, Object> summarizeLecture(
+            FeatureJdbcStore store,
+            String mediaNoteScope,
+            FeatureStorePayloadSupport payloadSupport,
+            String lectureId,
+            String style,
+            String language
+    ) {
+        Map<String, Object> note = payloadSupport.lectureSummaryNotePayload(
+                UUID.randomUUID().toString(),
+                lectureId,
+                payloadSupport.normalizeOrDefault(style, "brief"),
+                payloadSupport.normalizeOrDefault(language, "ko"),
+                Instant.now().toString()
+        );
+        store.insertEvent(mediaNoteScope, lectureId, String.valueOf(note.get("id")), note);
+        return note;
+    }
+
+    public List<Map<String, Object>> notes(FeatureJdbcStore store, String mediaNoteScope, String lectureId) {
+        return store.listEventsByOwner(mediaNoteScope, lectureId);
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -12,10 +12,8 @@ import com.myway.backendspring.persistence.FeatureJdbcStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @Service
 public class FeatureStoreService {
@@ -43,6 +41,7 @@ public class FeatureStoreService {
     private final FeatureStoreReadSupport readSupport;
     private final FeatureStoreExtractionReadSupport extractionReadSupport;
     private final FeatureStoreExtractionCallbackSupport extractionCallbackSupport;
+    private final FeatureStoreNoteSupport noteSupport;
 
     @Autowired
     public FeatureStoreService(
@@ -64,7 +63,8 @@ public class FeatureStoreService {
             FeatureStoreAssetSupport assetSupport,
             FeatureStoreReadSupport readSupport,
             FeatureStoreExtractionReadSupport extractionReadSupport,
-            FeatureStoreExtractionCallbackSupport extractionCallbackSupport
+            FeatureStoreExtractionCallbackSupport extractionCallbackSupport,
+            FeatureStoreNoteSupport noteSupport
     ) {
         this.store = store;
         this.ragService = ragService;
@@ -85,6 +85,7 @@ public class FeatureStoreService {
         this.readSupport = readSupport;
         this.extractionReadSupport = extractionReadSupport;
         this.extractionCallbackSupport = extractionCallbackSupport;
+        this.noteSupport = noteSupport;
     }
 
     // Backward-compatible constructor for tests instantiating service directly.
@@ -108,7 +109,8 @@ public class FeatureStoreService {
                 new FeatureStoreAssetSupport(),
                 new FeatureStoreReadSupport(),
                 new FeatureStoreExtractionReadSupport(),
-                new FeatureStoreExtractionCallbackSupport()
+                new FeatureStoreExtractionCallbackSupport(),
+                new FeatureStoreNoteSupport()
         );
     }
 
@@ -297,19 +299,11 @@ public class FeatureStoreService {
     }
 
     public Map<String, Object> summarizeLecture(String lectureId, String style, String language) {
-        Map<String, Object> note = payloadSupport.lectureSummaryNotePayload(
-                UUID.randomUUID().toString(),
-                lectureId,
-                payloadSupport.normalizeOrDefault(style, "brief"),
-                payloadSupport.normalizeOrDefault(language, "ko"),
-                Instant.now().toString()
-        );
-        store.insertEvent(MEDIA_NOTE_SCOPE, lectureId, String.valueOf(note.get("id")), note);
-        return note;
+        return noteSupport.summarizeLecture(store, MEDIA_NOTE_SCOPE, payloadSupport, lectureId, style, language);
     }
 
     public List<Map<String, Object>> notes(String lectureId) {
-        return store.listEventsByOwner(MEDIA_NOTE_SCOPE, lectureId);
+        return noteSupport.notes(store, MEDIA_NOTE_SCOPE, lectureId);
     }
 
     public Map<String, Object> mediaAsset(String assetKey) {


### PR DESCRIPTION
## Summary
- extract media summary-note creation/read logic into FeatureStoreNoteSupport
- reduce FeatureStoreService direct persistence orchestration for notes
- keep behavior unchanged for summarizeLecture/notes endpoints

## Validation
- CI checks required (local maven unavailable in this environment)
