### PR TITLE
refactor: split lecture watch and shortforms pages

### DIFF
--- a/frontend/src/features/lms/pages/LectureWatchPage.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPage.tsx
@@ -1,7 +1,8 @@
 import type { CourseCard, CourseDetail, LectureDetail } from '@myway/shared';
 import { StatePanel } from '../components/StatePanel';
 import { useLectureWatchPlayback } from './useLectureWatchPlayback';
-import { LectureWatchAside, LectureWatchHero, LectureWatchMain } from './LectureWatchPageSections';
+import { LectureWatchHero, LectureWatchMain } from './LectureWatchPageSections';
+import { LectureWatchAside } from './LectureWatchPageAside';
 import type { LectureWatchPanelTab } from './lectureWatchPageUtils';
 
 type LectureWatchPageProps = {

--- a/frontend/src/features/lms/pages/LectureWatchPageAside.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPageAside.tsx
@@ -1,0 +1,53 @@
+import type { CourseDetail, LectureDetail } from '@myway/shared';
+import type { RefObject } from 'react';
+import { CourseSessionTimeline } from '../components/CourseSessionTimeline';
+import { LectureSideChatPanel } from '../components/LectureSideChatPanel';
+import { StatePanel } from '../components/StatePanel';
+import { formatWatchTimecode, lectureWatchTabs, type LectureWatchPanelTab } from './lectureWatchPageUtils';
+
+type TranscriptView = {
+  duration_ms?: number;
+  segments?: Array<{ index: number; start_ms: number; end_ms: number; text: string }>;
+} | null;
+
+type NavigatePage = 'courses' | 'lecture-watch' | 'my-courses' | 'shortform' | 'ai-chat' | 'course-create' | 'lecture-studio' | 'media-pipeline';
+
+export function LectureWatchAside({
+  isLocked, selectedCourse, onEnroll, activePanelTab, setActivePanelTab, selectedLectureId, onSelectLecture, onNavigate,
+  transcriptLoading, transcript, seekVideoTo, highlightedLecture, sessionToken, handleSeekFromChat,
+}: {
+  isLocked: boolean;
+  selectedCourse: CourseDetail;
+  onEnroll: (courseId: string) => void;
+  activePanelTab: LectureWatchPanelTab;
+  setActivePanelTab: (tab: LectureWatchPanelTab) => void;
+  selectedLectureId: string;
+  onSelectLecture: (lectureId: string) => void;
+  onNavigate: (page: NavigatePage) => void;
+  transcriptLoading: boolean;
+  transcript: TranscriptView;
+  seekVideoTo: (startMs: number) => void;
+  highlightedLecture: LectureDetail | null;
+  sessionToken?: string | null;
+  handleSeekFromChat: (startMs: number) => void;
+}) {
+  return (
+    <aside className="overflow-hidden rounded-[30px] border border-[var(--app-border)] bg-white shadow-sm">
+      {isLocked ? (
+        <div className="p-5">
+          <StatePanel icon="ri-lock-line" tone="amber" title="수강 신청 후 시청 패널이 열립니다." description="차시 목록, 스크립트, 챗봇은 수강 신청이 완료된 뒤 사용할 수 있습니다." />
+          <button type="button" onClick={() => onEnroll(selectedCourse.id)} className="mt-4 w-full rounded-full bg-indigo-600 px-4 py-3 text-[12px] font-semibold text-white transition hover:bg-indigo-500">수강 신청하기</button>
+        </div>
+      ) : (
+        <>
+          <div className="border-b border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4"><div className="flex gap-2">{lectureWatchTabs.map((tab) => { const active = activePanelTab === tab.key; return <button key={tab.key} type="button" onClick={() => setActivePanelTab(tab.key)} className={`flex flex-1 items-center justify-center gap-2 rounded-2xl px-3 py-2.5 text-[12px] font-semibold transition ${active ? 'bg-indigo-600 text-white shadow-sm' : 'border border-[var(--app-border)] bg-[var(--app-surface-soft)] text-[var(--app-text-muted)] hover:text-[var(--app-text)]'}`}><i className={tab.icon} />{tab.label}</button>; })}</div></div>
+          <div className="p-4">
+            {activePanelTab === 'sessions' ? <div className="space-y-4"><div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4"><div className="text-[12px] font-semibold text-indigo-600">다음 차시 선택</div><div className="mt-1 text-[14px] font-bold text-[var(--app-text)]">현재 강의의 차시 목록을 바로 전환합니다.</div><p className="mt-2 text-[12px] leading-6 text-[var(--app-text-muted)]">원하는 주차를 눌러 선택하고, 이어서 영상 시청과 챗봇 질문으로 연결할 수 있습니다.</p></div><CourseSessionTimeline course={selectedCourse} selectedLectureId={selectedLectureId} onSelectLecture={onSelectLecture} onOpenLecture={(lectureId) => { onSelectLecture(lectureId); onNavigate('lecture-watch'); }} /></div> : null}
+            {activePanelTab === 'script' ? <div className="space-y-4"><div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4"><div className="text-[12px] font-semibold text-indigo-600">스크립트</div><div className="mt-1 text-[16px] font-bold text-[var(--app-text)]">타임스탬프 기준으로 바로 찾아볼 수 있습니다.</div><p className="mt-2 text-[12px] leading-6 text-[var(--app-text-muted)]">필요한 구간의 시작 시간을 누르면 영상이 해당 위치로 이동하고 재생을 시도합니다.</p></div>{transcriptLoading ? <StatePanel compact icon="ri-loader-4-line" tone="slate" title="스크립트를 불러오는 중입니다." description="전사 데이터를 가져오고 있습니다." /> : transcript?.segments?.length ? <div className="max-h-[560px] space-y-2 overflow-y-auto pr-1">{transcript.segments.map((segment) => <article key={segment.index} className="rounded-2xl border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4"><div className="flex items-start justify-between gap-3"><button type="button" onClick={() => seekVideoTo(segment.start_ms)} className="rounded-full bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white transition hover:bg-indigo-600">{formatWatchTimecode(segment.start_ms)} - {formatWatchTimecode(segment.end_ms)}</button><span className="text-[11px] font-semibold text-slate-400">#{segment.index + 1}</span></div><p className="mt-3 text-[13px] leading-7 text-[var(--app-text)]">{segment.text}</p></article>)}</div> : <StatePanel compact icon="ri-subtitle" tone="slate" title="스크립트가 아직 없습니다." description="전사 완료 후에 타임스탬프 기반 스크립트가 표시됩니다." />}</div> : null}
+            {activePanelTab === 'chat' ? <LectureSideChatPanel highlightedLecture={highlightedLecture} sessionToken={sessionToken} onSeekTimestamp={handleSeekFromChat} /> : null}
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/features/lms/pages/LectureWatchPageSections.tsx
+++ b/frontend/src/features/lms/pages/LectureWatchPageSections.tsx
@@ -1,9 +1,6 @@
 import type { CourseDetail, LectureDetail } from '@myway/shared';
 import type { RefObject } from 'react';
-import { CourseSessionTimeline } from '../components/CourseSessionTimeline';
-import { LectureSideChatPanel } from '../components/LectureSideChatPanel';
-import { StatePanel } from '../components/StatePanel';
-import { formatWatchDuration, formatWatchTimecode, lectureWatchTabs, type LectureWatchPanelTab } from './lectureWatchPageUtils';
+import { formatWatchDuration } from './lectureWatchPageUtils';
 
 type TranscriptView = {
   duration_ms?: number;
@@ -122,45 +119,5 @@ export function LectureWatchMain({
         </div>
       </div>
     </article>
-  );
-}
-
-export function LectureWatchAside({
-  isLocked, selectedCourse, onEnroll, activePanelTab, setActivePanelTab, selectedLectureId, onSelectLecture, onNavigate,
-  transcriptLoading, transcript, seekVideoTo, highlightedLecture, sessionToken, handleSeekFromChat,
-}: {
-  isLocked: boolean;
-  selectedCourse: CourseDetail;
-  onEnroll: (courseId: string) => void;
-  activePanelTab: LectureWatchPanelTab;
-  setActivePanelTab: (tab: LectureWatchPanelTab) => void;
-  selectedLectureId: string;
-  onSelectLecture: (lectureId: string) => void;
-  onNavigate: (page: NavigatePage) => void;
-  transcriptLoading: boolean;
-  transcript: TranscriptView;
-  seekVideoTo: (startMs: number) => void;
-  highlightedLecture: LectureDetail | null;
-  sessionToken?: string | null;
-  handleSeekFromChat: (startMs: number) => void;
-}) {
-  return (
-    <aside className="overflow-hidden rounded-[30px] border border-[var(--app-border)] bg-white shadow-sm">
-      {isLocked ? (
-        <div className="p-5">
-          <StatePanel icon="ri-lock-line" tone="amber" title="수강 신청 후 시청 패널이 열립니다." description="차시 목록, 스크립트, 챗봇은 수강 신청이 완료된 뒤 사용할 수 있습니다." />
-          <button type="button" onClick={() => onEnroll(selectedCourse.id)} className="mt-4 w-full rounded-full bg-indigo-600 px-4 py-3 text-[12px] font-semibold text-white transition hover:bg-indigo-500">수강 신청하기</button>
-        </div>
-      ) : (
-        <>
-          <div className="border-b border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4"><div className="flex gap-2">{lectureWatchTabs.map((tab) => { const active = activePanelTab === tab.key; return <button key={tab.key} type="button" onClick={() => setActivePanelTab(tab.key)} className={`flex flex-1 items-center justify-center gap-2 rounded-2xl px-3 py-2.5 text-[12px] font-semibold transition ${active ? 'bg-indigo-600 text-white shadow-sm' : 'border border-[var(--app-border)] bg-[var(--app-surface-soft)] text-[var(--app-text-muted)] hover:text-[var(--app-text)]'}`}><i className={tab.icon} />{tab.label}</button>; })}</div></div>
-          <div className="p-4">
-            {activePanelTab === 'sessions' ? <div className="space-y-4"><div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4"><div className="text-[12px] font-semibold text-indigo-600">다음 차시 선택</div><div className="mt-1 text-[14px] font-bold text-[var(--app-text)]">현재 강의의 차시 목록을 바로 전환합니다.</div><p className="mt-2 text-[12px] leading-6 text-[var(--app-text-muted)]">원하는 주차를 눌러 선택하고, 이어서 영상 시청과 챗봇 질문으로 연결할 수 있습니다.</p></div><CourseSessionTimeline course={selectedCourse} selectedLectureId={selectedLectureId} onSelectLecture={onSelectLecture} onOpenLecture={(lectureId) => { onSelectLecture(lectureId); onNavigate('lecture-watch'); }} /></div> : null}
-            {activePanelTab === 'script' ? <div className="space-y-4"><div className="rounded-[22px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4"><div className="text-[12px] font-semibold text-indigo-600">스크립트</div><div className="mt-1 text-[16px] font-bold text-[var(--app-text)]">타임스탬프 기준으로 바로 찾아볼 수 있습니다.</div><p className="mt-2 text-[12px] leading-6 text-[var(--app-text-muted)]">필요한 구간의 시작 시간을 누르면 영상이 해당 위치로 이동하고 재생을 시도합니다.</p></div>{transcriptLoading ? <StatePanel compact icon="ri-loader-4-line" tone="slate" title="스크립트를 불러오는 중입니다." description="전사 데이터를 가져오고 있습니다." /> : transcript?.segments?.length ? <div className="max-h-[560px] space-y-2 overflow-y-auto pr-1">{transcript.segments.map((segment) => <article key={segment.index} className="rounded-2xl border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4"><div className="flex items-start justify-between gap-3"><button type="button" onClick={() => seekVideoTo(segment.start_ms)} className="rounded-full bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white transition hover:bg-indigo-600">{formatWatchTimecode(segment.start_ms)} - {formatWatchTimecode(segment.end_ms)}</button><span className="text-[11px] font-semibold text-slate-400">#{segment.index + 1}</span></div><p className="mt-3 text-[13px] leading-7 text-[var(--app-text)]">{segment.text}</p></article>)}</div> : <StatePanel compact icon="ri-subtitle" tone="slate" title="스크립트가 아직 없습니다." description="전사 완료 후에 타임스탬프 기반 스크립트가 표시됩니다." />}</div> : null}
-            {activePanelTab === 'chat' ? <LectureSideChatPanel highlightedLecture={highlightedLecture} sessionToken={sessionToken} onSeekTimestamp={handleSeekFromChat} /> : null}
-          </div>
-        </>
-      )}
-    </aside>
   );
 }

--- a/frontend/src/features/lms/pages/MyShortformsPage.tsx
+++ b/frontend/src/features/lms/pages/MyShortformsPage.tsx
@@ -1,16 +1,12 @@
-﻿import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CourseCard, CourseDetail, CustomCourseLibraryItem, ShortformLibraryItem } from '@myway/shared';
 import {
-  copyCustomCourseDraft,
-  loadCustomCourseLibrary,
-  loadShortformLibrary,
-  retryShortformExportDraft,
-  saveShortformDraft,
-  shareCustomCourseDraft,
-  shareShortformDraft,
-  toggleShortformLikeDraft,
-} from '../../../lib/api';
-import { resolvePlayableVideoUrl } from '../../../lib/video-url';
+  MyShortformsControls,
+  MyShortformsHero,
+  MyShortformsList,
+  MyShortformsMetrics,
+} from './MyShortformsPageSections';
+import { useMyShortformsPageActions } from './useMyShortformsPageActions';
 
 type MyShortformsPageProps = {
   courses: CourseCard[];
@@ -20,17 +16,6 @@ type MyShortformsPageProps = {
 
 type LibraryTab = 'videos' | 'courses';
 
-function badgeClass(ownership: string): string {
-  return ownership === 'owned' ? 'bg-cyan-100 text-cyan-700' : 'bg-amber-100 text-amber-700';
-}
-
-function exportBadgeClass(status: string): string {
-  if (status === 'COMPLETED') return 'bg-emerald-100 text-emerald-700';
-  if (status === 'FAILED') return 'bg-rose-100 text-rose-700';
-  if (status === 'PROCESSING') return 'bg-amber-100 text-amber-700';
-  return 'bg-slate-100 text-slate-500';
-}
-
 export function MyShortformsPage({ courses, selectedCourse, sessionToken }: MyShortformsPageProps) {
   const [customCourses, setCustomCourses] = useState<CustomCourseLibraryItem[]>([]);
   const [shortformLibrary, setShortformLibrary] = useState<ShortformLibraryItem[]>([]);
@@ -38,58 +23,25 @@ export function MyShortformsPage({ courses, selectedCourse, sessionToken }: MySh
   const [query, setQuery] = useState('');
   const [tab, setTab] = useState<LibraryTab>('videos');
 
-  async function refreshLibrary() {
-    const [customCourseData, shortformData] = await Promise.all([
-      loadCustomCourseLibrary(sessionToken),
-      loadShortformLibrary(sessionToken),
-    ]);
-
-    setCustomCourses(customCourseData);
-    setShortformLibrary(shortformData);
-    setStatus('라이브러리가 최신 상태입니다.');
-  }
+  const {
+    refreshLibrary,
+    handleShareCourse,
+    handleCopyCourse,
+    handleShareShortform,
+    handleSaveShortform,
+    handleLikeShortform,
+    handleRetryExport,
+  } = useMyShortformsPageActions({
+    sessionToken,
+    setCustomCourses,
+    setShortformLibrary,
+    setStatus,
+  });
 
   useEffect(() => {
     void refreshLibrary();
-  }, [sessionToken]);
+  }, [refreshLibrary]);
 
-  async function handleShareCourse(courseId: string) {
-    const ok = await shareCustomCourseDraft(courseId, { message: '공유 가능한 개인 코스입니다.' }, sessionToken);
-    setStatus(ok ? '개인 코스를 공유했습니다.' : '개인 코스 공유에 실패했습니다.');
-    await refreshLibrary();
-  }
-
-  async function handleCopyCourse(courseId: string) {
-    const copied = await copyCustomCourseDraft(courseId, { custom_course_id: courseId }, sessionToken);
-    setStatus(copied ? '개인 코스를 복사했습니다.' : '복사에 실패했습니다.');
-    await refreshLibrary();
-  }
-
-  async function handleShareShortform(videoId: string, courseId: string) {
-    const ok = await shareShortformDraft({ video_id: videoId, course_id: courseId, message: '학습용 숏폼을 공유합니다.' }, sessionToken);
-    setStatus(ok ? '숏폼을 공유했습니다.' : '숏폼 공유에 실패했습니다.');
-    await refreshLibrary();
-  }
-
-  async function handleSaveShortform(videoId: string) {
-    const ok = await saveShortformDraft({ video_id: videoId, folder: 'library', note: '학습 라이브러리 저장' }, sessionToken);
-    setStatus(ok ? '숏폼을 라이브러리에 저장했습니다.' : '저장에 실패했습니다.');
-    await refreshLibrary();
-  }
-
-  async function handleLikeShortform(videoId: string) {
-    const ok = await toggleShortformLikeDraft(videoId, sessionToken);
-    setStatus(ok ? '좋아요 상태를 반영했습니다.' : '좋아요 처리에 실패했습니다.');
-    await refreshLibrary();
-  }
-
-  async function handleRetryExport(videoId: string) {
-    const ok = await retryShortformExportDraft(videoId, sessionToken);
-    setStatus(ok ? '숏폼 export를 다시 시작했습니다.' : '숏폼 export 재시도에 실패했습니다.');
-    await refreshLibrary();
-  }
-
-  const ownedCourses = customCourses.filter((course) => course.ownership === 'owned');
   const copiedCourses = customCourses.filter((course) => course.ownership === 'copied');
   const ownedVideos = shortformLibrary.filter((video) => video.ownership === 'owned');
   const savedVideos = shortformLibrary.filter((video) => video.ownership === 'saved');
@@ -112,114 +64,33 @@ export function MyShortformsPage({ courses, selectedCourse, sessionToken }: MySh
 
   return (
     <div className="space-y-5">
-      <section className="overflow-hidden rounded-3xl border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-5 py-5 text-white">
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <h2 className="text-[20px] font-extrabold tracking-[-0.03em]">내 숏폼 라이브러리</h2>
-            <p className="mt-2 text-[12px] leading-6 text-cyan-50/85">내 숏폼, 저장 숏폼, 개인 코스를 검색/관리하고 바로 공유할 수 있습니다.</p>
-            <div className="mt-2 text-[11px] text-cyan-100/80">{selectedCourse?.title ?? courses[0]?.title ?? '전체 강의'}</div>
-          </div>
-          <div className="rounded-xl border border-cyan-100/25 bg-white/10 px-4 py-3 text-[12px] text-cyan-50/90">
-            <div>내 숏폼 {ownedVideos.length}개 · 저장 {savedVideos.length}개</div>
-            <div className="mt-1">개인 코스 {customCourses.length}개</div>
-          </div>
-        </div>
-      </section>
+      <MyShortformsHero
+        selectedTitle={selectedCourse?.title ?? courses[0]?.title ?? '전체 강의'}
+        ownedVideosCount={ownedVideos.length}
+        savedVideosCount={savedVideos.length}
+        customCoursesCount={customCourses.length}
+      />
 
-      <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-        <div className="grid gap-3 lg:grid-cols-[1fr_auto] lg:items-end">
-          <label className="block">
-            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="숏폼 제목, 설명, 코스 ID 검색"
-              className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] outline-none focus:border-cyan-300"
-            />
-          </label>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setTab('videos')}
-              className={`rounded-full px-4 py-2 text-[12px] font-semibold ${tab === 'videos' ? 'bg-cyan-600 text-white' : 'border border-slate-200 text-slate-600'}`}
-            >
-              숏폼
-            </button>
-            <button
-              type="button"
-              onClick={() => setTab('courses')}
-              className={`rounded-full px-4 py-2 text-[12px] font-semibold ${tab === 'courses' ? 'bg-cyan-600 text-white' : 'border border-slate-200 text-slate-600'}`}
-            >
-              개인 코스
-            </button>
-          </div>
-        </div>
-        <p className="mt-3 text-[12px] text-slate-500">{status}</p>
-      </section>
+      <MyShortformsControls query={query} onQueryChange={setQuery} tab={tab} onTabChange={setTab} status={status} />
 
-      <section className="grid grid-cols-1 gap-4 md:grid-cols-4">
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{customCourses.length}</div><div className="mt-1 text-[12px] text-slate-500">개인 코스</div></article>
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{ownedVideos.length}</div><div className="mt-1 text-[12px] text-slate-500">내 숏폼</div></article>
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{savedVideos.length}</div><div className="mt-1 text-[12px] text-slate-500">저장 숏폼</div></article>
-        <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{copiedCourses.length}</div><div className="mt-1 text-[12px] text-slate-500">복사 코스</div></article>
-      </section>
+      <MyShortformsMetrics
+        customCoursesCount={customCourses.length}
+        ownedVideosCount={ownedVideos.length}
+        savedVideosCount={savedVideos.length}
+        copiedCoursesCount={copiedCourses.length}
+      />
 
-      {tab === 'videos' ? (
-        <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <h3 className="text-[15px] font-bold text-slate-900">숏폼 라이브러리</h3>
-          <div className="mt-4 space-y-3">
-            {filteredVideos.length > 0 ? (
-              filteredVideos.map((video) => {
-                const playable = resolvePlayableVideoUrl(video.export_result_url ?? undefined) ?? (video.video_url && !video.video_url.startsWith('/static/shortforms/') ? resolvePlayableVideoUrl(video.video_url) : null);
-                return (
-                  <div key={video.id} className="rounded-2xl border border-slate-200 px-4 py-4">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClass(video.ownership)}`}>{video.ownership}</span>
-                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${exportBadgeClass(video.export_status)}`}>export {video.export_status}</span>
-                      <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">{video.total_segments} 세그먼트</span>
-                    </div>
-                    <div className="mt-2 text-[14px] font-bold text-slate-900">{video.title}</div>
-                    <p className="mt-1 text-[12px] leading-6 text-slate-500">{video.description}</p>
-                    {playable ? <video className="mt-3 w-full rounded-2xl border border-slate-200 bg-black" controls preload="metadata" src={playable ?? undefined} /> : null}
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      <button type="button" onClick={() => void handleSaveShortform(video.id)} className="rounded-full bg-emerald-600 px-3 py-1.5 text-[11px] font-semibold text-white">저장</button>
-                      <button type="button" onClick={() => void handleLikeShortform(video.id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">좋아요</button>
-                      <button type="button" onClick={() => void handleShareShortform(video.id, video.course_id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">공유</button>
-                      {video.export_status === 'FAILED' ? <button type="button" onClick={() => void handleRetryExport(video.id)} className="rounded-full border border-rose-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-rose-600">export 재시도</button> : null}
-                    </div>
-                  </div>
-                );
-              })
-            ) : (
-              <p className="text-[13px] leading-6 text-slate-500">숏폼 라이브러리가 아직 없습니다.</p>
-            )}
-          </div>
-        </section>
-      ) : (
-        <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
-          <h3 className="text-[15px] font-bold text-slate-900">개인 코스 라이브러리</h3>
-          <div className="mt-4 space-y-3">
-            {filteredCourses.length > 0 ? (
-              filteredCourses.map((course) => (
-                <div key={course.id} className="rounded-2xl border border-slate-200 px-4 py-4">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClass(course.ownership)}`}>{course.ownership}</span>
-                    <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">{course.clip_count} 클립</span>
-                  </div>
-                  <div className="mt-2 text-[14px] font-bold text-slate-900">{course.title}</div>
-                  <p className="mt-1 text-[12px] leading-6 text-slate-500">{course.description}</p>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <button type="button" onClick={() => void handleShareCourse(course.id)} className="rounded-full bg-cyan-600 px-3 py-1.5 text-[11px] font-semibold text-white">공유</button>
-                    <button type="button" onClick={() => void handleCopyCourse(course.id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">복사</button>
-                  </div>
-                </div>
-              ))
-            ) : (
-              <p className="text-[13px] leading-6 text-slate-500">개인 코스가 아직 없습니다.</p>
-            )}
-          </div>
-        </section>
-      )}
+      <MyShortformsList
+        tab={tab}
+        filteredVideos={filteredVideos}
+        filteredCourses={filteredCourses}
+        onSaveShortform={handleSaveShortform}
+        onLikeShortform={handleLikeShortform}
+        onShareShortform={handleShareShortform}
+        onRetryExport={handleRetryExport}
+        onShareCourse={handleShareCourse}
+        onCopyCourse={handleCopyCourse}
+      />
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/MyShortformsPageSections.tsx
+++ b/frontend/src/features/lms/pages/MyShortformsPageSections.tsx
@@ -1,0 +1,179 @@
+import { resolvePlayableVideoUrl } from '../../../lib/video-url';
+
+function badgeClass(ownership: string): string {
+  return ownership === 'owned' ? 'bg-cyan-100 text-cyan-700' : 'bg-amber-100 text-amber-700';
+}
+
+function exportBadgeClass(status: string): string {
+  if (status === 'COMPLETED') return 'bg-emerald-100 text-emerald-700';
+  if (status === 'FAILED') return 'bg-rose-100 text-rose-700';
+  if (status === 'PROCESSING') return 'bg-amber-100 text-amber-700';
+  return 'bg-slate-100 text-slate-500';
+}
+
+export function MyShortformsHero({
+  selectedTitle,
+  ownedVideosCount,
+  savedVideosCount,
+  customCoursesCount,
+}: {
+  selectedTitle: string;
+  ownedVideosCount: number;
+  savedVideosCount: number;
+  customCoursesCount: number;
+}) {
+  return (
+    <section className="overflow-hidden rounded-3xl border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-5 py-5 text-white">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h2 className="text-[20px] font-extrabold tracking-[-0.03em]">내 숏폼 라이브러리</h2>
+          <p className="mt-2 text-[12px] leading-6 text-cyan-50/85">내 숏폼, 저장 숏폼, 개인 코스를 검색/관리하고 바로 공유할 수 있습니다.</p>
+          <div className="mt-2 text-[11px] text-cyan-100/80">{selectedTitle}</div>
+        </div>
+        <div className="rounded-xl border border-cyan-100/25 bg-white/10 px-4 py-3 text-[12px] text-cyan-50/90">
+          <div>내 숏폼 {ownedVideosCount}개 · 저장 {savedVideosCount}개</div>
+          <div className="mt-1">개인 코스 {customCoursesCount}개</div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function MyShortformsControls({
+  query,
+  onQueryChange,
+  tab,
+  onTabChange,
+  status,
+}: {
+  query: string;
+  onQueryChange: (value: string) => void;
+  tab: 'videos' | 'courses';
+  onTabChange: (value: 'videos' | 'courses') => void;
+  status: string;
+}) {
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+      <div className="grid gap-3 lg:grid-cols-[1fr_auto] lg:items-end">
+        <label className="block">
+          <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
+          <input
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="숏폼 제목, 설명, 코스 ID 검색"
+            className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] outline-none focus:border-cyan-300"
+          />
+        </label>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={() => onTabChange('videos')} className={`rounded-full px-4 py-2 text-[12px] font-semibold ${tab === 'videos' ? 'bg-cyan-600 text-white' : 'border border-slate-200 text-slate-600'}`}>
+            숏폼
+          </button>
+          <button type="button" onClick={() => onTabChange('courses')} className={`rounded-full px-4 py-2 text-[12px] font-semibold ${tab === 'courses' ? 'bg-cyan-600 text-white' : 'border border-slate-200 text-slate-600'}`}>
+            개인 코스
+          </button>
+        </div>
+      </div>
+      <p className="mt-3 text-[12px] text-slate-500">{status}</p>
+    </section>
+  );
+}
+
+export function MyShortformsMetrics({
+  customCoursesCount,
+  ownedVideosCount,
+  savedVideosCount,
+  copiedCoursesCount,
+}: {
+  customCoursesCount: number;
+  ownedVideosCount: number;
+  savedVideosCount: number;
+  copiedCoursesCount: number;
+}) {
+  return (
+    <section className="grid grid-cols-1 gap-4 md:grid-cols-4">
+      <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{customCoursesCount}</div><div className="mt-1 text-[12px] text-slate-500">개인 코스</div></article>
+      <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{ownedVideosCount}</div><div className="mt-1 text-[12px] text-slate-500">내 숏폼</div></article>
+      <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{savedVideosCount}</div><div className="mt-1 text-[12px] text-slate-500">저장 숏폼</div></article>
+      <article className="rounded-3xl border border-slate-200 bg-white px-5 py-5"><div className="text-[28px] font-extrabold tracking-[-0.03em] text-slate-900">{copiedCoursesCount}</div><div className="mt-1 text-[12px] text-slate-500">복사 코스</div></article>
+    </section>
+  );
+}
+
+export function MyShortformsList({
+  tab,
+  filteredVideos,
+  filteredCourses,
+  onSaveShortform,
+  onLikeShortform,
+  onShareShortform,
+  onRetryExport,
+  onShareCourse,
+  onCopyCourse,
+}: {
+  tab: 'videos' | 'courses';
+  filteredVideos: Array<{ id: string; ownership: string; export_status: string; total_segments: number; title: string; description: string; video_url?: string | null; export_result_url?: string | null; course_id: string }>;
+  filteredCourses: Array<{ id: string; ownership: string; clip_count: number; title: string; description: string }>;
+  onSaveShortform: (videoId: string) => void;
+  onLikeShortform: (videoId: string) => void;
+  onShareShortform: (videoId: string, courseId: string) => void;
+  onRetryExport: (videoId: string) => void;
+  onShareCourse: (courseId: string) => void;
+  onCopyCourse: (courseId: string) => void;
+}) {
+  return tab === 'videos' ? (
+    <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+      <h3 className="text-[15px] font-bold text-slate-900">숏폼 라이브러리</h3>
+      <div className="mt-4 space-y-3">
+        {filteredVideos.length > 0 ? (
+          filteredVideos.map((video) => {
+            const playable = resolvePlayableVideoUrl(video.export_result_url ?? undefined) ?? (video.video_url && !video.video_url.startsWith('/static/shortforms/') ? resolvePlayableVideoUrl(video.video_url) : null);
+            return (
+              <div key={video.id} className="rounded-2xl border border-slate-200 px-4 py-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClass(video.ownership)}`}>{video.ownership}</span>
+                  <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${exportBadgeClass(video.export_status)}`}>export {video.export_status}</span>
+                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">{video.total_segments} 세그먼트</span>
+                </div>
+                <div className="mt-2 text-[14px] font-bold text-slate-900">{video.title}</div>
+                <p className="mt-1 text-[12px] leading-6 text-slate-500">{video.description}</p>
+                {playable ? <video className="mt-3 w-full rounded-2xl border border-slate-200 bg-black" controls preload="metadata" src={playable ?? undefined} /> : null}
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button type="button" onClick={() => onSaveShortform(video.id)} className="rounded-full bg-emerald-600 px-3 py-1.5 text-[11px] font-semibold text-white">저장</button>
+                  <button type="button" onClick={() => onLikeShortform(video.id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">좋아요</button>
+                  <button type="button" onClick={() => onShareShortform(video.id, video.course_id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">공유</button>
+                  {video.export_status === 'FAILED' ? <button type="button" onClick={() => onRetryExport(video.id)} className="rounded-full border border-rose-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-rose-600">export 재시도</button> : null}
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <p className="text-[13px] leading-6 text-slate-500">숏폼 라이브러리가 아직 없습니다.</p>
+        )}
+      </div>
+    </section>
+  ) : (
+    <section className="rounded-3xl border border-slate-200 bg-white px-5 py-5">
+      <h3 className="text-[15px] font-bold text-slate-900">개인 코스 라이브러리</h3>
+      <div className="mt-4 space-y-3">
+        {filteredCourses.length > 0 ? (
+          filteredCourses.map((course) => (
+            <div key={course.id} className="rounded-2xl border border-slate-200 px-4 py-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClass(course.ownership)}`}>{course.ownership}</span>
+                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-500">{course.clip_count} 클립</span>
+              </div>
+              <div className="mt-2 text-[14px] font-bold text-slate-900">{course.title}</div>
+              <p className="mt-1 text-[12px] leading-6 text-slate-500">{course.description}</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button type="button" onClick={() => onShareCourse(course.id)} className="rounded-full bg-cyan-600 px-3 py-1.5 text-[11px] font-semibold text-white">공유</button>
+                <button type="button" onClick={() => onCopyCourse(course.id)} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-600">복사</button>
+              </div>
+            </div>
+          ))
+        ) : (
+          <p className="text-[13px] leading-6 text-slate-500">개인 코스가 아직 없습니다.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/lms/pages/useMyShortformsPageActions.ts
+++ b/frontend/src/features/lms/pages/useMyShortformsPageActions.ts
@@ -1,0 +1,84 @@
+import { useCallback } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { CustomCourseLibraryItem, ShortformLibraryItem } from '@myway/shared';
+import {
+  copyCustomCourseDraft,
+  loadCustomCourseLibrary,
+  loadShortformLibrary,
+  retryShortformExportDraft,
+  saveShortformDraft,
+  shareCustomCourseDraft,
+  shareShortformDraft,
+  toggleShortformLikeDraft,
+} from '../../../lib/api';
+
+type UseMyShortformsPageActionsParams = {
+  sessionToken: string | null;
+  setCustomCourses: Dispatch<SetStateAction<CustomCourseLibraryItem[]>>;
+  setShortformLibrary: Dispatch<SetStateAction<ShortformLibraryItem[]>>;
+  setStatus: (value: string) => void;
+};
+
+export function useMyShortformsPageActions({
+  sessionToken,
+  setCustomCourses,
+  setShortformLibrary,
+  setStatus,
+}: UseMyShortformsPageActionsParams) {
+  const refreshLibrary = useCallback(async () => {
+    const [customCourseData, shortformData] = await Promise.all([
+      loadCustomCourseLibrary(sessionToken),
+      loadShortformLibrary(sessionToken),
+    ]);
+
+    setCustomCourses(customCourseData);
+    setShortformLibrary(shortformData);
+    setStatus('라이브러리가 최신 상태입니다.');
+  }, [sessionToken, setCustomCourses, setShortformLibrary, setStatus]);
+
+  const handleShareCourse = useCallback(async (courseId: string) => {
+    const ok = await shareCustomCourseDraft(courseId, { message: '공유 가능한 개인 코스입니다.' }, sessionToken);
+    setStatus(ok ? '개인 코스를 공유했습니다.' : '개인 코스 공유에 실패했습니다.');
+    await refreshLibrary();
+  }, [refreshLibrary, sessionToken, setStatus]);
+
+  const handleCopyCourse = useCallback(async (courseId: string) => {
+    const copied = await copyCustomCourseDraft(courseId, { custom_course_id: courseId }, sessionToken);
+    setStatus(copied ? '개인 코스를 복사했습니다.' : '복사에 실패했습니다.');
+    await refreshLibrary();
+  }, [refreshLibrary, sessionToken, setStatus]);
+
+  const handleShareShortform = useCallback(async (videoId: string, courseId: string) => {
+    const ok = await shareShortformDraft({ video_id: videoId, course_id: courseId, message: '학습용 숏폼을 공유합니다.' }, sessionToken);
+    setStatus(ok ? '숏폼을 공유했습니다.' : '숏폼 공유에 실패했습니다.');
+    await refreshLibrary();
+  }, [refreshLibrary, sessionToken, setStatus]);
+
+  const handleSaveShortform = useCallback(async (videoId: string) => {
+    const ok = await saveShortformDraft({ video_id: videoId, folder: 'library', note: '학습 라이브러리 저장' }, sessionToken);
+    setStatus(ok ? '숏폼을 라이브러리에 저장했습니다.' : '저장에 실패했습니다.');
+    await refreshLibrary();
+  }, [refreshLibrary, sessionToken, setStatus]);
+
+  const handleLikeShortform = useCallback(async (videoId: string) => {
+    const ok = await toggleShortformLikeDraft(videoId, sessionToken);
+    setStatus(ok ? '좋아요 상태를 반영했습니다.' : '좋아요 처리에 실패했습니다.');
+    await refreshLibrary();
+  }, [refreshLibrary, sessionToken, setStatus]);
+
+  const handleRetryExport = useCallback(async (videoId: string) => {
+    const ok = await retryShortformExportDraft(videoId, sessionToken);
+    setStatus(ok ? '숏폼 export를 다시 시작했습니다.' : '숏폼 export 재시도에 실패했습니다.');
+    await refreshLibrary();
+  }, [refreshLibrary, sessionToken, setStatus]);
+
+  return {
+    refreshLibrary,
+    handleShareCourse,
+    handleCopyCourse,
+    handleShareShortform,
+    handleSaveShortform,
+    handleLikeShortform,
+    handleRetryExport,
+  };
+}


### PR DESCRIPTION
# 변경 요약
`LectureWatchPage`와 `MyShortformsPage`의 큰 UI/액션 블록을 분리해서 페이지 본체를 얇게 만들었습니다.

## 배경
두 페이지 모두 렌더/상태/액션/리스트가 한 파일에 섞여 있어 변경 범위가 커질수록 유지보수가 어려웠습니다.

## 변경 내용
- `LectureWatchPage`의 aside 패널을 별도 파일로 분리
- `LectureWatchPageSections`를 hero/main 중심으로 정리
- `MyShortformsPage`의 액션을 훅으로 분리
- `MyShortformsPage`의 hero/controls/metrics/list를 별도 섹션으로 분리

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run verify` 통과
- layer tests: `npm run test:backend` 포함, frontend build 포함
- risk/rollback: 페이지 섹션/액션 분리만 수행. 문제 시 새 파일들을 되돌리고 원래 페이지 구조로 복원 가능

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: `Proposed -> Accepted` 또는 `Accepted -> Superseded` (해당 시 기입)
