### PR TITLE
[Refactor] DemoLearningService 메타데이터 동기화 파사드 분리

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningLectureMetadataFacade.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningLectureMetadataFacade.java
@@ -1,0 +1,115 @@
+package com.myway.backendspring.domain;
+
+import com.myway.backendspring.persistence.FeatureJdbcStore;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Component
+public class DemoLearningLectureMetadataFacade {
+    private static final String LECTURE_META_SCOPE = "learning_lecture_meta";
+    private static final String TRANSCRIPT_SCOPE = "media_transcript";
+    private static final String EXTRACTION_SCOPE = "media_extraction";
+    private static final String SPEAKER_REVIEW_SCOPE = "media_speaker_review";
+
+    private final FeatureJdbcStore store;
+    private final DemoLearningMetadataSyncFacade metadataSyncFacade;
+    private final DemoLearningTranscriptSyncFacade transcriptSyncFacade;
+    private final DemoLearningMetadataSupport metadataSupport;
+    private final LectureMetadataSyncServiceSupport lectureMetadataSyncServiceSupport;
+    private final LectureMetadataSyncSupport lectureMetadataSyncSupport;
+    private final LectureDurationResolver lectureDurationResolver;
+
+    public DemoLearningLectureMetadataFacade(
+            FeatureJdbcStore store,
+            DemoLearningMetadataSyncFacade metadataSyncFacade,
+            DemoLearningTranscriptSyncFacade transcriptSyncFacade,
+            DemoLearningMetadataSupport metadataSupport,
+            LectureMetadataSyncServiceSupport lectureMetadataSyncServiceSupport,
+            LectureMetadataSyncSupport lectureMetadataSyncSupport,
+            LectureDurationResolver lectureDurationResolver
+    ) {
+        this.store = store;
+        this.metadataSyncFacade = metadataSyncFacade;
+        this.transcriptSyncFacade = transcriptSyncFacade;
+        this.metadataSupport = metadataSupport;
+        this.lectureMetadataSyncServiceSupport = lectureMetadataSyncServiceSupport;
+        this.lectureMetadataSyncSupport = lectureMetadataSyncSupport;
+        this.lectureDurationResolver = lectureDurationResolver;
+    }
+
+    public List<LectureItem> alignCourseLectures(boolean useStore, List<LectureItem> lectures) {
+        return transcriptSyncFacade.alignCourseLectures(
+                metadataSyncFacade,
+                metadataSupport,
+                useStore,
+                lectures,
+                lecture -> alignLectureDuration(useStore, lecture)
+        );
+    }
+
+    public Map<String, Object> syncAllFromTranscripts(boolean useStore, boolean overwriteExisting, Supplier<List<LectureItem>> lecturesSupplier) {
+        return transcriptSyncFacade.syncAll(
+                metadataSyncFacade,
+                metadataSupport,
+                store,
+                useStore,
+                lecturesSupplier.get(),
+                LECTURE_META_SCOPE,
+                TRANSCRIPT_SCOPE,
+                lectureMetadataSyncServiceSupport,
+                lectureMetadataSyncSupport,
+                this::buildLectureMetaFromTranscript,
+                overwriteExisting
+        );
+    }
+
+    public Map<String, Object> syncLectureFromTranscript(
+            boolean useStore,
+            String lectureId,
+            boolean overwriteExisting,
+            Function<String, LectureItem> lectureResolver
+    ) {
+        String normalizedLectureId = lectureId == null ? "" : lectureId.trim();
+        LectureItem lecture = normalizedLectureId.isBlank() ? null : lectureResolver.apply(normalizedLectureId);
+        return transcriptSyncFacade.syncOne(
+                metadataSyncFacade,
+                metadataSupport,
+                store,
+                useStore,
+                normalizedLectureId,
+                lecture,
+                LECTURE_META_SCOPE,
+                TRANSCRIPT_SCOPE,
+                lectureMetadataSyncServiceSupport,
+                lectureMetadataSyncSupport,
+                this::buildLectureMetaFromTranscript,
+                overwriteExisting
+        );
+    }
+
+    private LectureItem alignLectureDuration(boolean useStore, LectureItem lecture) {
+        return metadataSyncFacade.alignLectureDuration(
+                metadataSupport,
+                store,
+                useStore,
+                lecture,
+                LECTURE_META_SCOPE,
+                TRANSCRIPT_SCOPE,
+                EXTRACTION_SCOPE,
+                lectureMetadataSyncServiceSupport,
+                lectureMetadataSyncSupport,
+                lectureDurationResolver,
+                this::buildLectureMetaFromTranscript
+        );
+    }
+
+    private Map<String, Object> buildLectureMetaFromTranscript(LectureItem lecture, Map<String, Object> transcript) {
+        String lectureId = lecture == null ? "" : lecture.id();
+        Map<String, Object> speakerReview = store == null ? null : store.getKv(SPEAKER_REVIEW_SCOPE, lectureId);
+        return lectureMetadataSyncSupport.buildLectureMetaFromTranscript(lecture, transcript, speakerReview);
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/domain/DemoLearningService.java
@@ -16,10 +16,6 @@ public class DemoLearningService {
     private static final String COURSE_SCOPE = "learning_course";
     private static final String MATERIAL_SCOPE = "learning_material";
     private static final String NOTICE_SCOPE = "learning_notice";
-    private static final String LECTURE_META_SCOPE = "learning_lecture_meta";
-    private static final String TRANSCRIPT_SCOPE = "media_transcript";
-    private static final String EXTRACTION_SCOPE = "media_extraction";
-    private static final String SPEAKER_REVIEW_SCOPE = "media_speaker_review";
     private static final String DEFAULT_DEMO_STUDENT_ID = "usr_std_001";
     private final Map<String, CourseDetail> courses = new LinkedHashMap<>();
     private final Map<String, List<MaterialItem>> materialsByCourse = new ConcurrentHashMap<>();
@@ -42,8 +38,7 @@ public class DemoLearningService {
     private final DemoLearningCourseAccessSupport demoLearningCourseAccessSupport;
     private final DemoLearningDashboardSupport demoLearningDashboardSupport;
     private final DemoLearningLectureQuerySupport demoLearningLectureQuerySupport;
-    private final DemoLearningMetadataSyncFacade demoLearningMetadataSyncFacade;
-    private final DemoLearningTranscriptSyncFacade demoLearningTranscriptSyncFacade;
+    private final DemoLearningLectureMetadataFacade demoLearningLectureMetadataFacade;
     private final DemoLearningCourseWriteSupport demoLearningCourseWriteSupport;
     private final DemoLearningContentFacade demoLearningContentFacade;
     private final DemoLearningEnrollmentFacade demoLearningEnrollmentFacade;
@@ -66,8 +61,7 @@ public class DemoLearningService {
             DemoLearningCourseAccessSupport demoLearningCourseAccessSupport,
             DemoLearningDashboardSupport demoLearningDashboardSupport,
             DemoLearningLectureQuerySupport demoLearningLectureQuerySupport,
-            DemoLearningMetadataSyncFacade demoLearningMetadataSyncFacade,
-            DemoLearningTranscriptSyncFacade demoLearningTranscriptSyncFacade,
+            DemoLearningLectureMetadataFacade demoLearningLectureMetadataFacade,
             DemoLearningCourseWriteSupport demoLearningCourseWriteSupport,
             DemoLearningContentFacade demoLearningContentFacade,
             DemoLearningEnrollmentFacade demoLearningEnrollmentFacade
@@ -88,8 +82,7 @@ public class DemoLearningService {
         this.demoLearningCourseAccessSupport = demoLearningCourseAccessSupport;
         this.demoLearningDashboardSupport = demoLearningDashboardSupport;
         this.demoLearningLectureQuerySupport = demoLearningLectureQuerySupport;
-        this.demoLearningMetadataSyncFacade = demoLearningMetadataSyncFacade;
-        this.demoLearningTranscriptSyncFacade = demoLearningTranscriptSyncFacade;
+        this.demoLearningLectureMetadataFacade = demoLearningLectureMetadataFacade;
         this.demoLearningCourseWriteSupport = demoLearningCourseWriteSupport;
         this.demoLearningContentFacade = demoLearningContentFacade;
         this.demoLearningEnrollmentFacade = demoLearningEnrollmentFacade;
@@ -114,8 +107,15 @@ public class DemoLearningService {
         this.demoLearningCourseAccessSupport = new DemoLearningCourseAccessSupport();
         this.demoLearningDashboardSupport = new DemoLearningDashboardSupport();
         this.demoLearningLectureQuerySupport = new DemoLearningLectureQuerySupport();
-        this.demoLearningMetadataSyncFacade = new DemoLearningMetadataSyncFacade();
-        this.demoLearningTranscriptSyncFacade = new DemoLearningTranscriptSyncFacade();
+        this.demoLearningLectureMetadataFacade = new DemoLearningLectureMetadataFacade(
+                null,
+                new DemoLearningMetadataSyncFacade(),
+                new DemoLearningTranscriptSyncFacade(),
+                demoLearningMetadataSupport,
+                lectureMetadataSyncServiceSupport,
+                lectureMetadataSyncSupport,
+                lectureDurationResolver
+        );
         this.demoLearningCourseWriteSupport = new DemoLearningCourseWriteSupport();
         this.demoLearningContentFacade = new DemoLearningContentFacade();
         this.demoLearningEnrollmentFacade = new DemoLearningEnrollmentFacade();
@@ -395,64 +395,15 @@ public class DemoLearningService {
     }
 
     private List<LectureItem> alignLectureDurations(List<LectureItem> lectures) {
-        return demoLearningTranscriptSyncFacade.alignCourseLectures(
-                demoLearningMetadataSyncFacade,
-                demoLearningMetadataSupport,
-                useStore(),
-                lectures,
-                this::alignLectureDuration
-        );
-    }
-
-    private LectureItem alignLectureDuration(LectureItem lecture) {
-        return demoLearningMetadataSyncFacade.alignLectureDuration(
-                demoLearningMetadataSupport,
-                store,
-                useStore(),
-                lecture,
-                LECTURE_META_SCOPE,
-                TRANSCRIPT_SCOPE,
-                EXTRACTION_SCOPE,
-                lectureMetadataSyncServiceSupport,
-                lectureMetadataSyncSupport,
-                lectureDurationResolver,
-                this::buildLectureMetaFromTranscript
-        );
+        return demoLearningLectureMetadataFacade.alignCourseLectures(useStore(), lectures);
     }
 
     public Map<String, Object> syncLectureMetadataFromTranscripts(boolean overwriteExisting) {
-        return demoLearningTranscriptSyncFacade.syncAll(
-                demoLearningMetadataSyncFacade,
-                demoLearningMetadataSupport,
-                store,
-                useStore(),
-                listAllLectures(),
-                LECTURE_META_SCOPE,
-                TRANSCRIPT_SCOPE,
-                lectureMetadataSyncServiceSupport,
-                lectureMetadataSyncSupport,
-                this::buildLectureMetaFromTranscript,
-                overwriteExisting
-        );
+        return demoLearningLectureMetadataFacade.syncAllFromTranscripts(useStore(), overwriteExisting, this::listAllLectures);
     }
 
     public Map<String, Object> syncLectureMetadataForLectureFromTranscript(String lectureId, boolean overwriteExisting) {
-        String normalizedLectureId = lectureId == null ? "" : lectureId.trim();
-        LectureItem lecture = normalizedLectureId.isBlank() ? null : getLecture(normalizedLectureId);
-        return demoLearningTranscriptSyncFacade.syncOne(
-                demoLearningMetadataSyncFacade,
-                demoLearningMetadataSupport,
-                store,
-                useStore(),
-                normalizedLectureId,
-                lecture,
-                LECTURE_META_SCOPE,
-                TRANSCRIPT_SCOPE,
-                lectureMetadataSyncServiceSupport,
-                lectureMetadataSyncSupport,
-                this::buildLectureMetaFromTranscript,
-                overwriteExisting
-        );
+        return demoLearningLectureMetadataFacade.syncLectureFromTranscript(useStore(), lectureId, overwriteExisting, this::getLecture);
     }
 
     private List<CourseDetail> listAllCourses() {
@@ -484,9 +435,4 @@ public class DemoLearningService {
         }
     }
 
-    private Map<String, Object> buildLectureMetaFromTranscript(LectureItem lecture, Map<String, Object> transcript) {
-        String lectureId = lecture == null ? "" : lecture.id();
-        Map<String, Object> speakerReview = store.getKv(SPEAKER_REVIEW_SCOPE, lectureId);
-        return lectureMetadataSyncSupport.buildLectureMetaFromTranscript(lecture, transcript, speakerReview);
-    }
 }


### PR DESCRIPTION
## 작업 내용\n- DemoLearningLectureMetadataFacade 신규 도입\n- DemoLearningService의 강의 메타데이터 정렬/동기화 책임 이관\n- 서비스 본문에서 관련 구현 상세 제거, 파사드 위임\n\n## 검증\n- npm run verify 통과\n\n## 효과\n- DemoLearningService 책임 축소\n- 메타데이터 동기화 로직 모듈화