### PR TITLE
refactor: split major frontend pages into sections

### DIFF
--- a/docs/dev-logs/2026-06-03-frontend-page-split-bundle.md
+++ b/docs/dev-logs/2026-06-03-frontend-page-split-bundle.md
@@ -1,0 +1,60 @@
+# 2026-06-03 Frontend Page Split Bundle
+
+## 변경 요약
+- `LectureStudioPage`, `AIChatPage`, `InstructorDashboardPage`, `AdminDashboardPage`의 조립 책임을 분리했다.
+- 각 페이지의 hero/summary/content 섹션을 별도 컴포넌트로 추출했다.
+
+## 배경
+- 프론트 페이지가 200줄을 넘기 시작해 상태 조립과 렌더링 책임이 섞이고 있었다.
+- 동일한 페이지 내부에서 hero, dashboard summary, conversation, workspace가 섞여 있어 변경 영향 범위가 넓었다.
+
+## 변경 내용
+- `LectureStudioPage`는 hero와 workspace를 분리해 상태 오케스트레이션만 남겼다.
+- `AIChatPage`는 hero와 대화/사이드바 영역을 분리했다.
+- `InstructorDashboardPage`와 `AdminDashboardPage`는 공통 hero 섹션을 분리하고, 강사 도구 섹션도 별도 컴포넌트로 이동했다.
+- 각 페이지의 본문은 데이터 조립과 이벤트 전달만 담당하도록 정리했다.
+
+## 연결 이슈
+- Closes #
+- Fixes #
+
+## 검증
+- [x] 로컬 확인 완료
+- [x] 문서 갱신 완료
+- [x] 영향 범위 점검 완료
+- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)
+
+## 코드리뷰
+- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
+- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
+- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
+- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
+- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
+- [x] 리뷰 시 확인해야 할 포인트를 적었다
+- [ ] PR 본문에 연결 이슈 번호가 들어갔다
+
+## 체크 사항
+- [x] 범위가 MoSCoW 기준에 맞는다
+- [x] 관련 문서가 함께 갱신됐다
+- [x] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
+- [x] `docs/dev-logs/`에 변경 요약을 남겼다
+- [x] 불필요한 리팩터링이 없다
+
+## QA Gates (docs/architecture/qa-gates.md)
+- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
+- [x] 신규 `Map<String,Object>` 경계 도입 없음
+- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
+- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
+- [x] 이벤트 메타/멱등 규칙 준수
+- [x] Query key 중앙화 및 invalidate 대상 명시
+- [x] 예외 규칙 사용 시 ADR 링크 첨부
+- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)
+
+## 검증 로그 요약
+- verify: `npm run verify` 통과
+- layer tests: `npm run test:backend` 통과
+- risk/rollback: 페이지 섹션 파일과 import만 추가/이동했으며, 롤백은 새 섹션 파일 제거와 원본 JSX 복원으로 가능
+
+## ADR 링크
+- ADR: `docs/decisions/ADR-xxxx-*.md`
+- 상태 변경: `Proposed -> Accepted` 또는 `Accepted -> Superseded` (해당 시 기입)

--- a/frontend/src/features/lms/pages/AIChatPage.tsx
+++ b/frontend/src/features/lms/pages/AIChatPage.tsx
@@ -3,11 +3,8 @@ import type { AIRagResult, AIInsights, LectureDetail, SmartChatResult } from '@m
 import { loadAIRAGOverview } from '../../../lib/ai-rag';
 import { sendSmartChatDetailed } from '../../../lib/api';
 import { getAiErrorMessage, getPublicTestPolicyText, getQuotaStatusText } from '../../../lib/ai-access';
