### PR TITLE
refactor(backend): split learning store hydrate concerns

### DIFF
--- a/backend/src/lib/learning-store-hydrator.ts
+++ b/backend/src/lib/learning-store-hydrator.ts
@@ -1,0 +1,175 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import type { CourseDetail, Lecture, LecturePipeline } from '@myway/shared';
+import {
+  mapEnrollmentRow,
+  mapExtractionRow,
+  mapLectureProgressRow,
+  mapMaterialRow,
+  mapNoteRow,
+  mapNoticeRow,
+  mapPipelineRow,
+  mapTranscriptRow,
+  type EnrollmentRow,
+  type ExtractionRow,
+  type LectureProgressRow,
+  type MaterialRow,
+  type NoteRow,
+  type NoticeRow,
+  type PipelineRow,
+  type TranscriptRow,
+} from './learning-store-mappers';
+
+export type CourseRow = {
+  id: string;
+  instructor_id: string;
+  title: string;
+  description: string;
+  category: string;
+  difficulty: string;
+  is_published: number;
+  tags_json: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type LectureRow = {
+  id: string;
+  course_id: string;
+  title: string;
+  order_index: number;
+  week_number: number | null;
+  session_number: number | null;
+  content_type: string;
+  content_text: string;
+  duration_minutes: number;
+  is_published: number;
+  video_url?: string | null;
+  video_asset_key?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function parseTags(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function ensureLectureContentType(value: string): Lecture['content_type'] {
+  return value === 'text' ? 'text' : 'video';
+}
+
+function toBoolean(value: number): boolean {
+  return value === 1;
+}
+
+function upsertById<T extends { id: string }>(items: T[], item: T): void {
+  const index = items.findIndex((current) => current.id === item.id);
+  if (index >= 0) {
+    items[index] = item;
+    return;
+  }
+  items.push(item);
+}
+
+function upsertPipelineByLectureId(items: LecturePipeline[], item: LecturePipeline): void {
+  const index = items.findIndex((current) => current.lecture_id === item.lecture_id);
+  if (index >= 0) {
+    items[index] = item;
+    return;
+  }
+  items.push(item);
+}
+
+function mapLectureRow(row: LectureRow, demoLectures: Lecture[]): Lecture {
+  const lecture = demoLectures.find((item) => item.id === row.id);
+  return {
+    ...(lecture ?? {
+      id: row.id,
+      course_id: row.course_id,
+      title: row.title,
+      order_index: row.order_index,
+      week_number: row.week_number ?? undefined,
+      session_number: row.session_number ?? undefined,
+      content_type: ensureLectureContentType(row.content_type),
+      content_text: row.content_text,
+      duration_minutes: row.duration_minutes,
+      is_published: toBoolean(row.is_published),
+    }),
+    id: row.id,
+    course_id: row.course_id,
+    title: row.title,
+    order_index: row.order_index,
+    week_number: row.week_number ?? undefined,
+    session_number: row.session_number ?? undefined,
+    content_type: ensureLectureContentType(row.content_type),
+    content_text: row.content_text,
+    duration_minutes: row.duration_minutes,
+    is_published: toBoolean(row.is_published),
+    video_url: row.video_url ?? undefined,
+    video_asset_key: row.video_asset_key ?? undefined,
+  };
+}
+
+export async function hydrateLearningStoreMemory(
+  db: D1Database,
+  memory: {
+    demoCourses: Array<{
+      id: string;
+      instructor_id: string;
+      title: string;
+      description: string;
+      category: string;
+      difficulty: CourseDetail['difficulty'];
+      is_published: boolean;
+      tags: string[];
+    }>;
+    demoLectures: Lecture[];
+    demoMaterials: any[];
+    demoNotices: any[];
+    demoEnrollments: any[];
+    demoLectureProgress: any[];
+    demoLectureTranscripts: any[];
+    demoLectureNotes: any[];
+    demoAudioExtractions: any[];
+    demoLecturePipelines: LecturePipeline[];
+  },
+): Promise<void> {
+  const [courseRows, lectureRows, materialRows, noticeRows, enrollmentRows, progressRows, transcriptRows, noteRows, extractionRows, pipelineRows] = await Promise.all([
+    db.prepare('SELECT * FROM courses ORDER BY created_at ASC, id ASC').all<CourseRow>(),
+    db.prepare('SELECT * FROM lectures ORDER BY course_id ASC, order_index ASC, id ASC').all<LectureRow>(),
+    db.prepare('SELECT * FROM course_materials ORDER BY uploaded_at DESC, id ASC').all<MaterialRow>(),
+    db.prepare('SELECT * FROM course_notices ORDER BY pinned DESC, created_at DESC, id ASC').all<NoticeRow>(),
+    db.prepare('SELECT * FROM enrollments ORDER BY created_at ASC, id ASC').all<EnrollmentRow>(),
+    db.prepare('SELECT * FROM lecture_progress ORDER BY updated_at DESC, id ASC').all<LectureProgressRow>(),
+    db.prepare('SELECT * FROM lecture_transcripts ORDER BY created_at ASC, id ASC').all<TranscriptRow>(),
+    db.prepare('SELECT * FROM lecture_notes ORDER BY created_at ASC, id ASC').all<NoteRow>(),
+    db.prepare('SELECT * FROM audio_extractions ORDER BY created_at ASC, id ASC').all<ExtractionRow>(),
+    db.prepare('SELECT * FROM lecture_pipelines ORDER BY updated_at ASC, lecture_id ASC').all<PipelineRow>(),
+  ]);
+
+  for (const row of courseRows.results) {
+    upsertById(memory.demoCourses, {
+      id: row.id,
+      instructor_id: row.instructor_id,
+      title: row.title,
+      description: row.description,
+      category: row.category,
+      difficulty: row.difficulty as CourseDetail['difficulty'],
+      is_published: toBoolean(row.is_published),
+      tags: parseTags(row.tags_json),
+    });
+  }
+  for (const row of lectureRows.results) upsertById(memory.demoLectures, mapLectureRow(row, memory.demoLectures));
+  for (const row of materialRows.results) upsertById(memory.demoMaterials, mapMaterialRow(row));
+  for (const row of noticeRows.results) upsertById(memory.demoNotices, mapNoticeRow(row));
+  for (const row of enrollmentRows.results) upsertById(memory.demoEnrollments, mapEnrollmentRow(row));
+  for (const row of progressRows.results) upsertById(memory.demoLectureProgress, mapLectureProgressRow(row));
+  for (const row of transcriptRows.results) upsertById(memory.demoLectureTranscripts, mapTranscriptRow(row));
+  for (const row of noteRows.results) upsertById(memory.demoLectureNotes, mapNoteRow(row));
+  for (const row of extractionRows.results) upsertById(memory.demoAudioExtractions, mapExtractionRow(row));
+  for (const row of pipelineRows.results) upsertPipelineByLectureId(memory.demoLecturePipelines, mapPipelineRow(row));
+}

--- a/backend/src/lib/learning-store.ts
+++ b/backend/src/lib/learning-store.ts
@@ -19,24 +19,7 @@ import {
   seedLearningStoreCourseData,
   seedLearningStoreMediaData,
 } from './learning-store-bootstrap';
-import {
-  mapEnrollmentRow,
-  mapExtractionRow,
-  mapLectureProgressRow,
-  mapMaterialRow,
-  mapNoteRow,
-  mapNoticeRow,
-  mapPipelineRow,
-  mapTranscriptRow,
-  type EnrollmentRow,
-  type ExtractionRow,
-  type LectureProgressRow,
-  type MaterialRow,
-  type NoteRow,
-  type NoticeRow,
-  type PipelineRow,
-  type TranscriptRow,
-} from './learning-store-mappers';
+import { hydrateLearningStoreMemory } from './learning-store-hydrator';
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -52,36 +35,6 @@ const seedDemoAudioExtractions = clone(demoAudioExtractions);
 const seedDemoLecturePipelines = clone(demoLecturePipelines);
 const seedDemoEnrollments = clone(demoEnrollments);
 const seedDemoLectureProgress = clone(demoLectureProgress);
-
-type CourseRow = {
-  id: string;
-  instructor_id: string;
-  title: string;
-  description: string;
-  category: string;
-  difficulty: string;
-  is_published: number;
-  tags_json: string;
-  created_at: string;
-  updated_at: string;
-};
-
-type LectureRow = {
-  id: string;
-  course_id: string;
-  title: string;
-  order_index: number;
-  week_number: number | null;
-  session_number: number | null;
-  content_type: string;
-  content_text: string;
-  duration_minutes: number;
-  is_published: number;
-  video_url?: string | null;
-  video_asset_key?: string | null;
-  created_at: string;
-  updated_at: string;
-};
 
 type TranscriptDurationRow = {
   lecture_id: string;
@@ -111,38 +64,6 @@ function toNumber(value: boolean): number {
   return value ? 1 : 0;
 }
 
-function parseTags(value: string): string[] {
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
-  } catch {
-    return [];
-  }
-}
-
-function upsertById<T extends { id: string }>(items: T[], item: T): void {
-  const index = items.findIndex((current) => current.id === item.id);
-  if (index >= 0) {
-    items[index] = item;
-    return;
-  }
-
-  items.push(item);
-}
-
-function upsertPipelineByLectureId(items: LecturePipeline[], item: LecturePipeline): void {
-  const index = items.findIndex((current) => current.lecture_id === item.lecture_id);
-  if (index >= 0) {
-    items[index] = item;
-    return;
-  }
-
-  items.push(item);
-}
-
-function ensureLectureContentType(value: string): Lecture['content_type'] {
-  return value === 'text' ? 'text' : 'video';
-}
 
 function resolveDurationMinutes(durationMs: number): number {
   return Math.max(1, Math.ceil(durationMs / 60_000));
@@ -159,36 +80,6 @@ function resetMemoryState(): void {
   demoLecturePipelines.splice(0, demoLecturePipelines.length, ...clone(seedDemoLecturePipelines));
   demoEnrollments.splice(0, demoEnrollments.length, ...clone(seedDemoEnrollments));
   demoLectureProgress.splice(0, demoLectureProgress.length, ...clone(seedDemoLectureProgress));
-}
-
-function mapLectureRow(row: LectureRow): Lecture {
-  const lecture = demoLectures.find((item) => item.id === row.id);
-  return {
-    ...(lecture ?? {
-      id: row.id,
-      course_id: row.course_id,
-      title: row.title,
-      order_index: row.order_index,
-      week_number: row.week_number ?? undefined,
-      session_number: row.session_number ?? undefined,
-      content_type: ensureLectureContentType(row.content_type),
-      content_text: row.content_text,
-      duration_minutes: row.duration_minutes,
-      is_published: toBoolean(row.is_published),
-    }),
-    id: row.id,
-    course_id: row.course_id,
-    title: row.title,
-    order_index: row.order_index,
-    week_number: row.week_number ?? undefined,
-    session_number: row.session_number ?? undefined,
-    content_type: ensureLectureContentType(row.content_type),
-    content_text: row.content_text,
-    duration_minutes: row.duration_minutes,
-    is_published: toBoolean(row.is_published),
-    video_url: row.video_url ?? undefined,
-    video_asset_key: row.video_asset_key ?? undefined,
-  };
 }
 
 function syncLectureDurationMemory(lectureId: string, durationMinutes: number): void {
@@ -242,69 +133,6 @@ async function syncLectureDurationsFromMedia(db: D1Database): Promise<void> {
 
 
 
-async function hydrateMemory(db: D1Database): Promise<void> {
-  const [courseRows, lectureRows, materialRows, noticeRows, enrollmentRows, progressRows, transcriptRows, noteRows, extractionRows, pipelineRows] = await Promise.all([
-    db.prepare('SELECT * FROM courses ORDER BY created_at ASC, id ASC').all<CourseRow>(),
-    db.prepare('SELECT * FROM lectures ORDER BY course_id ASC, order_index ASC, id ASC').all<LectureRow>(),
-    db.prepare('SELECT * FROM course_materials ORDER BY uploaded_at DESC, id ASC').all<MaterialRow>(),
-    db.prepare('SELECT * FROM course_notices ORDER BY pinned DESC, created_at DESC, id ASC').all<NoticeRow>(),
-    db.prepare('SELECT * FROM enrollments ORDER BY created_at ASC, id ASC').all<EnrollmentRow>(),
-    db.prepare('SELECT * FROM lecture_progress ORDER BY updated_at DESC, id ASC').all<LectureProgressRow>(),
-    db.prepare('SELECT * FROM lecture_transcripts ORDER BY created_at ASC, id ASC').all<TranscriptRow>(),
-    db.prepare('SELECT * FROM lecture_notes ORDER BY created_at ASC, id ASC').all<NoteRow>(),
-    db.prepare('SELECT * FROM audio_extractions ORDER BY created_at ASC, id ASC').all<ExtractionRow>(),
-    db.prepare('SELECT * FROM lecture_pipelines ORDER BY updated_at ASC, lecture_id ASC').all<PipelineRow>(),
-  ]);
-
-  for (const row of courseRows.results) {
-    upsertById(demoCourses, {
-      id: row.id,
-      instructor_id: row.instructor_id,
-      title: row.title,
-      description: row.description,
-      category: row.category,
-      difficulty: row.difficulty as CourseDetail['difficulty'],
-      is_published: toBoolean(row.is_published),
-      tags: parseTags(row.tags_json),
-    });
-  }
-
-  for (const row of lectureRows.results) {
-    upsertById(demoLectures, mapLectureRow(row));
-  }
-
-  for (const row of materialRows.results) {
-    upsertById(demoMaterials, mapMaterialRow(row));
-  }
-
-  for (const row of noticeRows.results) {
-    upsertById(demoNotices, mapNoticeRow(row));
-  }
-
-  for (const row of enrollmentRows.results) {
-    upsertById(demoEnrollments, mapEnrollmentRow(row));
-  }
-
-  for (const row of progressRows.results) {
-    upsertById(demoLectureProgress, mapLectureProgressRow(row));
-  }
-
-  for (const row of transcriptRows.results) {
-    upsertById(demoLectureTranscripts, mapTranscriptRow(row));
-  }
-
-  for (const row of noteRows.results) {
-    upsertById(demoLectureNotes, mapNoteRow(row));
-  }
-
-  for (const row of extractionRows.results) {
-    upsertById(demoAudioExtractions, mapExtractionRow(row));
-  }
-
-  for (const row of pipelineRows.results) {
-    upsertPipelineByLectureId(demoLecturePipelines, mapPipelineRow(row));
-  }
-}
 
 async function upsertCourse(db: D1Database, detail: CourseDetail): Promise<void> {
   const timestamp = nowIso();
@@ -442,7 +270,18 @@ export async function ensureLearningStore(env?: RuntimeBindings): Promise<void> 
         extractions: seedDemoAudioExtractions,
         pipelines: seedDemoLecturePipelines,
       });
-      await hydrateMemory(db);
+      await hydrateLearningStoreMemory(db, {
+        demoCourses,
+        demoLectures,
+        demoMaterials,
+        demoNotices,
+        demoEnrollments,
+        demoLectureProgress,
+        demoLectureTranscripts,
+        demoLectureNotes,
+        demoAudioExtractions,
+        demoLecturePipelines,
+      });
       await syncLectureDurationsFromMedia(db);
       learningStoreReady = true;
     })().catch((error) => {
@@ -502,7 +341,18 @@ export async function refreshLearningStoreFromDatabase(env?: RuntimeBindings): P
         extractions: seedDemoAudioExtractions,
         pipelines: seedDemoLecturePipelines,
       });
-      await hydrateMemory(db);
+      await hydrateLearningStoreMemory(db, {
+        demoCourses,
+        demoLectures,
+        demoMaterials,
+        demoNotices,
+        demoEnrollments,
+        demoLectureProgress,
+        demoLectureTranscripts,
+        demoLectureNotes,
+        demoAudioExtractions,
+        demoLecturePipelines,
+      });
       await syncLectureDurationsFromMedia(db);
       learningStoreReady = true;
     })().catch((error) => {


### PR DESCRIPTION
## Summary
- extract learning-store hydration/query-to-memory sync concerns into learning-store-hydrator.ts
- remove hydration helpers and row sync logic from learning-store.ts
- keep persistence and initialization flows unchanged while shrinking core file

## Verification
- npm run verify