### PR TITLE
refactor(bundle): split course detail sections and demo course write support

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningCourseWriteSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningCourseWriteSupport.java
@@ -1,0 +1,37 @@
+package com.myway.backendspring.domain;
+
+import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+public class DemoLearningCourseWriteSupport {
+    public CourseDetail createCourse(
+            boolean useStore,
+            FeatureJdbcStore store,
+            String courseScope,
+            LearningPayloadMapper payloadMapper,
+            Map<String, CourseDetail> courses,
+            String instructorId,
+            String title,
+            List<String> lectureTitles
+    ) {
+        String courseId = "crs_" + UUID.randomUUID();
+        List<String> titles = lectureTitles == null || lectureTitles.isEmpty() ? List.of(title) : lectureTitles;
+        List<LectureItem> lectures = new ArrayList<>();
+        for (int i = 0; i < titles.size(); i++) {
+            lectures.add(new LectureItem("lec_" + UUID.randomUUID(), courseId, titles.get(i), 25 + (i * 5)));
+        }
+        CourseDetail detail = new CourseDetail(courseId, title, instructorId, List.copyOf(lectures), 0);
+        if (useStore) {
+            store.upsertKv(courseScope, courseId, payloadMapper.toCoursePayload(detail));
+        } else {
+            courses.put(courseId, detail);
+        }
+        return detail;
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -42,6 +42,7 @@ public class DemoLearningService {
     private final DemoLearningDashboardSupport demoLearningDashboardSupport;
     private final DemoLearningLectureQuerySupport demoLearningLectureQuerySupport;
     private final DemoLearningMetadataSyncFacade demoLearningMetadataSyncFacade;
+    private final DemoLearningCourseWriteSupport demoLearningCourseWriteSupport;
 
     @Autowired
     public DemoLearningService(
@@ -61,7 +62,8 @@ public class DemoLearningService {
             DemoLearningCourseAccessSupport demoLearningCourseAccessSupport,
             DemoLearningDashboardSupport demoLearningDashboardSupport,
             DemoLearningLectureQuerySupport demoLearningLectureQuerySupport,
-            DemoLearningMetadataSyncFacade demoLearningMetadataSyncFacade
+            DemoLearningMetadataSyncFacade demoLearningMetadataSyncFacade,
+            DemoLearningCourseWriteSupport demoLearningCourseWriteSupport
     ) {
         this.store = store;
         this.activityEventService = activityEventService;
@@ -80,6 +82,7 @@ public class DemoLearningService {
         this.demoLearningDashboardSupport = demoLearningDashboardSupport;
         this.demoLearningLectureQuerySupport = demoLearningLectureQuerySupport;
         this.demoLearningMetadataSyncFacade = demoLearningMetadataSyncFacade;
+        this.demoLearningCourseWriteSupport = demoLearningCourseWriteSupport;
         initSeedData();
     }
 
@@ -102,6 +105,7 @@ public class DemoLearningService {
         this.demoLearningDashboardSupport = new DemoLearningDashboardSupport();
         this.demoLearningLectureQuerySupport = new DemoLearningLectureQuerySupport();
         this.demoLearningMetadataSyncFacade = new DemoLearningMetadataSyncFacade();
+        this.demoLearningCourseWriteSupport = new DemoLearningCourseWriteSupport();
         initSeedData();
     }
 
@@ -150,19 +154,16 @@ public class DemoLearningService {
     }
 
     public CourseDetail createCourse(String instructorId, String title, List<String> lectureTitles) {
-        String courseId = "crs_" + UUID.randomUUID();
-        List<String> titles = lectureTitles == null || lectureTitles.isEmpty() ? List.of(title) : lectureTitles;
-        List<LectureItem> lectures = new ArrayList<>();
-        for (int i = 0; i < titles.size(); i++) {
-            lectures.add(new LectureItem("lec_" + UUID.randomUUID(), courseId, titles.get(i), 25 + (i * 5)));
-        }
-        CourseDetail detail = new CourseDetail(courseId, title, instructorId, List.copyOf(lectures), 0);
-        if (useStore()) {
-            store.upsertKv(COURSE_SCOPE, courseId, learningPayloadMapper.toCoursePayload(detail));
-        } else {
-            courses.put(courseId, detail);
-        }
-        return detail;
+        return demoLearningCourseWriteSupport.createCourse(
+                useStore(),
+                store,
+                COURSE_SCOPE,
+                learningPayloadMapper,
+                courses,
+                instructorId,
+                title,
+                lectureTitles
+        );
     }
 
     public CourseDetail getCourseDetail(String courseId, String userId) {

--- a/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanel.tsx
@@ -3,6 +3,7 @@ import { CourseSessionTimeline } from './CourseSessionTimeline';
 import { StatePanel } from './StatePanel';
 import { buildProtectedVideoUrl, resolveLectureVideoUrl } from '../../../lib/video-url';
 import { useLectureAssetRemap } from './useLectureAssetRemap';
+import { formatDuration, renderMaterialList, renderNoticeList } from './CourseExploreDetailPanelSections';
 
 type CourseExploreDetailPanelProps = {
   course: CourseDetail | null;
@@ -29,137 +30,6 @@ const primaryButtonClass =
 const secondaryButtonClass =
   'rounded-xl border border-slate-200 bg-white px-4 py-2 text-[12px] font-semibold text-slate-700 transition hover:border-cyan-200 hover:text-cyan-700';
 
-function formatDisplayDate(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-}
-
-function formatDuration(minutes: number): string {
-  if (minutes < 60) {
-    return `${minutes}분`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  const remain = minutes % 60;
-  return remain > 0 ? `${hours}시간 ${remain}분` : `${hours}시간`;
-}
-
-function renderNoticeList(course: CourseDetail) {
-  const notices = Array.isArray(course.notices) ? course.notices : [];
-  if (notices.length === 0) {
-    return (
-      <StatePanel
-        compact
-        icon="ri-megaphone-line"
-        tone="slate"
-        title="등록된 공지가 없습니다."
-        description="공지사항이 추가되면 이 영역에서 최신 안내를 바로 확인할 수 있습니다."
-      />
-    );
-  }
-
-  return (
-    <div className="space-y-3">
-      <div className="rounded-2xl border border-cyan-200/30 bg-cyan-50/70 px-4 py-3">
-        <div className="text-[12px] font-semibold text-cyan-800">공지 요약</div>
-        <div className="mt-1 text-[12px] text-cyan-700">총 {notices.length}건 · 중요 공지는 상단 고정되어 먼저 보입니다.</div>
-      </div>
-      {notices.map((notice) => (
-        <article key={notice.id} className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
-          <div className="flex items-start justify-between gap-3">
-            <div className="flex min-w-0 flex-1 items-start gap-3">
-              <div className={`mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${notice.pinned ? 'bg-cyan-100 text-cyan-700' : 'bg-slate-100 text-slate-500'}`}>
-                <i className={notice.pinned ? 'ri-pushpin-fill' : 'ri-megaphone-line'} />
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="text-[14px] font-semibold text-slate-900">{notice.title}</p>
-                  {notice.pinned ? <span className="rounded-full bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-700">고정</span> : null}
-                </div>
-                <p className="mt-2 whitespace-pre-line text-[12px] leading-6 text-slate-500">{notice.content}</p>
-              </div>
-            </div>
-            <div className="flex-shrink-0 text-[11px] text-slate-400">{formatDisplayDate(notice.created_at)}</div>
-          </div>
-        </article>
-      ))}
-    </div>
-  );
-}
-
-function renderMaterialList(
-  course: CourseDetail,
-  canManageCurrent: boolean,
-  onOpenMaterial: (fileName: string) => void,
-  onNavigateStudio: () => void,
-) {
-  const materials = Array.isArray(course.materials) ? course.materials : [];
-  if (materials.length === 0) {
-    return (
-      <StatePanel
-        compact
-        icon="ri-folder-line"
-        tone="amber"
-        title="등록된 자료가 없습니다."
-        description="강의 자료가 올라오면 파일명, 요약, 업로드 시점을 함께 보여줍니다."
-      />
-    );
-  }
-
-  return (
-    <div className="space-y-3">
-      <div className="rounded-2xl border border-cyan-200/30 bg-cyan-50/70 px-4 py-3">
-        <div className="text-[12px] font-semibold text-cyan-800">자료실</div>
-        <div className="mt-1 text-[12px] text-cyan-700">총 {materials.length}건 · 파일명과 업로드일을 기준으로 빠르게 찾을 수 있습니다.</div>
-      </div>
-      {materials.map((material) => (
-        <article key={material.id} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-          <div className="flex items-start gap-3">
-            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-white text-[18px] text-cyan-700 shadow-sm">
-              <i className="ri-file-pdf-2-line" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <p className="truncate text-[13px] font-semibold text-slate-900">{material.title}</p>
-                <span className="text-[11px] text-slate-400">{formatDisplayDate(material.uploaded_at)}</span>
-              </div>
-              <p className="mt-1 text-[11px] font-medium text-cyan-700">{material.file_name}</p>
-              <p className="mt-2 text-[12px] leading-6 text-slate-500">{material.summary}</p>
-              <div className="mt-3">
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => onOpenMaterial(material.file_name)}
-                    className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700"
-                  >
-                    파일명 복사
-                  </button>
-                  {canManageCurrent ? (
-                    <button
-                      type="button"
-                      onClick={onNavigateStudio}
-                      className="rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700 transition hover:border-cyan-300 hover:bg-cyan-100"
-                    >
-                      강의 스튜디오 이동
-                    </button>
-                  ) : null}
-                </div>
-              </div>
-            </div>
-          </div>
-        </article>
-      ))}
-    </div>
-  );
-}
 
 export function CourseExploreDetailPanel({
   course,

--- a/frontend/src/features/lms/components/CourseExploreDetailPanelSections.tsx
+++ b/frontend/src/features/lms/components/CourseExploreDetailPanelSections.tsx
@@ -1,0 +1,110 @@
+import type { CourseDetail } from '@myway/shared';
+import { StatePanel } from './StatePanel';
+
+export function formatDisplayDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
+}
+
+export function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes}분`;
+  const hours = Math.floor(minutes / 60);
+  const remain = minutes % 60;
+  return remain > 0 ? `${hours}시간 ${remain}분` : `${hours}시간`;
+}
+
+export function renderNoticeList(course: CourseDetail) {
+  const notices = Array.isArray(course.notices) ? course.notices : [];
+  if (notices.length === 0) {
+    return (
+      <StatePanel
+        compact
+        icon="ri-megaphone-line"
+        tone="slate"
+        title="등록된 공지가 없습니다."
+        description="공지사항이 추가되면 이 영역에서 최신 안내를 바로 확인할 수 있습니다."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-2xl border border-cyan-200/30 bg-cyan-50/70 px-4 py-3">
+        <div className="text-[12px] font-semibold text-cyan-800">공지 요약</div>
+        <div className="mt-1 text-[12px] text-cyan-700">총 {notices.length}건 · 중요 공지는 상단 고정되어 먼저 보입니다.</div>
+      </div>
+      {notices.map((notice) => (
+        <article key={notice.id} className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.04)]">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 flex-1 items-start gap-3">
+              <div className={`mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${notice.pinned ? 'bg-cyan-100 text-cyan-700' : 'bg-slate-100 text-slate-500'}`}>
+                <i className={notice.pinned ? 'ri-pushpin-fill' : 'ri-megaphone-line'} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-[14px] font-semibold text-slate-900">{notice.title}</p>
+                  {notice.pinned ? <span className="rounded-full bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-700">고정</span> : null}
+                </div>
+                <p className="mt-2 whitespace-pre-line text-[12px] leading-6 text-slate-500">{notice.content}</p>
+              </div>
+            </div>
+            <div className="flex-shrink-0 text-[11px] text-slate-400">{formatDisplayDate(notice.created_at)}</div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function renderMaterialList(
+  course: CourseDetail,
+  canManageCurrent: boolean,
+  onOpenMaterial: (fileName: string) => void,
+  onNavigateStudio: () => void,
+) {
+  const materials = Array.isArray(course.materials) ? course.materials : [];
+  if (materials.length === 0) {
+    return (
+      <StatePanel compact icon="ri-folder-line" tone="amber" title="등록된 자료가 없습니다." description="강의 자료가 올라오면 파일명, 요약, 업로드 시점을 함께 보여줍니다." />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-2xl border border-cyan-200/30 bg-cyan-50/70 px-4 py-3">
+        <div className="text-[12px] font-semibold text-cyan-800">자료실</div>
+        <div className="mt-1 text-[12px] text-cyan-700">총 {materials.length}건 · 파일명과 업로드일을 기준으로 빠르게 찾을 수 있습니다.</div>
+      </div>
+      {materials.map((material) => (
+        <article key={material.id} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-white text-[18px] text-cyan-700 shadow-sm">
+              <i className="ri-file-pdf-2-line" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="truncate text-[13px] font-semibold text-slate-900">{material.title}</p>
+                <span className="text-[11px] text-slate-400">{formatDisplayDate(material.uploaded_at)}</span>
+              </div>
+              <p className="mt-1 text-[11px] font-medium text-cyan-700">{material.file_name}</p>
+              <p className="mt-2 text-[12px] leading-6 text-slate-500">{material.summary}</p>
+              <div className="mt-3">
+                <div className="flex flex-wrap gap-2">
+                  <button type="button" onClick={() => onOpenMaterial(material.file_name)} className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-600 transition hover:border-cyan-200 hover:text-cyan-700">
+                    파일명 복사
+                  </button>
+                  {canManageCurrent ? (
+                    <button type="button" onClick={onNavigateStudio} className="rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700 transition hover:border-cyan-300 hover:bg-cyan-100">
+                      강의 스튜디오 이동
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- frontend: split CourseExploreDetailPanel notice/material section renderers into CourseExploreDetailPanelSections
- backend: extract DemoLearningService.createCourse write flow into DemoLearningCourseWriteSupport
- keep behavior unchanged while reducing per-file responsibility

## Validation
- npm --prefix frontend run build (pass)
- backend validation via CI checks
