### PR TITLE
refactor(domain): extract demo learning content facade

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningContentFacade.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningContentFacade.java
@@ -1,0 +1,99 @@
+package com.myway.backendspring.domain;
+
+import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class DemoLearningContentFacade {
+
+    public List<MaterialItem> getMaterials(
+            LearningContentStoreSupport learningContentStoreSupport,
+            boolean useStore,
+            FeatureJdbcStore store,
+            String materialScope,
+            LearningPayloadMapper payloadMapper,
+            Map<String, List<MaterialItem>> materialsByCourse,
+            String courseId
+    ) {
+        return learningContentStoreSupport.getMaterials(
+                useStore,
+                store,
+                materialScope,
+                payloadMapper,
+                materialsByCourse,
+                courseId
+        );
+    }
+
+    public List<NoticeItem> getNotices(
+            LearningContentStoreSupport learningContentStoreSupport,
+            boolean useStore,
+            FeatureJdbcStore store,
+            String noticeScope,
+            LearningPayloadMapper payloadMapper,
+            Map<String, List<NoticeItem>> noticesByCourse,
+            String courseId
+    ) {
+        return learningContentStoreSupport.getNotices(
+                useStore,
+                store,
+                noticeScope,
+                payloadMapper,
+                noticesByCourse,
+                courseId
+        );
+    }
+
+    public MaterialItem addMaterial(
+            LearningContentStoreSupport learningContentStoreSupport,
+            boolean useStore,
+            FeatureJdbcStore store,
+            String materialScope,
+            LearningPayloadMapper payloadMapper,
+            Map<String, List<MaterialItem>> materialsByCourse,
+            String courseId,
+            String title,
+            String summary,
+            String fileName
+    ) {
+        return learningContentStoreSupport.addMaterial(
+                useStore,
+                store,
+                materialScope,
+                payloadMapper,
+                materialsByCourse,
+                courseId,
+                title,
+                summary,
+                fileName
+        );
+    }
+
+    public NoticeItem addNotice(
+            LearningContentStoreSupport learningContentStoreSupport,
+            boolean useStore,
+            FeatureJdbcStore store,
+            String noticeScope,
+            LearningPayloadMapper payloadMapper,
+            Map<String, List<NoticeItem>> noticesByCourse,
+            String courseId,
+            String title,
+            String content,
+            boolean pinned
+    ) {
+        return learningContentStoreSupport.addNotice(
+                useStore,
+                store,
+                noticeScope,
+                payloadMapper,
+                noticesByCourse,
+                courseId,
+                title,
+                content,
+                pinned
+        );
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -43,6 +43,7 @@ public class DemoLearningService {
     private final DemoLearningLectureQuerySupport demoLearningLectureQuerySupport;
     private final DemoLearningMetadataSyncFacade demoLearningMetadataSyncFacade;
     private final DemoLearningCourseWriteSupport demoLearningCourseWriteSupport;
+    private final DemoLearningContentFacade demoLearningContentFacade;
 
     @Autowired
     public DemoLearningService(
@@ -63,7 +64,8 @@ public class DemoLearningService {
             DemoLearningDashboardSupport demoLearningDashboardSupport,
             DemoLearningLectureQuerySupport demoLearningLectureQuerySupport,
             DemoLearningMetadataSyncFacade demoLearningMetadataSyncFacade,
-            DemoLearningCourseWriteSupport demoLearningCourseWriteSupport
+            DemoLearningCourseWriteSupport demoLearningCourseWriteSupport,
+            DemoLearningContentFacade demoLearningContentFacade
     ) {
         this.store = store;
         this.activityEventService = activityEventService;
@@ -83,6 +85,7 @@ public class DemoLearningService {
         this.demoLearningLectureQuerySupport = demoLearningLectureQuerySupport;
         this.demoLearningMetadataSyncFacade = demoLearningMetadataSyncFacade;
         this.demoLearningCourseWriteSupport = demoLearningCourseWriteSupport;
+        this.demoLearningContentFacade = demoLearningContentFacade;
         initSeedData();
     }
 
@@ -106,6 +109,7 @@ public class DemoLearningService {
         this.demoLearningLectureQuerySupport = new DemoLearningLectureQuerySupport();
         this.demoLearningMetadataSyncFacade = new DemoLearningMetadataSyncFacade();
         this.demoLearningCourseWriteSupport = new DemoLearningCourseWriteSupport();
+        this.demoLearningContentFacade = new DemoLearningContentFacade();
         initSeedData();
     }
 
@@ -201,7 +205,8 @@ public class DemoLearningService {
     }
 
     public List<MaterialItem> getMaterials(String courseId) {
-        return learningContentStoreSupport.getMaterials(
+        return demoLearningContentFacade.getMaterials(
+                learningContentStoreSupport,
                 useStore(),
                 store,
                 MATERIAL_SCOPE,
@@ -212,7 +217,8 @@ public class DemoLearningService {
     }
 
     public List<NoticeItem> getNotices(String courseId) {
-        return learningContentStoreSupport.getNotices(
+        return demoLearningContentFacade.getNotices(
+                learningContentStoreSupport,
                 useStore(),
                 store,
                 NOTICE_SCOPE,
@@ -223,7 +229,8 @@ public class DemoLearningService {
     }
 
     public MaterialItem addMaterial(String userId, String courseId, String title, String summary, String fileName) {
-        return learningContentStoreSupport.addMaterial(
+        return demoLearningContentFacade.addMaterial(
+                learningContentStoreSupport,
                 useStore(),
                 store,
                 MATERIAL_SCOPE,
@@ -237,7 +244,8 @@ public class DemoLearningService {
     }
 
     public NoticeItem addNotice(String userId, String courseId, String title, String content, boolean pinned) {
-        return learningContentStoreSupport.addNotice(
+        return demoLearningContentFacade.addNotice(
+                learningContentStoreSupport,
                 useStore(),
                 store,
                 NOTICE_SCOPE,


### PR DESCRIPTION
## Summary
- extract materials/notices read-write delegation from DemoLearningService into DemoLearningContentFacade
- reduce service method clutter and keep orchestration style consistent
- preserve existing domain behavior

## Validation
- CI checks required (local maven unavailable in this environment)