-import { AIChatComposer } from '../components/AIChatComposer';
-import { AiNoticeBanner } from '../components/AiNoticeBanner';
-import { AIChatSidebar } from '../components/AIChatSidebar';
-import { AIChatThread, type AIChatMessage } from '../components/AIChatThread';
-import { StatePanel } from '../components/StatePanel';
+import { type AIChatMessage } from '../components/AIChatThread';
+import { AIChatPageConversation, AIChatPageHero } from './AIChatPageSections';
 
 type AIChatPageProps = {
   highlightedLecture: LectureDetail | null;
@@ -153,98 +150,34 @@ export function AIChatPage({ highlightedLecture, insights, selectedCourse, canMa
 
   return (
     <div className="space-y-5">
-      {isLocked ? (
-        <StatePanel
-          icon="ri-lock-line"
-          tone="amber"
-          title="수강 신청 후 AI 챗봇을 사용할 수 있습니다."
-          description="강의 내용 검색과 질문 응답은 수강 신청한 강의에서만 열립니다."
-        />
-      ) : null}
+      <AIChatPageHero
+        highlightedLecture={highlightedLecture}
+        isLocked={isLocked}
+        onToggleSidebar={() => setSidebarOpen((current) => !current)}
+      />
 
-      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#03162a_0%,#004e7d_42%,#00a7c8_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(5,44,74,0.25)] lg:px-8">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <span className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">AI 학습 챗</span>
-            <h1 className="mt-3 text-[26px] font-extrabold tracking-[-0.05em] lg:text-[32px]">질문에 맞는 답을 바로 받을 수 있는 챗봇 화면입니다.</h1>
-            <p className="mt-2 text-[13px] leading-6 text-white/78">
-              {isLocked
-                ? '수강 신청 후에 강의 내용 검색과 질문을 이어갈 수 있습니다.'
-                : highlightedLecture
-                  ? `${highlightedLecture.title} 기준으로 질문을 이어갈 수 있습니다.`
-                  : '강의 기반 질문과 복습을 위한 채팅 화면입니다.'}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setSidebarOpen((current) => !current)}
-            className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-[12px] font-semibold text-white lg:hidden"
-          >
-            <i className="ri-layout-right-line mr-1" />
-            도우미 패널
-          </button>
-        </div>
-      </section>
-
-      {!isLocked ? <AiNoticeBanner title={bannerTitle} description={bannerDescription} tone="indigo" meta={bannerMeta} /> : null}
-
-      {!isLocked ? (
-        <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
-        <section className="overflow-hidden rounded-[30px] border border-[var(--app-border)] bg-white shadow-sm">
-          <div className="flex items-center justify-between border-b border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-4">
-            <div>
-              <h2 className="text-[15px] font-bold text-[var(--app-text)]">대화</h2>
-              <p className="mt-1 text-[12px] text-[var(--app-text-muted)]">
-                질문, 요약, 퀴즈, 복습 순서로 이어가면 레퍼런스처럼 흐름이 안정적입니다.
-              </p>
-            </div>
-            <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
-              {messages.length}개 메시지
-            </span>
-          </div>
-
-          <div className="min-h-[400px] space-y-4 px-5 py-5">
-            <AIChatThread messages={messages} loading={sending} />
-
-            {ragOverview ? (
-              <div className="rounded-[28px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <div className="text-[12px] font-semibold text-[var(--app-text-muted)]">RAG 파이프라인</div>
-                    <div className="mt-1 text-[14px] font-bold text-[var(--app-text)]">{ragOverview.query}</div>
-                  </div>
-                  <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-[11px] font-semibold text-cyan-700">
-                    {ragOverview.provider.search_provider}
-                  </span>
-                </div>
-                <p className="mt-3 text-[12px] leading-5 text-[var(--app-text-secondary)]">{ragOverview.answer.answer}</p>
-              </div>
-            ) : null}
-          </div>
-
-          <AIChatComposer
-            value={input}
-            onChange={setInput}
-            onSubmit={() => void handleSubmit()}
-            quickPrompts={quickPrompts}
-            onQuickPrompt={(prompt) => {
-              setInput(prompt);
-              void handleSubmit(prompt);
-            }}
-            disabled={sending}
-          />
-        </section>
-
-        <AIChatSidebar
-          highlightedLecture={highlightedLecture}
-          insights={insights}
-          ragOverview={ragOverview}
-          ragLoading={ragLoading}
-          openOnMobile={sidebarOpen}
-          onCloseMobile={() => setSidebarOpen(false)}
-        />
-        </div>
-      ) : null}
+      <AIChatPageConversation
+        highlightedLecture={highlightedLecture}
+        insights={insights}
+        isLocked={isLocked}
+        messages={messages}
+        sending={sending}
+        input={input}
+        bannerTitle={bannerTitle}
+        bannerDescription={bannerDescription}
+        bannerMeta={bannerMeta}
+        ragOverview={ragOverview}
+        ragLoading={ragLoading}
+        sidebarOpen={sidebarOpen}
+        quickPrompts={quickPrompts}
+        onChangeInput={setInput}
+        onSubmit={() => void handleSubmit()}
+        onQuickPrompt={(prompt) => {
+          setInput(prompt);
+          void handleSubmit(prompt);
+        }}
+        onCloseSidebar={() => setSidebarOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/AIChatPageSections.tsx
+++ b/frontend/src/features/lms/pages/AIChatPageSections.tsx
@@ -1,0 +1,152 @@
+import type { AIInsights, AIRagResult, LectureDetail } from '@myway/shared';
+import { AIChatComposer } from '../components/AIChatComposer';
+import { AiNoticeBanner } from '../components/AiNoticeBanner';
+import { AIChatSidebar } from '../components/AIChatSidebar';
+import { AIChatThread, type AIChatMessage } from '../components/AIChatThread';
+import { StatePanel } from '../components/StatePanel';
+
+type AIChatPageHeroProps = {
+  highlightedLecture: LectureDetail | null;
+  isLocked: boolean;
+  onToggleSidebar: () => void;
+};
+
+export function AIChatPageHero({ highlightedLecture, isLocked, onToggleSidebar }: AIChatPageHeroProps) {
+  return (
+    <>
+      {isLocked ? (
+        <StatePanel
+          icon="ri-lock-line"
+          tone="amber"
+          title="수강 신청 후 AI 챗봇을 사용할 수 있습니다."
+          description="강의 내용 검색과 질문 응답은 수강 신청한 강의에서만 열립니다."
+        />
+      ) : null}
+
+      <section className="overflow-hidden rounded-[32px] bg-[linear-gradient(135deg,#03162a_0%,#004e7d_42%,#00a7c8_100%)] px-6 py-7 text-white shadow-[0_30px_70px_rgba(5,44,74,0.25)] lg:px-8">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <span className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/90 backdrop-blur">AI 학습 챗</span>
+            <h1 className="mt-3 text-[26px] font-extrabold tracking-[-0.05em] lg:text-[32px]">질문에 맞는 답을 바로 받을 수 있는 챗봇 화면입니다.</h1>
+            <p className="mt-2 text-[13px] leading-6 text-white/78">
+              {isLocked
+                ? '수강 신청 후에 강의 내용 검색과 질문을 이어갈 수 있습니다.'
+                : highlightedLecture
+                  ? `${highlightedLecture.title} 기준으로 질문을 이어갈 수 있습니다.`
+                  : '강의 기반 질문과 복습을 위한 채팅 화면입니다.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onToggleSidebar}
+            className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-[12px] font-semibold text-white lg:hidden"
+          >
+            <i className="ri-layout-right-line mr-1" />
+            도우미 패널
+          </button>
+        </div>
+      </section>
+    </>
+  );
+}
+
+type AIChatPageConversationProps = {
+  highlightedLecture: LectureDetail | null;
+  insights: AIInsights | null;
+  isLocked: boolean;
+  messages: AIChatMessage[];
+  sending: boolean;
+  input: string;
+  bannerTitle: string;
+  bannerDescription: string;
+  bannerMeta: string | null;
+  ragOverview: AIRagResult | null;
+  ragLoading: boolean;
+  sidebarOpen: boolean;
+  quickPrompts: string[];
+  onChangeInput: (value: string) => void;
+  onSubmit: () => void;
+  onQuickPrompt: (prompt: string) => void;
+  onCloseSidebar: () => void;
+};
+
+export function AIChatPageConversation({
+  highlightedLecture,
+  insights,
+  isLocked,
+  messages,
+  sending,
+  input,
+  bannerTitle,
+  bannerDescription,
+  bannerMeta,
+  ragOverview,
+  ragLoading,
+  sidebarOpen,
+  quickPrompts,
+  onChangeInput,
+  onSubmit,
+  onQuickPrompt,
+  onCloseSidebar,
+}: AIChatPageConversationProps) {
+  return (
+    <>
+      {!isLocked ? <AiNoticeBanner title={bannerTitle} description={bannerDescription} tone="indigo" meta={bannerMeta} /> : null}
+
+      {!isLocked ? (
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <section className="overflow-hidden rounded-[30px] border border-[var(--app-border)] bg-white shadow-sm">
+            <div className="flex items-center justify-between border-b border-[var(--app-border)] bg-[var(--app-surface-soft)] px-5 py-4">
+              <div>
+                <h2 className="text-[15px] font-bold text-[var(--app-text)]">대화</h2>
+                <p className="mt-1 text-[12px] text-[var(--app-text-muted)]">
+                  질문, 요약, 퀴즈, 복습 순서로 이어가면 레퍼런스처럼 흐름이 안정적입니다.
+                </p>
+              </div>
+              <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
+                {messages.length}개 메시지
+              </span>
+            </div>
+
+            <div className="min-h-[400px] space-y-4 px-5 py-5">
+              <AIChatThread messages={messages} loading={sending} />
+
+              {ragOverview ? (
+                <div className="rounded-[28px] border border-[var(--app-border)] bg-[var(--app-surface-soft)] px-4 py-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="text-[12px] font-semibold text-[var(--app-text-muted)]">RAG 파이프라인</div>
+                      <div className="mt-1 text-[14px] font-bold text-[var(--app-text)]">{ragOverview.query}</div>
+                    </div>
+                    <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-[11px] font-semibold text-cyan-700">
+                      {ragOverview.provider.search_provider}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-[12px] leading-5 text-[var(--app-text-secondary)]">{ragOverview.answer.answer}</p>
+                </div>
+              ) : null}
+            </div>
+
+            <AIChatComposer
+              value={input}
+              onChange={onChangeInput}
+              onSubmit={onSubmit}
+              quickPrompts={quickPrompts}
+              onQuickPrompt={onQuickPrompt}
+              disabled={sending}
+            />
+          </section>
+
+          <AIChatSidebar
+            highlightedLecture={highlightedLecture}
+            insights={insights}
+            ragOverview={ragOverview}
+            ragLoading={ragLoading}
+            openOnMobile={sidebarOpen}
+            onCloseMobile={onCloseSidebar}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/features/lms/pages/AdminDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/AdminDashboardPage.tsx
@@ -2,6 +2,7 @@ import type { AIInsights, AuthUser, CourseCard, Dashboard } from '@myway/shared'
 import { DashboardStatsGrid } from '../components/DashboardStatsGrid';
 import { DashboardTimeline } from '../components/DashboardTimeline';
 import { demoCourses, demoDashboard, demoInsights, demoUsers } from '../data/demo';
+import { DashboardHero } from './DashboardPageSections';
 
 type AdminDashboardPageProps = {
   dashboard: Dashboard | null;
@@ -9,14 +10,6 @@ type AdminDashboardPageProps = {
   courses: CourseCard[];
   insights: AIInsights | null;
 };
-
-function countByRole(users: AuthUser[]) {
-  return {
-    ADMIN: users.filter((user) => user.role === 'ADMIN').length,
-    INSTRUCTOR: users.filter((user) => user.role === 'INSTRUCTOR').length,
-    STUDENT: users.filter((user) => user.role === 'STUDENT').length,
-  };
-}
 
 function formatProgress(value: number): string {
   return `${Math.round(value)}%`;
@@ -27,7 +20,6 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
   const resolvedUsers = users.length > 0 ? users : demoUsers;
   const resolvedCourses = courses.length > 0 ? courses : demoCourses;
   const resolvedInsights = insights ?? demoInsights;
-  const roleCounts = countByRole(resolvedUsers);
   const stats =
     resolvedDashboard.stats ?? [
       {
@@ -70,44 +62,18 @@ export function AdminDashboardPage({ dashboard, users, courses, insights }: Admi
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-6 shadow-sm lg:px-8">
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px] xl:items-end">
-          <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
-              <i className="ri-shield-star-line" />
-              관리자 대시보드
-            </div>
-            <h2 className="mt-4 text-[24px] font-bold text-slate-900 lg:text-[28px]">운영 관리자 대시보드</h2>
-            <p className="mt-2 max-w-2xl text-[14px] leading-6 text-slate-500">
-              {resolvedDashboard.next_action ?? '운영 통계와 AI 사용량을 확인하고 병목이 생긴 코스를 점검하세요.'}
-            </p>
-          </div>
-
-          <div className="rounded-2xl border border-[#d6e6f5] bg-[#f4faff] px-5 py-5">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">역할 분포</div>
-            <div className="mt-4 space-y-3">
-              {[
-                { label: '운영자', count: roleCounts.ADMIN, color: 'bg-amber-400' },
-                { label: '교강사', count: roleCounts.INSTRUCTOR, color: 'bg-emerald-400' },
-                { label: '수강생', count: roleCounts.STUDENT, color: 'bg-cyan-400' },
-              ].map((item) => (
-                <div key={item.label} className="flex items-center gap-3">
-                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200">
-                    <div
-                      className={`h-full rounded-full ${item.color}`}
-                      style={{ width: `${Math.max((item.count / Math.max(resolvedUsers.length, 1)) * 100, item.count > 0 ? 12 : 0)}%` }}
-                    />
-                  </div>
-                  <div className="w-12 text-right text-[12px] font-semibold text-slate-700">
-                    {item.label}
-                    <span className="ml-1 text-slate-400">{item.count}</span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
+      <DashboardHero
+        badge="관리자 대시보드"
+        title="운영 관리자 대시보드"
+        description={resolvedDashboard.next_action ?? '운영 통계와 AI 사용량을 확인하고 병목이 생긴 코스를 점검하세요.'}
+        summaryLabel="역할 분포"
+        summaryValue={`운영자 ${resolvedUsers.filter((user) => user.role === 'ADMIN').length} · 강사 ${resolvedUsers.filter((user) => user.role === 'INSTRUCTOR').length} · 학생 ${resolvedUsers.filter((user) => user.role === 'STUDENT').length}`}
+        icon="ri-shield-star-line"
+        secondaryLabel="전체 강의"
+        secondaryValue={`${resolvedCourses.length}개`}
+        footerLabel="AI 요청"
+        footerValue={`${resolvedInsights.summary.total_requests}회`}
+      />
 
       <DashboardStatsGrid stats={stats} />
 

--- a/frontend/src/features/lms/pages/DashboardPageSections.tsx
+++ b/frontend/src/features/lms/pages/DashboardPageSections.tsx
@@ -1,0 +1,112 @@
+type DashboardHeroProps = {
+  badge: string;
+  title: string;
+  description: string;
+  summaryLabel: string;
+  summaryValue: string;
+  secondaryLabel: string;
+  secondaryValue: string;
+  footerLabel: string;
+  footerValue: string;
+  icon: string;
+};
+
+export function DashboardHero({
+  badge,
+  title,
+  description,
+  summaryLabel,
+  summaryValue,
+  secondaryLabel,
+  secondaryValue,
+  footerLabel,
+  footerValue,
+  icon,
+}: DashboardHeroProps) {
+  return (
+    <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-6 shadow-sm lg:px-8">
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px] xl:items-end">
+        <div>
+          <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
+            <i className={icon} />
+            {badge}
+          </div>
+          <h2 className="mt-4 text-[24px] font-bold text-slate-900 lg:text-[28px]">{title}</h2>
+          <p className="mt-2 max-w-2xl text-[14px] leading-6 text-slate-500">{description}</p>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">{summaryLabel}</div>
+              <div className="mt-1 text-[20px] font-bold text-slate-900">{summaryValue}</div>
+            </div>
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-[24px] text-cyan-700">
+              <i className="ri-dashboard-3-line" />
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-2 gap-3 text-[12px] text-slate-600">
+            <div className="rounded-2xl bg-white px-3 py-3">
+              <div className="text-slate-500">{secondaryLabel}</div>
+              <div className="mt-1 text-[18px] font-bold text-slate-900">{secondaryValue}</div>
+            </div>
+            <div className="rounded-2xl bg-white px-3 py-3">
+              <div className="text-slate-500">{footerLabel}</div>
+              <div className="mt-1 text-[18px] font-bold text-slate-900">{footerValue}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const instructorTools = [
+  {
+    icon: 'ri-file-text-line',
+    iconClass: 'bg-cyan-50 text-cyan-700',
+    title: 'AI 강의 요약',
+    description: '전사와 요약 기반으로 학습 포인트를 빠르게 정리합니다.',
+  },
+  {
+    icon: 'ri-question-line',
+    iconClass: 'bg-emerald-50 text-emerald-600',
+    title: '퀴즈 자동 생성',
+    description: '강의 흐름을 유지한 채 문제 유형과 난이도를 조정합니다.',
+  },
+  {
+    icon: 'ri-scissors-cut-line',
+    iconClass: 'bg-violet-50 text-violet-600',
+    title: '숏폼 제작',
+    description: '핵심 구간을 추려 복습용 콘텐츠로 다시 엮습니다.',
+  },
+  {
+    icon: 'ri-presentation-line',
+    iconClass: 'bg-amber-50 text-amber-700',
+    title: '강의 스튜디오',
+    description: '자료, 차시, 미디어 파이프라인을 한 곳에서 조정합니다.',
+  },
+];
+
+export function InstructorDashboardToolsSection() {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
+      <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
+        <i className="ri-tools-line text-cyan-700" />
+        제작 도구
+      </h3>
+      <div className="mt-4 grid gap-3">
+        {instructorTools.map((tool) => (
+          <article key={tool.title} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+            <div className={`mb-3 flex h-11 w-11 items-center justify-center rounded-2xl text-[20px] ${tool.iconClass}`}>
+              <i className={tool.icon} />
+            </div>
+            <h4 className="text-[14px] font-bold text-slate-900">{tool.title}</h4>
+            <p className="mt-1 text-[12px] leading-6 text-slate-500">{tool.description}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
+++ b/frontend/src/features/lms/pages/InstructorDashboardPage.tsx
@@ -2,39 +2,13 @@ import type { AIInsights, CourseCard, Dashboard } from '@myway/shared';
 import { DashboardStatsGrid } from '../components/DashboardStatsGrid';
 import { DashboardTimeline } from '../components/DashboardTimeline';
 import { StatePanel } from '../components/StatePanel';
+import { DashboardHero, InstructorDashboardToolsSection } from './DashboardPageSections';
 
 type InstructorDashboardPageProps = {
   dashboard: Dashboard | null;
   courses: CourseCard[];
   insights: AIInsights | null;
 };
-
-const tools = [
-  {
-    icon: 'ri-file-text-line',
-    iconClass: 'bg-cyan-50 text-cyan-700',
-    title: 'AI 강의 요약',
-    description: '전사와 요약 기반으로 학습 포인트를 빠르게 정리합니다.',
-  },
-  {
-    icon: 'ri-question-line',
-    iconClass: 'bg-emerald-50 text-emerald-600',
-    title: '퀴즈 자동 생성',
-    description: '강의 흐름을 유지한 채 문제 유형과 난이도를 조정합니다.',
-  },
-  {
-    icon: 'ri-scissors-cut-line',
-    iconClass: 'bg-violet-50 text-violet-600',
-    title: '숏폼 제작',
-    description: '핵심 구간을 추려 복습용 콘텐츠로 다시 엮습니다.',
-  },
-  {
-    icon: 'ri-presentation-line',
-    iconClass: 'bg-amber-50 text-amber-700',
-    title: '강의 스튜디오',
-    description: '자료, 차시, 미디어 파이프라인을 한 곳에서 조정합니다.',
-  },
-];
 
 function formatDuration(minutes: number): string {
   if (minutes < 60) {
@@ -90,41 +64,18 @@ export function InstructorDashboardPage({ dashboard, courses, insights }: Instru
 
   return (
     <div className="space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-cyan-200/20 bg-[radial-gradient(circle_at_12%_8%,rgba(34,211,238,0.16),transparent_30%),linear-gradient(135deg,#f8fcff_0%,#f0f9ff_45%,#ecfeff_100%)] px-6 py-6 shadow-sm lg:px-8">
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px] xl:items-end">
-          <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">
-              <i className="ri-presentation-line" />
-              강사 대시보드
-            </div>
-            <h2 className="mt-4 text-[24px] font-bold text-slate-900 lg:text-[28px]">강의 운영 대시보드</h2>
-            <p className="mt-2 max-w-2xl text-[14px] leading-6 text-slate-500">{nextAction}</p>
-          </div>
-
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-5">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">운영 상태</div>
-                <div className="mt-1 text-[20px] font-bold text-slate-900">{managedCount}개 강의</div>
-              </div>
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-[24px] text-cyan-700">
-                <i className="ri-dashboard-3-line" />
-              </div>
-            </div>
-
-            <div className="mt-4 grid grid-cols-2 gap-3 text-[12px] text-slate-600">
-              <div className="rounded-2xl bg-white px-3 py-3">
-                <div className="text-slate-500">진행 중</div>
-                <div className="mt-1 text-[18px] font-bold text-slate-900">{activeCount}</div>
-              </div>
-              <div className="rounded-2xl bg-white px-3 py-3">
-                <div className="text-slate-500">평균 진도</div>
-                <div className="mt-1 text-[18px] font-bold text-slate-900">{avgProgress}%</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
+      <DashboardHero
+        badge="강사 대시보드"
+        title="강의 운영 대시보드"
+        description={nextAction}
+        summaryLabel="운영 상태"
+        summaryValue={`${managedCount}개 강의`}
+        icon="ri-presentation-line"
+        secondaryLabel="진행 중"
+        secondaryValue={`${activeCount}개`}
+        footerLabel="평균 진도"
+        footerValue={`${avgProgress}%`}
+      />
 
       <DashboardStatsGrid stats={stats} />
 
@@ -187,23 +138,7 @@ export function InstructorDashboardPage({ dashboard, courses, insights }: Instru
         </div>
 
         <div className="space-y-6">
-          <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">
-            <h3 className="flex items-center gap-2 text-[15px] font-bold text-slate-900">
-              <i className="ri-tools-line text-cyan-700" />
-              제작 도구
-            </h3>
-            <div className="mt-4 grid gap-3">
-              {tools.map((tool) => (
-                <article key={tool.title} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-                  <div className={`mb-3 flex h-11 w-11 items-center justify-center rounded-2xl text-[20px] ${tool.iconClass}`}>
-                    <i className={tool.icon} />
-                  </div>
-                  <h4 className="text-[14px] font-bold text-slate-900">{tool.title}</h4>
-                  <p className="mt-1 text-[12px] leading-6 text-slate-500">{tool.description}</p>
-                </article>
-              ))}
-            </div>
-          </section>
+          <InstructorDashboardToolsSection />
 
           {insights ? (
             <section className="rounded-2xl border border-slate-200 bg-white px-5 py-5 shadow-sm">

--- a/frontend/src/features/lms/pages/LectureStudioPage.tsx
+++ b/frontend/src/features/lms/pages/LectureStudioPage.tsx
@@ -10,8 +10,6 @@ import {
   updateLectureStudioDraft,
 } from '../../../lib/api';
 import { queryKeys } from '../../../lib/query-keys';
-import { LectureStudioEditor } from '../components/lecture-studio/LectureStudioEditor';
-import { LectureStudioPreview } from '../components/lecture-studio/LectureStudioPreview';
 import {
   buildLectureStudioDraft,
   buildLectureStudioDraftFromRecord,
@@ -19,6 +17,7 @@ import {
   type LectureStudioDraft,
 } from '../components/lecture-studio/types';
 import { demoCourseDetail, demoLectureDetail } from '../data/demo';
+import { LectureStudioPageHero, LectureStudioPageWorkspace } from './LectureStudioPageSections';
 
 type LectureStudioPageProps = {
   courses: CourseCard[];
@@ -198,55 +197,26 @@ export function LectureStudioPage({ courses, selectedCourse, highlightedLecture,
 
   return (
     <div className="space-y-5">
-      <section className="rounded-3xl border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-cyan-200">Instructor Studio</div>
-            <h1 className="mt-2 text-[26px] font-extrabold tracking-[-0.04em]">강의 제작 스튜디오</h1>
-            <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-300">
-              수강 인원, 강의실, 온라인/오프라인, 과제, 시험, 퀴즈, AI 연계 옵션까지 한 화면에서 조정하는 강사 전용 제작 공간입니다.
-            </p>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-3">
-            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
-              <div className="font-semibold text-white">선택 강의</div>
-              <div className="mt-1">{selectedCourse?.title ?? '강의 미선택'}</div>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
-              <div className="font-semibold text-white">목차 / 자료</div>
-              <div className="mt-1">{outlineCount}개 · {materialCount}개</div>
-              <div className="mt-1 text-slate-300">초안 {draftSummaries.length}개</div>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
-              <div className="font-semibold text-white">현재 상태</div>
-              <div className="mt-1 capitalize">{draft.reviewState === 'ready' ? '발행 준비' : draft.reviewState === 'review' ? '검토 중' : '작성 중'}</div>
-            </div>
-          </div>
-        </div>
-        <div className="mt-4 rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] leading-6 text-slate-200">
-          {statusNote}
-        </div>
-      </section>
+      <LectureStudioPageHero
+        selectedCourse={selectedCourse}
+        draft={draft}
+        statusNote={statusNote}
+        draftCount={draftSummaries.length}
+        outlineCount={outlineCount}
+        materialCount={materialCount}
+      />
 
-      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-        <LectureStudioEditor
-          courses={courses.length > 0 ? courses : [demoCourseDetail]}
-          selectedCourse={activeCourse}
-          highlightedLecture={previewLecture}
-          draft={draft}
-          statusNote={statusNote}
-          onChange={setDraft}
-          onSelectCourse={onSelectCourse}
-          onSaveDraft={handleSaveDraft}
-          onMarkReady={handleMarkReady}
-        />
-        <LectureStudioPreview
-          draft={draft}
-          selectedCourse={activeCourse}
-          highlightedLecture={previewLecture}
-          statusNote={statusNote}
-        />
-      </section>
+      <LectureStudioPageWorkspace
+        courses={courses.length > 0 ? courses : [demoCourseDetail]}
+        activeCourse={activeCourse}
+        previewLecture={previewLecture}
+        draft={draft}
+        statusNote={statusNote}
+        onChange={setDraft}
+        onSelectCourse={onSelectCourse}
+        onSaveDraft={handleSaveDraft}
+        onMarkReady={handleMarkReady}
+      />
     </div>
   );
 }

--- a/frontend/src/features/lms/pages/LectureStudioPageSections.tsx
+++ b/frontend/src/features/lms/pages/LectureStudioPageSections.tsx
@@ -1,0 +1,96 @@
+import type { CourseCard, CourseDetail, Lecture, LectureDetail, LectureStudioDraft } from '@myway/shared';
+import { LectureStudioEditor } from '../components/lecture-studio/LectureStudioEditor';
+import { LectureStudioPreview } from '../components/lecture-studio/LectureStudioPreview';
+
+type LectureStudioPageHeroProps = {
+  selectedCourse: CourseDetail | null;
+  draft: LectureStudioDraft;
+  statusNote: string;
+  draftCount: number;
+  outlineCount: number;
+  materialCount: number;
+};
+
+export function LectureStudioPageHero({
+  selectedCourse,
+  draft,
+  statusNote,
+  draftCount,
+  outlineCount,
+  materialCount,
+}: LectureStudioPageHeroProps) {
+  return (
+    <section className="rounded-3xl border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-cyan-200">Instructor Studio</div>
+          <h1 className="mt-2 text-[26px] font-extrabold tracking-[-0.04em]">강의 제작 스튜디오</h1>
+          <p className="mt-2 max-w-2xl text-[13px] leading-6 text-slate-300">
+            수강 인원, 강의실, 온라인/오프라인, 과제, 시험, 퀴즈, AI 연계 옵션까지 한 화면에서 조정하는 강사 전용 제작 공간입니다.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+            <div className="font-semibold text-white">선택 강의</div>
+            <div className="mt-1">{selectedCourse?.title ?? '강의 미선택'}</div>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+            <div className="font-semibold text-white">목차 / 자료</div>
+            <div className="mt-1">
+              {outlineCount}개 · {materialCount}개
+            </div>
+            <div className="mt-1 text-slate-300">초안 {draftCount}개</div>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] text-slate-200">
+            <div className="font-semibold text-white">현재 상태</div>
+            <div className="mt-1 capitalize">
+              {draft.reviewState === 'ready' ? '발행 준비' : draft.reviewState === 'review' ? '검토 중' : '작성 중'}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-4 rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-[12px] leading-6 text-slate-200">{statusNote}</div>
+    </section>
+  );
+}
+
+type LectureStudioPageWorkspaceProps = {
+  courses: CourseCard[];
+  activeCourse: CourseDetail;
+  previewLecture: LectureDetail | Lecture | null;
+  draft: LectureStudioDraft;
+  statusNote: string;
+  onChange: (draft: LectureStudioDraft) => void;
+  onSelectCourse: (courseId: string) => void;
+  onSaveDraft: () => void;
+  onMarkReady: () => void;
+};
+
+export function LectureStudioPageWorkspace({
+  courses,
+  activeCourse,
+  previewLecture,
+  draft,
+  statusNote,
+  onChange,
+  onSelectCourse,
+  onSaveDraft,
+  onMarkReady,
+}: LectureStudioPageWorkspaceProps) {
+  return (
+    <section className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+      <LectureStudioEditor
+        courses={courses}
+        selectedCourse={activeCourse}
+        highlightedLecture={previewLecture}
+        draft={draft}
+        statusNote={statusNote}
+        onChange={onChange}
+        onSelectCourse={onSelectCourse}
+        onSaveDraft={onSaveDraft}
+        onMarkReady={onMarkReady}
+      />
+      <LectureStudioPreview draft={draft} selectedCourse={activeCourse} highlightedLecture={previewLecture} statusNote={statusNote} />
+    </section>
+  );
+}


### PR DESCRIPTION
# 변경 요약
`LectureStudioPage`, `AIChatPage`, `InstructorDashboardPage`, `AdminDashboardPage`의 조립 책임을 분리하고, hero/summary/content 섹션을 별도 컴포넌트로 추출했습니다.

## 배경
프론트 주요 페이지가 200줄대를 넘기면서 상태 조립과 렌더링 책임이 섞이고 있었습니다. 변경 범위를 줄이고 반복 작업을 더 안전하게 만들기 위해 페이지를 얇은 조립 파일로 정리했습니다.

## 변경 내용
- `LectureStudioPage`는 hero와 workspace를 분리하고 상태 오케스트레이션만 남겼습니다.
- `AIChatPage`는 hero와 대화/사이드바 영역을 분리했습니다.
- `InstructorDashboardPage`와 `AdminDashboardPage`는 공통 hero 섹션을 분리했습니다.
- 강사 대시보드의 도구 카드 묶음을 별도 섹션으로 이동했습니다.
- `docs/dev-logs/`에 변경 요약을 남겼습니다.

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run verify` 통과
- layer tests: `npm run test:backend` 통과
- risk/rollback: 페이지 섹션 파일과 import만 추가/이동했으며, 롤백은 새 섹션 파일 제거와 원본 JSX 복원으로 가능

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: `Proposed -> Accepted` 또는 `Accepted -> Superseded` (해당 시 기입)
