### PR TITLE
refactor: bundle frontend common ui sections v3

### DIFF
--- a/docs/dev-logs/2026-06-03-frontend-common-ui-split-bundle-v3.md
+++ b/docs/dev-logs/2026-06-03-frontend-common-ui-split-bundle-v3.md
@@ -1,0 +1,13 @@
+﻿# Frontend Common UI Split Bundle v3
+
+## Summary
+- `AssignmentCheckPage`, `AdminUsersPage`, `LectureStudioPage`를 조립기 중심으로 축소
+- `ShortformWizardStep3`를 preview/meta/actions/utils 단위로 분리
+- `MediaPipelineBoard` 상세 패널을 별도 파일로 분리하고 reexport 정리
+
+## Validation
+- `npm run verify` 통과
+
+## Notes
+- 원본 페이지는 상태/연산만 남기고 렌더 책임을 섹션 파일로 이동
+- 미디어 보드 상세 영역은 `MediaPipelineBoardDetailsSection`으로 분리

--- a/frontend/src/features/lms/components/ShortformWizardStep3Actions.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep3Actions.tsx
@@ -1,0 +1,31 @@
+type ShortformWizardStep3ActionsProps = {
+  status: string;
+  createdVideoId: string | null;
+  onBack: () => void;
+  onSave: () => void;
+  onShare: () => void;
+};
+
+export function ShortformWizardStep3Actions({ status, createdVideoId, onBack, onSave, onShare }: ShortformWizardStep3ActionsProps) {
+  return (
+    <>
+      <div className="flex flex-wrap gap-2 border-t border-slate-100 pt-4">
+        <button type="button" onClick={onSave} className="inline-flex h-10 items-center rounded-lg bg-cyan-600 px-4 text-[12px] font-semibold text-white">
+          숏폼 생성
+        </button>
+        <button
+          type="button"
+          onClick={onShare}
+          disabled={!createdVideoId}
+          className="inline-flex h-10 items-center rounded-lg border border-slate-200 bg-white px-4 text-[12px] font-semibold text-slate-600 disabled:pointer-events-none disabled:opacity-50"
+        >
+          공유하기
+        </button>
+        <button type="button" onClick={onBack} className="inline-flex h-10 items-center rounded-lg border border-slate-200 px-4 text-[12px] font-semibold text-slate-600">
+          이전
+        </button>
+      </div>
+      <p className="text-[12px] leading-6 text-slate-500">{status}</p>
+    </>
+  );
+}

--- a/frontend/src/features/lms/components/ShortformWizardStep3Meta.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep3Meta.tsx
@@ -1,0 +1,33 @@
+type ShortformWizardStep3MetaProps = {
+  title: string;
+  description: string;
+  onTitleChange: (value: string) => void;
+  onDescriptionChange: (value: string) => void;
+};
+
+export function ShortformWizardStep3Meta({ title, description, onTitleChange, onDescriptionChange }: ShortformWizardStep3MetaProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div>
+        <label className="mb-1.5 block text-[12px] font-semibold text-slate-500">
+          숏폼 제목 <span className="text-rose-500">*</span>
+        </label>
+        <input
+          value={title}
+          onChange={(event) => onTitleChange(event.target.value)}
+          className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-[13px] outline-none transition focus:border-cyan-300 focus:bg-white"
+          placeholder="예: AI 1주차 핵심 요약"
+        />
+      </div>
+      <div>
+        <label className="mb-1.5 block text-[12px] font-semibold text-slate-500">설명 <span className="text-xs text-slate-400">(선택)</span></label>
+        <textarea
+          value={description}
+          onChange={(event) => onDescriptionChange(event.target.value)}
+          className="h-24 w-full resize-none rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-[13px] leading-6 outline-none transition focus:border-cyan-300 focus:bg-white"
+          placeholder="숏폼에 대한 간단한 설명"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/lms/components/ShortformWizardStep3Preview.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep3Preview.tsx
@@ -1,0 +1,104 @@
+import type { ClipSuggestion } from './ShortformWizardTypes';
+import { formatTimestampInput, parseTimestampInput } from './ShortformWizardStep3Utils';
+
+type ShortformWizardStep3PreviewProps = {
+  courseTitle?: string | null;
+  selectedClips: ClipSuggestion[];
+  title: string;
+  previewVideoUrl: string | null;
+  exportStatus: string | null;
+  totalDurationMs: number;
+  onRemoveClip: (key: string) => void;
+  onUpdateClipTimes: (key: string, startTimeMs: number, endTimeMs: number) => void;
+  formatDuration: (ms: number) => string;
+};
+
+export function ShortformWizardStep3Preview({
+  courseTitle,
+  selectedClips,
+  title,
+  previewVideoUrl,
+  exportStatus,
+  totalDurationMs,
+  onRemoveClip,
+  onUpdateClipTimes,
+  formatDuration,
+}: ShortformWizardStep3PreviewProps) {
+  return (
+    <div className="overflow-hidden rounded-xl bg-slate-950 p-5 text-white">
+      <div className="flex items-center justify-between gap-3 text-[11px] font-semibold text-white/70">
+        <span>{courseTitle ?? '선택된 강좌 없음'}</span>
+        <span>
+          {selectedClips.length}클립 · {formatDuration(totalDurationMs)}
+        </span>
+      </div>
+      <div className="mt-4 overflow-hidden rounded-xl border border-white/10 bg-white/5">
+        {previewVideoUrl ? (
+          <video className="aspect-video w-full bg-black" controls preload="metadata" src={previewVideoUrl} />
+        ) : (
+          <div className="flex min-h-[180px] items-center justify-center p-6">
+            <div className="text-center text-white/60">
+              <i className="ri-play-circle-line text-5xl" />
+              <p className="mt-2 text-[13px] font-semibold text-white/80">{title || '숏폼 제목을 입력하세요'}</p>
+              <p className="mt-1 text-[12px]">{selectedClips.length}개 클립 재생 목록</p>
+              <p className="mt-2 text-[11px] text-white/45">
+                {exportStatus === 'PROCESSING'
+                  ? '숏폼 영상을 합치는 중입니다. 완료되면 바로 재생할 수 있습니다.'
+                  : '선택한 구간을 조립해 실제 재생 가능한 숏폼으로 저장합니다.'}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="mt-4 space-y-1.5">
+        {selectedClips.map((clip, index) => {
+          const key = `${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`;
+          return (
+            <div key={key} className="space-y-3 rounded-xl bg-white/5 px-3 py-3 text-xs">
+              <div className="flex items-center gap-2">
+                <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-cyan-100 text-[10px] font-bold text-cyan-700">
+                  {index + 1}
+                </span>
+                <span className="min-w-0 flex-1 truncate">
+                  {clip.lecture_title} - {clip.label}
+                </span>
+                <span className="text-white/60">{formatDuration(clip.end_time_ms - clip.start_time_ms)}</span>
+                <button type="button" onClick={() => onRemoveClip(key)} className="text-white/35 hover:text-white">
+                  <i className="ri-close-line" />
+                </button>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <label className="space-y-1">
+                  <span className="text-[10px] uppercase tracking-[0.08em] text-white/45">시작 시각</span>
+                  <input
+                    value={formatTimestampInput(clip.start_time_ms)}
+                    onChange={(event) => {
+                      const nextStart = parseTimestampInput(event.target.value);
+                      if (nextStart === null) return;
+                      onUpdateClipTimes(key, nextStart, clip.end_time_ms);
+                    }}
+                    placeholder="00:00"
+                    className="w-full rounded-xl border border-white/10 bg-slate-900/70 px-3 py-2 text-[12px] text-white outline-none transition focus:border-cyan-300"
+                  />
+                </label>
+                <label className="space-y-1">
+                  <span className="text-[10px] uppercase tracking-[0.08em] text-white/45">끝 시각</span>
+                  <input
+                    value={formatTimestampInput(clip.end_time_ms)}
+                    onChange={(event) => {
+                      const nextEnd = parseTimestampInput(event.target.value);
+                      if (nextEnd === null) return;
+                      onUpdateClipTimes(key, clip.start_time_ms, nextEnd);
+                    }}
+                    placeholder="00:30"
+                    className="w-full rounded-xl border border-white/10 bg-slate-900/70 px-3 py-2 text-[12px] text-white outline-none transition focus:border-cyan-300"
+                  />
+                </label>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/lms/components/ShortformWizardStep3Sections.tsx
+++ b/frontend/src/features/lms/components/ShortformWizardStep3Sections.tsx
@@ -1,4 +1,7 @@
 import type { ClipSuggestion } from './ShortformWizardTypes';
+import { ShortformWizardStep3Actions } from './ShortformWizardStep3Actions';
+import { ShortformWizardStep3Meta } from './ShortformWizardStep3Meta';
+import { ShortformWizardStep3Preview } from './ShortformWizardStep3Preview';
 
 type ShortformWizardStep3SectionsProps = {
   courseTitle?: string | null;
@@ -19,30 +22,6 @@ type ShortformWizardStep3SectionsProps = {
   onDescriptionChange: (value: string) => void;
   formatDuration: (ms: number) => string;
 };
-
-function formatTimestampInput(ms: number): string {
-  const totalSeconds = Math.max(0, Math.round(ms / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
-}
-
-function parseTimestampInput(value: string): number | null {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  const parts = trimmed.split(':').map((part) => Number(part));
-  if (parts.some((part) => Number.isNaN(part))) return null;
-  if (parts.length === 1) return Math.max(0, Math.round(parts[0] * 1000));
-  if (parts.length === 2) {
-    const [minutes, seconds] = parts;
-    return Math.max(0, Math.round((minutes * 60 + seconds) * 1000));
-  }
-  if (parts.length === 3) {
-    const [hours, minutes, seconds] = parts;
-    return Math.max(0, Math.round((hours * 3600 + minutes * 60 + seconds) * 1000));
-  }
-  return null;
-}
 
 export function ShortformWizardStep3Sections({
   courseTitle,
@@ -81,119 +60,26 @@ export function ShortformWizardStep3Sections({
         </div>
       </div>
 
-      <div className="overflow-hidden rounded-xl bg-slate-950 p-5 text-white">
-        <div className="flex items-center justify-between gap-3 text-[11px] font-semibold text-white/70">
-          <span>{courseTitle ?? '선택된 강좌 없음'}</span>
-          <span>
-            {selectedClips.length}클립 · {formatDuration(totalDurationMs)}
-          </span>
-        </div>
-        <div className="mt-4 overflow-hidden rounded-xl border border-white/10 bg-white/5">
-          {previewVideoUrl ? (
-            <video className="aspect-video w-full bg-black" controls preload="metadata" src={previewVideoUrl} />
-          ) : (
-            <div className="flex min-h-[180px] items-center justify-center p-6">
-              <div className="text-center text-white/60">
-                <i className="ri-play-circle-line text-5xl" />
-                <p className="mt-2 text-[13px] font-semibold text-white/80">{title || '숏폼 제목을 입력하세요'}</p>
-                <p className="mt-1 text-[12px]">{selectedClips.length}개 클립 재생 목록</p>
-                <p className="mt-2 text-[11px] text-white/45">
-                  {exportStatus === 'PROCESSING'
-                    ? '숏폼 영상을 합치는 중입니다. 완료되면 바로 재생할 수 있습니다.'
-                    : '선택한 구간을 조립해 실제 재생 가능한 숏폼으로 저장합니다.'}
-                </p>
-              </div>
-            </div>
-          )}
-        </div>
-        <div className="mt-4 space-y-1.5">
-          {selectedClips.map((clip, index) => {
-            const key = `${clip.lecture_id}:${clip.start_time_ms}:${clip.end_time_ms}`;
-            return (
-              <div key={key} className="space-y-3 rounded-xl bg-white/5 px-3 py-3 text-xs">
-                <div className="flex items-center gap-2">
-                  <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-cyan-100 text-[10px] font-bold text-cyan-700">
-                    {index + 1}
-                  </span>
-                  <span className="min-w-0 flex-1 truncate">
-                    {clip.lecture_title} - {clip.label}
-                  </span>
-                  <span className="text-white/60">{formatDuration(clip.end_time_ms - clip.start_time_ms)}</span>
-                  <button type="button" onClick={() => onRemoveClip(key)} className="text-white/35 hover:text-white">
-                    <i className="ri-close-line" />
-                  </button>
-                </div>
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <label className="space-y-1">
-                    <span className="text-[10px] uppercase tracking-[0.08em] text-white/45">시작 시각</span>
-                    <input
-                      value={formatTimestampInput(clip.start_time_ms)}
-                      onChange={(event) => {
-                        const nextStart = parseTimestampInput(event.target.value);
-                        if (nextStart === null) return;
-                        onUpdateClipTimes(key, nextStart, clip.end_time_ms);
-                      }}
-                      placeholder="00:00"
-                      className="w-full rounded-xl border border-white/10 bg-slate-900/70 px-3 py-2 text-[12px] text-white outline-none transition focus:border-cyan-300"
-                    />
-                  </label>
-                  <label className="space-y-1">
-                    <span className="text-[10px] uppercase tracking-[0.08em] text-white/45">끝 시각</span>
-                    <input
-                      value={formatTimestampInput(clip.end_time_ms)}
-                      onChange={(event) => {
-                        const nextEnd = parseTimestampInput(event.target.value);
-                        if (nextEnd === null) return;
-                        onUpdateClipTimes(key, clip.start_time_ms, nextEnd);
-                      }}
-                      placeholder="00:30"
-                      className="w-full rounded-xl border border-white/10 bg-slate-900/70 px-3 py-2 text-[12px] text-white outline-none transition focus:border-cyan-300"
-                    />
-                  </label>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
+      <ShortformWizardStep3Preview
+        courseTitle={courseTitle}
+        selectedClips={selectedClips}
+        title={title}
+        previewVideoUrl={previewVideoUrl}
+        exportStatus={exportStatus}
+        totalDurationMs={totalDurationMs}
+        onRemoveClip={onRemoveClip}
+        onUpdateClipTimes={onUpdateClipTimes}
+        formatDuration={formatDuration}
+      />
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div>
-          <label className="mb-1.5 block text-[12px] font-semibold text-slate-500">
-            숏폼 제목 <span className="text-rose-500">*</span>
-          </label>
-          <input
-            value={title}
-            onChange={(event) => onTitleChange(event.target.value)}
-            className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-[13px] outline-none transition focus:border-cyan-300 focus:bg-white"
-            placeholder="예: AI 1주차 핵심 요약"
-          />
-        </div>
-        <div>
-          <label className="mb-1.5 block text-[12px] font-semibold text-slate-500">설명 <span className="text-xs text-slate-400">(선택)</span></label>
-          <textarea
-            value={description}
-            onChange={(event) => onDescriptionChange(event.target.value)}
-            className="h-24 w-full resize-none rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-[13px] leading-6 outline-none transition focus:border-cyan-300 focus:bg-white"
-            placeholder="숏폼에 대한 간단한 설명"
-          />
-        </div>
-      </div>
+      <ShortformWizardStep3Meta
+        title={title}
+        description={description}
+        onTitleChange={onTitleChange}
+        onDescriptionChange={onDescriptionChange}
+      />
 
-      <div className="flex flex-wrap gap-2 border-t border-slate-100 pt-4">
-        <button type="button" onClick={onSave} className="inline-flex h-10 items-center rounded-lg bg-cyan-600 px-4 text-[12px] font-semibold text-white">
-          숏폼 생성
-        </button>
-        <button
-          type="button"
-          onClick={onShare}
-          disabled={!createdVideoId}
-          className="inline-flex h-10 items-center rounded-lg border border-slate-200 bg-white px-4 text-[12px] font-semibold text-slate-600 disabled:pointer-events-none disabled:opacity-50"
-        >
-          공유하기
-        </button>
-      </div>
-      <p className="text-[12px] leading-6 text-slate-500">{status}</p>
+      <ShortformWizardStep3Actions status={status} createdVideoId={createdVideoId} onBack={onBack} onSave={onSave} onShare={onShare} />
       {createdVideoId ? <p className="text-[11px] text-slate-400">생성 ID: {createdVideoId}</p> : null}
     </article>
   );

--- a/frontend/src/features/lms/components/ShortformWizardStep3Utils.ts
+++ b/frontend/src/features/lms/components/ShortformWizardStep3Utils.ts
@@ -1,0 +1,23 @@
+export function formatTimestampInput(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+export function parseTimestampInput(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(':').map((part) => Number(part));
+  if (parts.some((part) => Number.isNaN(part))) return null;
+  if (parts.length === 1) return Math.max(0, Math.round(parts[0] * 1000));
+  if (parts.length === 2) {
+    const [minutes, seconds] = parts;
+    return Math.max(0, Math.round((minutes * 60 + seconds) * 1000));
+  }
+  if (parts.length === 3) {
+    const [hours, minutes, seconds] = parts;
+    return Math.max(0, Math.round((hours * 3600 + minutes * 60 + seconds) * 1000));
+  }
+  return null;
+}

--- a/frontend/src/features/lms/components/media-pipeline/MediaPipelineBoardDetailsSection.tsx
+++ b/frontend/src/features/lms/components/media-pipeline/MediaPipelineBoardDetailsSection.tsx
@@ -1,0 +1,138 @@
+﻿import type { AudioExtraction, LecturePipeline, MediaProcessorHealth, STTProviderCatalog } from '@myway/shared';
+import type { MediaUploadResult } from '../../../../lib/api-media';
+
+type MediaPipelineBoardDetailsSectionProps = {
+  pipeline: LecturePipeline | null;
+  extraction: AudioExtraction | null;
+  uploadResult: MediaUploadResult | null;
+  recentExtractions: AudioExtraction[];
+  processorHealth: MediaProcessorHealth | null;
+  isRefreshing: boolean;
+  onRefresh?: () => void;
+  providers: STTProviderCatalog | null;
+};
+
+function statusTone(status: string): string {
+  if (status === 'COMPLETED' || status === 'available') return 'bg-emerald-100 text-emerald-700';
+  if (status === 'PROCESSING' || status === 'checking' || status === 'PENDING') return 'bg-amber-100 text-amber-700';
+  if (status === 'FAILED' || status === 'disabled') return 'bg-rose-100 text-rose-700';
+  return 'bg-slate-100 text-slate-700';
+}
+
+function statusLabel(status: string): string {
+  if (status === 'COMPLETED') return '완료';
+  if (status === 'PROCESSING') return '처리 중';
+  if (status === 'PENDING') return '대기';
+  if (status === 'FAILED') return '실패';
+  if (status === 'available') return '사용 가능';
+  if (status === 'planned') return '계획됨';
+  if (status === 'disabled') return '비활성';
+  return status;
+}
+
+function formatDateTime(value?: string | null): string {
+  return value ? new Date(value).toLocaleString('ko-KR') : '기록 없음';
+}
+
+function stageLabel(stage?: string | null): string {
+  switch (stage) {
+    case 'queued': return '대기열 등록';
+    case 'downloading': return '원본 다운로드';
+    case 'extracting': return '오디오 추출';
+    case 'uploading': return '오디오 업로드';
+    case 'callback': return '콜백 반영';
+    case 'transcribing': return 'STT 전사';
+    case 'summarizing': return '요약 생성';
+    case 'completed': return '완료';
+    case 'failed': return '실패';
+    default: return '미확인';
+  }
+}
+
+export function MediaPipelineBoardDetailsSection({ pipeline, extraction, uploadResult, recentExtractions, processorHealth, isRefreshing, onRefresh, providers }: MediaPipelineBoardDetailsSectionProps) {
+  return (
+    <section className="grid gap-3 xl:grid-cols-[1.2fr_0.8fr]">
+      <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-semibold text-slate-900">파이프라인 상태</div>
+            <div className="text-xs text-slate-500">영상 업로드, 오디오 추출, 전사 상태를 같이 확인합니다.</div>
+          </div>
+          <div className="flex items-center gap-2">
+            {onRefresh ? <button type="button" onClick={onRefresh} disabled={isRefreshing} className="rounded-full border border-[#cce0f2] bg-white px-3 py-1 text-xs font-semibold text-[#3e5d7b] transition hover:border-cyan-300 hover:text-cyan-700 disabled:cursor-not-allowed disabled:opacity-60">{isRefreshing ? '갱신 중' : '상태 새로고침'}</button> : null}
+            {isRefreshing ? <div className="rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-700">상태 새로고침 중</div> : null}
+            <div className="rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-700">{pipeline?.updated_at ? new Date(pipeline.updated_at).toLocaleString('ko-KR') : '업데이트 전'}</div>
+          </div>
+        </div>
+        <div className="mt-4 grid gap-3 md:grid-cols-3">
+          {[
+            { label: '오디오 상태', value: pipeline?.audio_status ?? 'PENDING' },
+            { label: 'STT 상태', value: extraction?.stt_status ?? pipeline?.transcript_status ?? 'PENDING' },
+            { label: '요약 상태', value: pipeline?.summary_status ?? 'PENDING' },
+            { label: '처리 단계', value: stageLabel(extraction?.processing_stage) },
+            { label: '처리 서비스 job', value: extraction?.processing_job_id ?? '없음' },
+            { label: '전사 ID', value: extraction?.transcript_id ?? pipeline?.transcript_id ?? '없음' },
+            { label: '처리 완료 시각', value: extraction?.processed_at ? new Date(extraction.processed_at).toLocaleString('ko-KR') : '대기 중' },
+          ].map((item) => (
+            <div key={item.label} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
+              <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">{item.label}</div>
+              <div className="mt-2 break-words text-sm font-semibold text-slate-900">{item.value}</div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-5 space-y-3">
+          <div className="text-sm font-semibold text-slate-900">최근 추출 이력</div>
+          {recentExtractions.length > 0 ? (
+            <div className="space-y-3">
+              {recentExtractions.slice(0, 3).map((item) => (
+                <div key={item.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div><div className="text-sm font-semibold text-slate-900">{item.id}</div><div className="mt-1 text-xs text-slate-500">생성 {formatDateTime(item.created_at)} · 갱신 {formatDateTime(item.updated_at)}</div></div>
+                    <div className={`rounded-full px-3 py-1 text-xs font-semibold ${statusTone(item.status)}`}>{statusLabel(item.status)}</div>
+                  </div>
+                  <div className="mt-3 grid gap-3 md:grid-cols-2">
+                    <div><div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">오디오 URL</div><div className="mt-1 break-all text-sm text-slate-700">{item.audio_url ?? 'callback 대기 중'}</div></div>
+                    <div><div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">처리 서비스 job</div><div className="mt-1 break-all text-sm text-slate-700">{item.processing_job_id ?? '아직 없음'}</div></div>
+                  </div>
+                  {item.processing_error ? <div className="mt-3 rounded-xl border border-rose-100 bg-rose-50 px-3 py-2 text-xs text-rose-700">{item.processing_error}</div> : null}
+                </div>
+              ))}
+            </div>
+          ) : <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">아직 기록된 추출 이력이 없습니다.</div>}
+        </div>
+        <div className="mt-5 space-y-3">
+          <div className="text-sm font-semibold text-slate-900">업로드 산출물</div>
+          {uploadResult ? <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-sm text-emerald-900"><div className="font-semibold">{uploadResult.asset_key}</div><div className="mt-1 break-all text-xs">{uploadResult.video_url}</div></div> : <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">아직 업로드된 영상이 없습니다.</div>}
+        </div>
+      </div>
+      <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
+        <div className="text-sm font-semibold text-slate-900">STT provider 상태</div>
+        <div className="mt-3 space-y-3">
+          {providers?.providers?.map((provider) => (
+            <div key={provider.name} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div><div className="text-sm font-semibold text-slate-900">{provider.label}</div><div className="mt-1 text-xs text-slate-500">{provider.description}</div></div>
+                <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${statusTone(provider.status)}`}>{statusLabel(provider.status)}</span>
+              </div>
+            </div>
+          )) ?? <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">provider 정보를 불러오지 못했습니다.</div>}
+        </div>
+        <div className="mt-5 space-y-3">
+          <div className="text-sm font-semibold text-slate-900">최근 processor job</div>
+          {processorHealth?.recent_jobs?.length ? (
+            <div className="space-y-3">
+              {processorHealth.recent_jobs.slice(0, 3).map((job) => (
+                <div key={job.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div><div className="text-sm font-semibold text-slate-900">{job.lecture_id}</div><div className="mt-1 text-xs text-slate-500">생성 {formatDateTime(job.created_at)} · 갱신 {formatDateTime(job.updated_at)}</div></div>
+                    <div className={`rounded-full px-3 py-1 text-xs font-semibold ${statusTone(job.status)}`}>{statusLabel(job.status)}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">processor job 이력이 없습니다.</div>}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/lms/components/media-pipeline/MediaPipelineBoardSections.tsx
+++ b/frontend/src/features/lms/components/media-pipeline/MediaPipelineBoardSections.tsx
@@ -1,1 +1,2 @@
-export { DetailSections, HealthCards, PipelineCards } from './MediaPipelineBoardSectionsParts';
+export { HealthCards, PipelineCards } from './MediaPipelineBoardSectionsParts';
+export { MediaPipelineBoardDetailsSection as DetailSections } from './MediaPipelineBoardDetailsSection';

--- a/frontend/src/features/lms/components/media-pipeline/MediaPipelineBoardSectionsParts.tsx
+++ b/frontend/src/features/lms/components/media-pipeline/MediaPipelineBoardSectionsParts.tsx
@@ -1,4 +1,4 @@
-import { getLectureDisplayDurationMinutes, type AudioExtraction, type LecturePipeline, type MediaProcessorHealth, type STTProviderCatalog } from '@myway/shared';
+﻿import { getLectureDisplayDurationMinutes, type AudioExtraction, type LecturePipeline, type MediaProcessorHealth, type STTProviderCatalog } from '@myway/shared';
 import type { MediaUploadResult } from '../../../../lib/api-media';
 
 type SectionProps = {
@@ -29,25 +29,6 @@ function statusLabel(status: string): string {
   if (status === 'planned') return '계획됨';
   if (status === 'disabled') return '비활성';
   return status;
-}
-
-function formatDateTime(value?: string | null): string {
-  return value ? new Date(value).toLocaleString('ko-KR') : '기록 없음';
-}
-
-function stageLabel(stage?: string | null): string {
-  switch (stage) {
-    case 'queued': return '대기열 등록';
-    case 'downloading': return '원본 다운로드';
-    case 'extracting': return '오디오 추출';
-    case 'uploading': return '오디오 업로드';
-    case 'callback': return '콜백 반영';
-    case 'transcribing': return 'STT 전사';
-    case 'summarizing': return '요약 생성';
-    case 'completed': return '완료';
-    case 'failed': return '실패';
-    default: return '미확인';
-  }
 }
 
 export function HealthCards({ processorHealth }: Pick<SectionProps, 'processorHealth'>) {
@@ -100,94 +81,6 @@ export function PipelineCards({ uploadResult, extraction, pipeline, selectedLect
         <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">트랜스크립트</div>
         <div className={`mt-3 inline-flex rounded-full px-3 py-1 text-xs font-semibold ${statusTone(pipeline?.transcript_status ?? 'PENDING')}`}>{statusLabel(pipeline?.transcript_status ?? 'PENDING')}</div>
         <p className="mt-4 text-sm text-slate-600">{selectedLecture ? `${selectedLecture.title} · ${getLectureDisplayDurationMinutes(selectedLecture)}분` : '강의를 선택하면 전사 경로가 연결됩니다.'}</p>
-      </div>
-    </section>
-  );
-}
-
-export function DetailSections({ pipeline, extraction, uploadResult, recentExtractions, processorHealth, isRefreshing, onRefresh, providers }: Pick<SectionProps, 'pipeline'|'extraction'|'uploadResult'|'recentExtractions'|'processorHealth'|'isRefreshing'|'onRefresh'|'providers'>) {
-  return (
-    <section className="grid gap-3 xl:grid-cols-[1.2fr_0.8fr]">
-      <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="text-sm font-semibold text-slate-900">파이프라인 상태</div>
-            <div className="text-xs text-slate-500">영상 업로드, 오디오 추출, 전사 상태를 같이 확인합니다.</div>
-          </div>
-          <div className="flex items-center gap-2">
-            {onRefresh ? <button type="button" onClick={onRefresh} disabled={isRefreshing} className="rounded-full border border-[#cce0f2] bg-white px-3 py-1 text-xs font-semibold text-[#3e5d7b] transition hover:border-cyan-300 hover:text-cyan-700 disabled:cursor-not-allowed disabled:opacity-60">{isRefreshing ? '갱신 중' : '상태 새로고침'}</button> : null}
-            {isRefreshing ? <div className="rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-700">상태 새로고침 중</div> : null}
-            <div className="rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-700">{pipeline?.updated_at ? new Date(pipeline.updated_at).toLocaleString('ko-KR') : '업데이트 전'}</div>
-          </div>
-        </div>
-        <div className="mt-4 grid gap-3 md:grid-cols-3">
-          {[
-            { label: '오디오 상태', value: pipeline?.audio_status ?? 'PENDING' },
-            { label: 'STT 상태', value: extraction?.stt_status ?? pipeline?.transcript_status ?? 'PENDING' },
-            { label: '요약 상태', value: pipeline?.summary_status ?? 'PENDING' },
-            { label: '처리 단계', value: stageLabel(extraction?.processing_stage) },
-            { label: '처리 서비스 job', value: extraction?.processing_job_id ?? '없음' },
-            { label: '전사 ID', value: extraction?.transcript_id ?? pipeline?.transcript_id ?? '없음' },
-            { label: '처리 완료 시각', value: extraction?.processed_at ? new Date(extraction.processed_at).toLocaleString('ko-KR') : '대기 중' },
-          ].map((item) => (
-            <div key={item.label} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
-              <div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">{item.label}</div>
-              <div className="mt-2 break-words text-sm font-semibold text-slate-900">{item.value}</div>
-            </div>
-          ))}
-        </div>
-        <div className="mt-5 space-y-3">
-          <div className="text-sm font-semibold text-slate-900">최근 추출 이력</div>
-          {recentExtractions.length > 0 ? (
-            <div className="space-y-3">
-              {recentExtractions.slice(0, 3).map((item) => (
-                <div key={item.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div><div className="text-sm font-semibold text-slate-900">{item.id}</div><div className="mt-1 text-xs text-slate-500">생성 {formatDateTime(item.created_at)} · 갱신 {formatDateTime(item.updated_at)}</div></div>
-                    <div className={`rounded-full px-3 py-1 text-xs font-semibold ${statusTone(item.status)}`}>{statusLabel(item.status)}</div>
-                  </div>
-                  <div className="mt-3 grid gap-3 md:grid-cols-2">
-                    <div><div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">오디오 URL</div><div className="mt-1 break-all text-sm text-slate-700">{item.audio_url ?? 'callback 대기 중'}</div></div>
-                    <div><div className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">처리 서비스 job</div><div className="mt-1 break-all text-sm text-slate-700">{item.processing_job_id ?? '아직 없음'}</div></div>
-                  </div>
-                  {item.processing_error ? <div className="mt-3 rounded-xl border border-rose-100 bg-rose-50 px-3 py-2 text-xs text-rose-700">{item.processing_error}</div> : null}
-                </div>
-              ))}
-            </div>
-          ) : <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">아직 기록된 추출 이력이 없습니다.</div>}
-        </div>
-        <div className="mt-5 space-y-3">
-          <div className="text-sm font-semibold text-slate-900">업로드 산출물</div>
-          {uploadResult ? <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-sm text-emerald-900"><div className="font-semibold">{uploadResult.asset_key}</div><div className="mt-1 break-all text-xs">{uploadResult.video_url}</div></div> : <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">아직 업로드된 영상이 없습니다.</div>}
-        </div>
-      </div>
-      <div className="rounded-3xl border border-[#d6e6f5] bg-white p-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
-        <div className="text-sm font-semibold text-slate-900">STT provider 상태</div>
-        <div className="mt-3 space-y-3">
-          {providers?.providers?.map((provider) => (
-            <div key={provider.name} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
-              <div className="flex items-center justify-between gap-3">
-                <div><div className="text-sm font-semibold text-slate-900">{provider.label}</div><div className="mt-1 text-xs text-slate-500">{provider.description}</div></div>
-                <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${statusTone(provider.status)}`}>{statusLabel(provider.status)}</span>
-              </div>
-            </div>
-          )) ?? <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">provider 정보를 불러오지 못했습니다.</div>}
-        </div>
-        <div className="mt-5 space-y-3">
-          <div className="text-sm font-semibold text-slate-900">최근 processor job</div>
-          {processorHealth?.recent_jobs?.length ? (
-            <div className="space-y-3">
-              {processorHealth.recent_jobs.slice(0, 3).map((job) => (
-                <div key={job.id} className="rounded-2xl border border-[#dce9f7] bg-[#f4faff] p-4">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div><div className="text-sm font-semibold text-slate-900">{job.lecture_id}</div><div className="mt-1 text-xs text-slate-500">생성 {formatDateTime(job.created_at)} · 갱신 {formatDateTime(job.updated_at)}</div></div>
-                    <div className={`rounded-full px-3 py-1 text-xs font-semibold ${statusTone(job.status)}`}>{statusLabel(job.status)}</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">processor job 이력이 없습니다.</div>}
-        </div>
       </div>
     </section>
   );

--- a/frontend/src/features/lms/pages/AdminUsersPage.tsx
+++ b/frontend/src/features/lms/pages/AdminUsersPage.tsx
@@ -1,26 +1,13 @@
 import { useMemo, useState } from 'react';
 import type { AuthUser } from '@myway/shared';
-import { roleLabel } from '../config';
-import { StatePanel } from '../components/StatePanel';
 import { demoUsers } from '../data/demo';
+import { AdminUsersPageSections } from './AdminUsersPageSections';
 
 type AdminUsersPageProps = {
   users: AuthUser[];
 };
 
 type RoleFilter = 'all' | AuthUser['role'];
-
-const roleBadgeClasses: Record<AuthUser['role'], string> = {
-  ADMIN: 'bg-amber-100 text-amber-700',
-  INSTRUCTOR: 'bg-emerald-100 text-emerald-600',
-  STUDENT: 'bg-indigo-100 text-indigo-600',
-};
-
-const roleToneClasses: Record<AuthUser['role'], string> = {
-  ADMIN: 'border-amber-200 bg-amber-50 text-amber-700',
-  INSTRUCTOR: 'border-emerald-200 bg-emerald-50 text-emerald-600',
-  STUDENT: 'border-indigo-200 bg-indigo-50 text-indigo-600',
-};
 
 export function AdminUsersPage({ users }: AdminUsersPageProps) {
   const [query, setQuery] = useState('');
@@ -50,161 +37,13 @@ export function AdminUsersPage({ users }: AdminUsersPageProps) {
   );
 
   return (
-    <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
-          <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
-              <i className="ri-user-settings-line" />
-              사용자 관리
-            </div>
-            <h2 className="mt-4 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[32px]">
-              역할별 사용자와
-              <br />
-              활동 상태를 빠르게 찾습니다.
-            </h2>
-            <p className="mt-3 max-w-2xl text-[14px] leading-7 text-white/78">
-              검색과 역할 필터를 함께 써서 필요한 계정만 빠르게 좁힐 수 있습니다.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3 rounded-[28px] border border-white/10 bg-white/10 px-5 py-5 text-white/85 backdrop-blur">
-            <div className="rounded-2xl bg-white/10 px-3 py-3">
-              <div className="text-[11px] text-white/60">전체</div>
-              <div className="mt-1 text-[20px] font-extrabold text-white">{counts.total}</div>
-            </div>
-            <div className="rounded-2xl bg-white/10 px-3 py-3">
-              <div className="text-[11px] text-white/60">수강생</div>
-              <div className="mt-1 text-[20px] font-extrabold text-white">{counts.student}</div>
-            </div>
-            <div className="rounded-2xl bg-white/10 px-3 py-3">
-              <div className="text-[11px] text-white/60">교강사</div>
-              <div className="mt-1 text-[20px] font-extrabold text-white">{counts.instructor}</div>
-            </div>
-            <div className="rounded-2xl bg-white/10 px-3 py-3">
-              <div className="text-[11px] text-white/60">운영자</div>
-              <div className="mt-1 text-[20px] font-extrabold text-white">{counts.admin}</div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-end">
-          <label className="block">
-            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="이름, 이메일, 학과, 역할 검색"
-              className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-400"
-            />
-          </label>
-
-          <div className="flex flex-wrap gap-2 lg:justify-end">
-            {[
-              { key: 'all', label: '전체' },
-              { key: 'ADMIN', label: '운영자' },
-              { key: 'INSTRUCTOR', label: '교강사' },
-              { key: 'STUDENT', label: '수강생' },
-            ].map((item) => {
-              const active = roleFilter === item.key;
-              return (
-                <button
-                  key={item.key}
-                  type="button"
-                  onClick={() => setRoleFilter(item.key as RoleFilter)}
-                  className={`rounded-full px-4 py-2 text-[12px] font-semibold transition ${
-                    active ? 'bg-cyan-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:border-cyan-200 hover:text-cyan-700'
-                  }`}
-                >
-                  {item.label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-500">전체 {counts.total}명</span>
-          <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-500">검색 결과 {filteredUsers.length}명</span>
-          <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">역할별 색상 적용</span>
-        </div>
-      </section>
-
-      <section className="rounded-[30px] border border-slate-200 bg-white shadow-sm">
-        <div className="hidden overflow-hidden rounded-[30px] md:block">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="border-b border-slate-200 bg-slate-50">
-                <tr>
-                  <th className="px-4 py-3 text-left font-semibold text-slate-600">이름</th>
-                  <th className="px-4 py-3 text-left font-semibold text-slate-600">이메일</th>
-                  <th className="px-4 py-3 text-left font-semibold text-slate-600">역할</th>
-                  <th className="px-4 py-3 text-left font-semibold text-slate-600">학과</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100">
-                {filteredUsers.map((user) => (
-                  <tr key={user.id} className="transition hover:bg-slate-50/80">
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${roleToneClasses[user.role]}`}>
-                          {user.name.slice(0, 1)}
-                        </div>
-                        <div>
-                          <div className="font-medium text-slate-900">{user.name}</div>
-                          <div className="mt-0.5 text-[11px] text-slate-400">{user.bio}</div>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-slate-500">{user.email}</td>
-                    <td className="px-4 py-3">
-                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${roleBadgeClasses[user.role]}`}>
-                        {roleLabel(user.role)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-slate-500">{user.department}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div className="space-y-3 p-4 md:hidden">
-          {filteredUsers.length > 0 ? (
-            filteredUsers.map((user) => (
-              <article key={user.id} className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
-                <div className="flex items-start gap-3">
-                  <div className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl text-[13px] font-bold ${roleToneClasses[user.role]}`}>
-                    {user.name.slice(0, 1)}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <div className="text-[14px] font-semibold text-slate-900">{user.name}</div>
-                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${roleBadgeClasses[user.role]}`}>
-                        {roleLabel(user.role)}
-                      </span>
-                    </div>
-                    <div className="mt-1 text-[12px] leading-6 text-slate-500">{user.email}</div>
-                    <div className="text-[12px] leading-6 text-slate-500">{user.department}</div>
-                    <p className="mt-2 text-[12px] leading-6 text-slate-500">{user.bio}</p>
-                  </div>
-                </div>
-              </article>
-            ))
-          ) : (
-            <StatePanel
-              compact
-              icon="ri-search-line"
-              tone="slate"
-              title="조건에 맞는 사용자가 없습니다."
-              description="검색어와 역할 필터를 바꾸면 다른 계정을 다시 찾을 수 있습니다."
-            />
-          )}
-        </div>
-      </section>
-    </div>
+    <AdminUsersPageSections
+      counts={counts}
+      query={query}
+      roleFilter={roleFilter}
+      filteredUsers={filteredUsers}
+      onQueryChange={setQuery}
+      onRoleFilterChange={setRoleFilter}
+    />
   );
 }

--- a/frontend/src/features/lms/pages/AdminUsersPageSections.tsx
+++ b/frontend/src/features/lms/pages/AdminUsersPageSections.tsx
@@ -1,0 +1,197 @@
+import type { AuthUser } from '@myway/shared';
+import { roleLabel } from '../config';
+import { StatePanel } from '../components/StatePanel';
+
+const roleBadgeClasses: Record<AuthUser['role'], string> = {
+  ADMIN: 'bg-amber-100 text-amber-700',
+  INSTRUCTOR: 'bg-emerald-100 text-emerald-600',
+  STUDENT: 'bg-indigo-100 text-indigo-600',
+};
+
+const roleToneClasses: Record<AuthUser['role'], string> = {
+  ADMIN: 'border-amber-200 bg-amber-50 text-amber-700',
+  INSTRUCTOR: 'border-emerald-200 bg-emerald-50 text-emerald-600',
+  STUDENT: 'border-indigo-200 bg-indigo-50 text-indigo-600',
+};
+
+type AdminUsersPageSectionsProps = {
+  counts: {
+    total: number;
+    admin: number;
+    instructor: number;
+    student: number;
+  };
+  query: string;
+  roleFilter: 'all' | AuthUser['role'];
+  filteredUsers: AuthUser[];
+  onQueryChange: (query: string) => void;
+  onRoleFilterChange: (filter: 'all' | AuthUser['role']) => void;
+};
+
+export function AdminUsersPageSections({
+  counts,
+  query,
+  roleFilter,
+  filteredUsers,
+  onQueryChange,
+  onRoleFilterChange,
+}: AdminUsersPageSectionsProps) {
+  return (
+    <div className="space-y-6">
+      <section className="overflow-hidden rounded-[32px] border border-cyan-200/20 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.24),transparent_28%),radial-gradient(circle_at_80%_20%,rgba(14,116,144,0.32),transparent_42%),linear-gradient(135deg,#071a35_0%,#123f66_52%,#175479_100%)] px-6 py-6 text-white shadow-sm lg:px-8 lg:py-8">
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
+              <i className="ri-user-settings-line" />
+              사용자 관리
+            </div>
+            <h2 className="mt-4 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[32px]">
+              역할별 사용자와
+              <br />
+              활동 상태를 빠르게 찾습니다.
+            </h2>
+            <p className="mt-3 max-w-2xl text-[14px] leading-7 text-white/78">
+              검색과 역할 필터를 함께 써서 필요한 계정만 빠르게 좁힐 수 있습니다.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 rounded-[28px] border border-white/10 bg-white/10 px-5 py-5 text-white/85 backdrop-blur">
+            <div className="rounded-2xl bg-white/10 px-3 py-3">
+              <div className="text-[11px] text-white/60">전체</div>
+              <div className="mt-1 text-[20px] font-extrabold text-white">{counts.total}</div>
+            </div>
+            <div className="rounded-2xl bg-white/10 px-3 py-3">
+              <div className="text-[11px] text-white/60">수강생</div>
+              <div className="mt-1 text-[20px] font-extrabold text-white">{counts.student}</div>
+            </div>
+            <div className="rounded-2xl bg-white/10 px-3 py-3">
+              <div className="text-[11px] text-white/60">교강사</div>
+              <div className="mt-1 text-[20px] font-extrabold text-white">{counts.instructor}</div>
+            </div>
+            <div className="rounded-2xl bg-white/10 px-3 py-3">
+              <div className="text-[11px] text-white/60">운영자</div>
+              <div className="mt-1 text-[20px] font-extrabold text-white">{counts.admin}</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[30px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-end">
+          <label className="block">
+            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
+            <input
+              value={query}
+              onChange={(event) => onQueryChange(event.target.value)}
+              placeholder="이름, 이메일, 학과, 역할 검색"
+              className="h-11 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-400"
+            />
+          </label>
+
+          <div className="flex flex-wrap gap-2 lg:justify-end">
+            {[
+              { key: 'all', label: '전체' },
+              { key: 'ADMIN', label: '운영자' },
+              { key: 'INSTRUCTOR', label: '교강사' },
+              { key: 'STUDENT', label: '수강생' },
+            ].map((item) => {
+              const active = roleFilter === item.key;
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => onRoleFilterChange(item.key as 'all' | AuthUser['role'])}
+                  className={`rounded-full px-4 py-2 text-[12px] font-semibold transition ${
+                    active ? 'bg-cyan-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:border-cyan-200 hover:text-cyan-700'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-500">전체 {counts.total}명</span>
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-500">검색 결과 {filteredUsers.length}명</span>
+          <span className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">역할별 색상 적용</span>
+        </div>
+      </section>
+
+      <section className="rounded-[30px] border border-slate-200 bg-white shadow-sm">
+        <div className="hidden overflow-hidden rounded-[30px] md:block">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b border-slate-200 bg-slate-50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-600">이름</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-600">이메일</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-600">역할</th>
+                  <th className="px-4 py-3 text-left font-semibold text-slate-600">학과</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {filteredUsers.map((user) => (
+                  <tr key={user.id} className="transition hover:bg-slate-50/80">
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${roleToneClasses[user.role]}`}>
+                          {user.name.slice(0, 1)}
+                        </div>
+                        <div>
+                          <div className="font-medium text-slate-900">{user.name}</div>
+                          <div className="mt-0.5 text-[11px] text-slate-400">{user.bio}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-slate-500">{user.email}</td>
+                    <td className="px-4 py-3">
+                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${roleBadgeClasses[user.role]}`}>
+                        {roleLabel(user.role)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-slate-500">{user.department}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="space-y-3 p-4 md:hidden">
+          {filteredUsers.length > 0 ? (
+            filteredUsers.map((user) => (
+              <article key={user.id} className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-4">
+                <div className="flex items-start gap-3">
+                  <div className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl text-[13px] font-bold ${roleToneClasses[user.role]}`}>
+                    {user.name.slice(0, 1)}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <div className="text-[14px] font-semibold text-slate-900">{user.name}</div>
+                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${roleBadgeClasses[user.role]}`}>
+                        {roleLabel(user.role)}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-[12px] leading-6 text-slate-500">{user.email}</div>
+                    <div className="text-[12px] leading-6 text-slate-500">{user.department}</div>
+                    <p className="mt-2 text-[12px] leading-6 text-slate-500">{user.bio}</p>
+                  </div>
+                </div>
+              </article>
+            ))
+          ) : (
+            <StatePanel
+              compact
+              icon="ri-search-line"
+              tone="slate"
+              title="조건에 맞는 사용자가 없습니다."
+              description="검색어와 역할 필터를 바꾸면 다른 계정을 다시 찾을 수 있습니다."
+            />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/lms/pages/AssignmentCheckPage.tsx
+++ b/frontend/src/features/lms/pages/AssignmentCheckPage.tsx
@@ -1,27 +1,9 @@
 import { useMemo, useState } from 'react';
 import type { CourseCard } from '@myway/shared';
-import { StatePanel } from '../components/StatePanel';
+import { AssignmentCheckPageSections, type AssignmentItem, type ReviewStatus } from './AssignmentCheckPageSections';
 
 type AssignmentCheckPageProps = {
   courses: CourseCard[];
-};
-
-type ReviewStatus = 'all' | 'pending' | 'reviewed' | 'flagged';
-
-type AssignmentItem = {
-  id: string;
-  course: CourseCard;
-  title: string;
-  status: Exclude<ReviewStatus, 'all'>;
-  score: number;
-  submittedAt: string;
-  feedback: string;
-};
-
-const statusMeta: Record<Exclude<ReviewStatus, 'all'>, { label: string; icon: string; tone: string }> = {
-  pending: { label: '검토 대기', icon: 'ri-time-line', tone: 'bg-amber-50 text-amber-700 border-amber-200' },
-  reviewed: { label: '검토 완료', icon: 'ri-check-double-line', tone: 'bg-emerald-50 text-emerald-600 border-emerald-200' },
-  flagged: { label: '보완 필요', icon: 'ri-alert-line', tone: 'bg-rose-50 text-rose-600 border-rose-200' },
 };
 
 function buildAssignments(courses: CourseCard[]): AssignmentItem[] {
@@ -74,138 +56,13 @@ export function AssignmentCheckPage({ courses }: AssignmentCheckPageProps) {
   );
 
   return (
-    <div className="space-y-6">
-      <section className="overflow-hidden rounded-[32px] border border-cyan-100 bg-[linear-gradient(135deg,#03162a_0%,#005d93_48%,#0bc5ea_100%)] px-6 py-6 text-white shadow-[0_22px_50px_rgba(4,49,84,0.24)] lg:px-8 lg:py-8">
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
-          <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
-              <i className="ri-file-check-line" />
-              과제 검사
-            </div>
-            <h2 className="mt-4 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[32px]">
-              제출 상태, 점수,
-              <br />
-              피드백을 한 번에 정리합니다.
-            </h2>
-            <p className="mt-3 max-w-2xl text-[14px] leading-7 text-white/78">
-              검토 대기, 완료, 보완 필요를 색으로 나눠 빠르게 확인하고, 바로 다음 액션으로 이어갈 수 있습니다.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3 rounded-[28px] border border-white/10 bg-white/10 px-5 py-5 text-white/85 backdrop-blur">
-            <div className="rounded-2xl bg-white/10 px-3 py-3">
-              <div className="text-[11px] text-white/60">검토 대기</div>
-              <div className="mt-1 text-[20px] font-extrabold text-white">{stats.pending}</div>
-            </div>
-            <div className="rounded-2xl bg-white/10 px-3 py-3">
-              <div className="text-[11px] text-white/60">검토 완료</div>
-              <div className="mt-1 text-[20px] font-extrabold text-white">{stats.reviewed}</div>
-            </div>
-            <div className="rounded-2xl bg-white/10 px-3 py-3">
-              <div className="text-[11px] text-white/60">보완 필요</div>
-              <div className="mt-1 text-[20px] font-extrabold text-white">{stats.flagged}</div>
-            </div>
-            <div className="rounded-2xl bg-white/10 px-3 py-3">
-              <div className="text-[11px] text-white/60">평균 점수</div>
-              <div className="mt-1 text-[20px] font-extrabold text-white">{stats.averageScore}</div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
-          <label className="block">
-            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
-            <input
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="과제명, 강의명, 강사명, 피드백 검색"
-              className="h-11 w-full rounded-2xl border border-[#cce0f2] bg-[#f4faff] px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-[#7e94ad] focus:border-cyan-400"
-            />
-          </label>
-
-          <div className="flex flex-wrap gap-2 lg:justify-end">
-            {[
-              { key: 'all', label: '전체' },
-              { key: 'pending', label: '검토 대기' },
-              { key: 'reviewed', label: '검토 완료' },
-              { key: 'flagged', label: '보완 필요' },
-            ].map((item) => {
-              const active = reviewStatus === item.key;
-              return (
-                <button
-                  key={item.key}
-                  type="button"
-                  onClick={() => setReviewStatus(item.key as ReviewStatus)}
-                  className={`rounded-full px-4 py-2 text-[12px] font-semibold transition ${
-                    active
-                      ? 'bg-[linear-gradient(135deg,#00b8e6_0%,#0077b6_100%)] text-white'
-                      : 'border border-[#cce0f2] bg-white text-[#4a6885] hover:border-cyan-300 hover:text-cyan-700'
-                  }`}
-                >
-                  {item.label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      </section>
-
-      <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h3 className="text-[15px] font-bold text-slate-900">과제 목록</h3>
-            <p className="mt-1 text-[12px] text-slate-500">상태별 아이콘과 점수, 제출 시점을 함께 확인합니다.</p>
-          </div>
-          <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">검색 결과 {filteredAssignments.length}개</div>
-        </div>
-
-        <div className="mt-4 space-y-3">
-          {filteredAssignments.length > 0 ? (
-            filteredAssignments.map((item) => {
-              const meta = statusMeta[item.status];
-              return (
-                <article key={item.id} className="rounded-[26px] border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
-                  <div className="flex flex-col gap-4 lg:flex-row lg:items-center">
-                    <div className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl border ${meta.tone} bg-white text-[20px]`}>
-                      <i className={meta.icon} />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <h4 className="text-[14px] font-bold text-slate-900">{item.title}</h4>
-                        <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${meta.tone}`}>{meta.label}</span>
-                      </div>
-                      <div className="mt-1 text-[12px] text-slate-500">
-                        {item.course.category} · {item.course.instructor_name} · {item.course.lecture_count}차시
-                      </div>
-                      <p className="mt-2 text-[12px] leading-6 text-slate-500">{item.feedback}</p>
-                    </div>
-                    <div className="grid gap-2 sm:grid-cols-2 lg:w-[240px] lg:grid-cols-1">
-                      <div className="rounded-2xl bg-white px-4 py-3">
-                        <div className="text-[11px] text-slate-400">점수</div>
-                        <div className="mt-1 text-[18px] font-extrabold text-slate-900">{item.score}</div>
-                      </div>
-                      <div className="rounded-2xl bg-white px-4 py-3">
-                        <div className="text-[11px] text-slate-400">제출 시점</div>
-                        <div className="mt-1 text-[13px] font-semibold text-slate-900">{item.submittedAt}</div>
-                      </div>
-                    </div>
-                  </div>
-                </article>
-              );
-            })
-          ) : (
-            <StatePanel
-              compact
-              icon="ri-search-line"
-              tone="slate"
-              title="조건에 맞는 과제가 없습니다."
-              description="검색어와 상태 필터를 바꾸면 다른 과제를 다시 찾을 수 있습니다."
-            />
-          )}
-        </div>
-      </section>
-    </div>
+    <AssignmentCheckPageSections
+      stats={stats}
+      reviewStatus={reviewStatus}
+      searchQuery={searchQuery}
+      filteredAssignments={filteredAssignments}
+      onReviewStatusChange={setReviewStatus}
+      onSearchQueryChange={setSearchQuery}
+    />
   );
 }

--- a/frontend/src/features/lms/pages/AssignmentCheckPageSections.tsx
+++ b/frontend/src/features/lms/pages/AssignmentCheckPageSections.tsx
@@ -1,0 +1,180 @@
+import type { CourseCard } from '@myway/shared';
+import { StatePanel } from '../components/StatePanel';
+
+export type ReviewStatus = 'all' | 'pending' | 'reviewed' | 'flagged';
+
+export type AssignmentItem = {
+  id: string;
+  course: CourseCard;
+  title: string;
+  status: Exclude<ReviewStatus, 'all'>;
+  score: number;
+  submittedAt: string;
+  feedback: string;
+};
+
+export const statusMeta: Record<Exclude<ReviewStatus, 'all'>, { label: string; icon: string; tone: string }> = {
+  pending: { label: '검토 대기', icon: 'ri-time-line', tone: 'bg-amber-50 text-amber-700 border-amber-200' },
+  reviewed: { label: '검토 완료', icon: 'ri-check-double-line', tone: 'bg-emerald-50 text-emerald-600 border-emerald-200' },
+  flagged: { label: '보완 필요', icon: 'ri-alert-line', tone: 'bg-rose-50 text-rose-600 border-rose-200' },
+};
+
+type AssignmentCheckPageSectionsProps = {
+  stats: {
+    total: number;
+    pending: number;
+    reviewed: number;
+    flagged: number;
+    averageScore: number;
+  };
+  reviewStatus: ReviewStatus;
+  searchQuery: string;
+  filteredAssignments: AssignmentItem[];
+  onReviewStatusChange: (status: ReviewStatus) => void;
+  onSearchQueryChange: (query: string) => void;
+};
+
+export function AssignmentCheckPageSections({
+  stats,
+  reviewStatus,
+  searchQuery,
+  filteredAssignments,
+  onReviewStatusChange,
+  onSearchQueryChange,
+}: AssignmentCheckPageSectionsProps) {
+  return (
+    <div className="space-y-6">
+      <section className="overflow-hidden rounded-[32px] border border-cyan-100 bg-[linear-gradient(135deg,#03162a_0%,#005d93_48%,#0bc5ea_100%)] px-6 py-6 text-white shadow-[0_22px_50px_rgba(4,49,84,0.24)] lg:px-8 lg:py-8">
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white/85 backdrop-blur">
+              <i className="ri-file-check-line" />
+              과제 검사
+            </div>
+            <h2 className="mt-4 text-[26px] font-extrabold tracking-[-0.04em] lg:text-[32px]">
+              제출 상태, 점수,
+              <br />
+              피드백을 한 번에 정리합니다.
+            </h2>
+            <p className="mt-3 max-w-2xl text-[14px] leading-7 text-white/78">
+              검토 대기, 완료, 보완 필요를 색으로 나눠 빠르게 확인하고, 바로 다음 액션으로 이어갈 수 있습니다.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 rounded-[28px] border border-white/10 bg-white/10 px-5 py-5 text-white/85 backdrop-blur">
+            <div className="rounded-2xl bg-white/10 px-3 py-3">
+              <div className="text-[11px] text-white/60">검토 대기</div>
+              <div className="mt-1 text-[20px] font-extrabold text-white">{stats.pending}</div>
+            </div>
+            <div className="rounded-2xl bg-white/10 px-3 py-3">
+              <div className="text-[11px] text-white/60">검토 완료</div>
+              <div className="mt-1 text-[20px] font-extrabold text-white">{stats.reviewed}</div>
+            </div>
+            <div className="rounded-2xl bg-white/10 px-3 py-3">
+              <div className="text-[11px] text-white/60">보완 필요</div>
+              <div className="mt-1 text-[20px] font-extrabold text-white">{stats.flagged}</div>
+            </div>
+            <div className="rounded-2xl bg-white/10 px-3 py-3">
+              <div className="text-[11px] text-white/60">평균 점수</div>
+              <div className="mt-1 text-[20px] font-extrabold text-white">{stats.averageScore}</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
+          <label className="block">
+            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-400">검색</span>
+            <input
+              value={searchQuery}
+              onChange={(event) => onSearchQueryChange(event.target.value)}
+              placeholder="과제명, 강의명, 강사명, 피드백 검색"
+              className="h-11 w-full rounded-2xl border border-[#cce0f2] bg-[#f4faff] px-4 text-[13px] text-slate-900 outline-none transition placeholder:text-[#7e94ad] focus:border-cyan-400"
+            />
+          </label>
+
+          <div className="flex flex-wrap gap-2 lg:justify-end">
+            {[
+              { key: 'all', label: '전체' },
+              { key: 'pending', label: '검토 대기' },
+              { key: 'reviewed', label: '검토 완료' },
+              { key: 'flagged', label: '보완 필요' },
+            ].map((item) => {
+              const active = reviewStatus === item.key;
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => onReviewStatusChange(item.key as ReviewStatus)}
+                  className={`rounded-full px-4 py-2 text-[12px] font-semibold transition ${
+                    active
+                      ? 'bg-[linear-gradient(135deg,#00b8e6_0%,#0077b6_100%)] text-white'
+                      : 'border border-[#cce0f2] bg-white text-[#4a6885] hover:border-cyan-300 hover:text-cyan-700'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[30px] border border-[#d6e6f5] bg-white px-5 py-5 shadow-[0_14px_30px_rgba(6,31,57,0.08)]">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-[15px] font-bold text-slate-900">과제 목록</h3>
+            <p className="mt-1 text-[12px] text-slate-500">상태별 아이콘과 점수, 제출 시점을 함께 확인합니다.</p>
+          </div>
+          <div className="rounded-full bg-cyan-50 px-3 py-1 text-[11px] font-semibold text-cyan-700">검색 결과 {filteredAssignments.length}개</div>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          {filteredAssignments.length > 0 ? (
+            filteredAssignments.map((item) => {
+              const meta = statusMeta[item.status];
+              return (
+                <article key={item.id} className="rounded-[26px] border border-[#dce9f7] bg-[#f4faff] px-4 py-4">
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-center">
+                    <div className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl border ${meta.tone} bg-white text-[20px]`}>
+                      <i className={meta.icon} />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h4 className="text-[14px] font-bold text-slate-900">{item.title}</h4>
+                        <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${meta.tone}`}>{meta.label}</span>
+                      </div>
+                      <div className="mt-1 text-[12px] text-slate-500">
+                        {item.course.category} · {item.course.instructor_name} · {item.course.lecture_count}차시
+                      </div>
+                      <p className="mt-2 text-[12px] leading-6 text-slate-500">{item.feedback}</p>
+                    </div>
+                    <div className="grid gap-2 sm:grid-cols-2 lg:w-[240px] lg:grid-cols-1">
+                      <div className="rounded-2xl bg-white px-4 py-3">
+                        <div className="text-[11px] text-slate-400">점수</div>
+                        <div className="mt-1 text-[18px] font-extrabold text-slate-900">{item.score}</div>
+                      </div>
+                      <div className="rounded-2xl bg-white px-4 py-3">
+                        <div className="text-[11px] text-slate-400">제출 시점</div>
+                        <div className="mt-1 text-[13px] font-semibold text-slate-900">{item.submittedAt}</div>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              );
+            })
+          ) : (
+            <StatePanel
+              compact
+              icon="ri-search-line"
+              tone="slate"
+              title="조건에 맞는 과제가 없습니다."
+              description="검색어와 상태 필터를 바꾸면 다른 과제를 다시 찾을 수 있습니다."
+            />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/lms/pages/LectureStudioPage.tsx
+++ b/frontend/src/features/lms/pages/LectureStudioPage.tsx
@@ -1,23 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { CourseCard, CourseDetail, Lecture, LectureDetail, LectureStudioDraftSummary } from '@myway/shared';
-import {
-  createAudioExtractionDetailed,
-  loadLectureStudioDraft,
-  loadLectureStudioDrafts,
-  publishLectureStudioDraft,
-  saveLectureStudioDraft,
-  updateLectureStudioDraft,
-} from '../../../lib/api';
-import { queryKeys } from '../../../lib/query-keys';
-import {
-  buildLectureStudioDraft,
-  buildLectureStudioDraftFromRecord,
-  toLectureStudioDraftInput,
-  type LectureStudioDraft,
-} from '../components/lecture-studio/types';
-import { demoCourseDetail, demoLectureDetail } from '../data/demo';
+import type { CourseCard, CourseDetail, Lecture, LectureDetail } from '@myway/shared';
 import { LectureStudioPageHero, LectureStudioPageWorkspace } from './LectureStudioPageSections';
+import { useLectureStudioPageFlow } from './useLectureStudioPageFlow';
 
 type LectureStudioPageProps = {
   courses: CourseCard[];
@@ -27,173 +10,18 @@ type LectureStudioPageProps = {
 };
 
 export function LectureStudioPage({ courses, selectedCourse, highlightedLecture, onSelectCourse }: LectureStudioPageProps) {
-  const queryClient = useQueryClient();
-  const activeCourse = selectedCourse ?? demoCourseDetail;
-  const activeLecture = highlightedLecture ?? demoLectureDetail;
-  const demoMode = !selectedCourse;
-  const [draft, setDraft] = useState<LectureStudioDraft>(() => buildLectureStudioDraft(activeCourse, activeLecture));
-  const [statusNote, setStatusNote] = useState('수강 인원, 강의실, 평가 방식, AI 보조 옵션을 단계적으로 채워보세요.');
-  const [draftId, setDraftId] = useState<string | null>(null);
-  const [draftSummaries, setDraftSummaries] = useState<LectureStudioDraftSummary[]>([]);
-
-  const previewLecture = useMemo(() => activeLecture ?? activeCourse.lectures[0] ?? null, [activeCourse, activeLecture]);
-  const outlineCount = draft.outlineText.split(/\r?\n/).filter(Boolean).length;
-  const materialCount = draft.materialsText.split(/\r?\n/).filter(Boolean).length;
-  const selectedCourseId = selectedCourse?.id ?? '';
-
-  const draftsQuery = useQuery({
-    queryKey: queryKeys.learning.drafts(selectedCourseId),
-    queryFn: () => loadLectureStudioDrafts(selectedCourseId),
-    enabled: !demoMode && !!selectedCourseId,
-  });
-
-  const matchedSummary = useMemo(() => {
-    if (demoMode || !selectedCourse) {
-      return null;
-    }
-    const lectureId = previewLecture?.id ?? selectedCourse.lectures[0]?.id ?? null;
-    if (!lectureId || !draftsQuery.data) {
-      return null;
-    }
-    return draftsQuery.data.find((item) => item.lecture_id === lectureId) ?? null;
-  }, [demoMode, draftsQuery.data, previewLecture?.id, selectedCourse]);
-
-  const draftDetailQuery = useQuery({
-    queryKey: queryKeys.learning.draftDetail(selectedCourseId, matchedSummary?.id ?? ''),
-    queryFn: () => loadLectureStudioDraft(selectedCourseId, matchedSummary!.id),
-    enabled: !demoMode && !!selectedCourseId && !!matchedSummary?.id,
-  });
-
-  useEffect(() => {
-    if (demoMode) {
-      setDraft(buildLectureStudioDraft(activeCourse, activeLecture));
-      setDraftId(null);
-      setDraftSummaries([]);
-      setStatusNote('데모 데이터로 강의 제작 스튜디오를 미리 보여주고 있습니다. 실제 저장은 강의 선택 후 가능합니다.');
-      return;
-    }
-
-    if (!selectedCourse) {
-      return;
-    }
-
-    setDraft(buildLectureStudioDraft(selectedCourse, highlightedLecture));
-    setDraftId(null);
-    setStatusNote(`${selectedCourse.title} 기준 강의 제작 초안을 불러오는 중입니다.`);
-  }, [activeCourse, activeLecture, demoMode, highlightedLecture, selectedCourse]);
-
-  useEffect(() => {
-    if (demoMode || !selectedCourse || draftsQuery.isLoading) {
-      return;
-    }
-
-    const summaries = draftsQuery.data ?? [];
-    setDraftSummaries(summaries);
-
-    if (!matchedSummary) {
-      setStatusNote(
-        summaries.length > 0
-          ? `${selectedCourse.title}에 초안 ${summaries.length}개가 있습니다. 새 초안을 바로 시작할 수 있습니다.`
-          : `${selectedCourse.title} 기준 새 초안을 시작합니다.`,
-      );
-    }
-  }, [demoMode, draftsQuery.data, draftsQuery.isLoading, matchedSummary, selectedCourse]);
-
-  useEffect(() => {
-    if (demoMode || !draftDetailQuery.data) {
-      return;
-    }
-    const record = draftDetailQuery.data;
-    setDraft(buildLectureStudioDraftFromRecord(record));
-    setDraftId(record.id);
-    setStatusNote(`${record.lecture_title} 초안을 불러왔습니다. 저장이나 발행 준비를 이어갈 수 있습니다.`);
-  }, [demoMode, draftDetailQuery.data]);
-
-  async function persistDraft() {
-    if (demoMode || !selectedCourse || !previewLecture) {
-      setStatusNote('저장할 강의와 차시를 먼저 선택해 주세요.');
-      return null;
-    }
-
-    const input = toLectureStudioDraftInput(draft, previewLecture.id);
-    const record = draftId
-      ? await updateLectureStudioDraft(selectedCourse, draftId, previewLecture, input)
-      : await saveLectureStudioDraft(selectedCourse, previewLecture, input);
-
-    if (!record) {
-      setStatusNote('초안 저장에 실패했습니다. 다시 시도해 주세요.');
-      return null;
-    }
-
-    setDraftId(record.id);
-    setDraft(buildLectureStudioDraftFromRecord(record));
-    return record;
-  }
-
-  async function startMediaPipelineAfterPublish(publishedTitle: string, lecture: LectureDetail | Lecture | null) {
-    if (!lecture || !('video_url' in lecture) || !lecture.video_url) {
-      setStatusNote(`${publishedTitle}은 발행 준비까지 완료했습니다. 영상 소스가 없어 미디어 파이프라인 자동 시작은 건너뜁니다.`);
-      return;
-    }
-
-    setStatusNote(`${publishedTitle} 발행 후 영상 기반 미디어 파이프라인을 자동 시작합니다.`);
-
-    const extraction = await createAudioExtractionDetailed(
-      {
-        lecture_id: lecture.id,
-        video_url: lecture.video_url,
-        source_file_name: `${lecture.title}.mp4`,
-        source_content_type: 'video/mp4',
-        language: 'ko',
-      },
-    );
-
-    if (!extraction?.success) {
-      setStatusNote(`${publishedTitle} 발행은 완료했지만 미디어 파이프라인 자동 시작은 실패했습니다. 제작 스튜디오에서 다시 시도할 수 있습니다.`);
-      return;
-    }
-
-    setStatusNote(`${publishedTitle} 발행 후 미디어 파이프라인을 자동 시작했습니다.`);
-  }
-
-  const handleSaveDraft = () => {
-    void (async () => {
-      const record = await persistDraft();
-      if (!record) {
-        return;
-      }
-
-      setDraft((current) => ({ ...current, reviewState: 'review' }));
-      setStatusNote(`${record.title} 초안을 저장하고 검토 상태로 전환했습니다.`);
-    })();
-  };
-
-  const publishDraftMutation = useMutation({
-    mutationFn: ({ courseId, targetDraftId }: { courseId: string; targetDraftId: string }) =>
-      publishLectureStudioDraft(courseId, targetDraftId),
-  });
-
-  const handleMarkReady = () => {
-    void (async () => {
-      const record = await persistDraft();
-      if (!record) {
-        return;
-      }
-
-      const published = await publishDraftMutation.mutateAsync({ courseId: record.course_id, targetDraftId: record.id });
-      if (!published) {
-        setStatusNote('발행 준비 상태로 전환하지 못했습니다. 다시 시도해 주세요.');
-        return;
-      }
-
-      setDraftId(published.id);
-      setDraft(buildLectureStudioDraftFromRecord(published));
-      await queryClient.invalidateQueries({ queryKey: queryKeys.learning.drafts(record.course_id) });
-      await queryClient.invalidateQueries({ queryKey: queryKeys.learning.draftDetail(record.course_id, published.id) });
-      setStatusNote(`${published.title} 초안을 발행 준비 상태로 전환했습니다.`);
-      void startMediaPipelineAfterPublish(published.title, previewLecture);
-    })();
-  };
+  const {
+    activeCourse,
+    draft,
+    setDraft,
+    statusNote,
+    draftSummaries,
+    previewLecture,
+    outlineCount,
+    materialCount,
+    handleSaveDraft,
+    handleMarkReady,
+  } = useLectureStudioPageFlow({ selectedCourse, highlightedLecture });
 
   return (
     <div className="space-y-5">
@@ -207,7 +35,7 @@ export function LectureStudioPage({ courses, selectedCourse, highlightedLecture,
       />
 
       <LectureStudioPageWorkspace
-        courses={courses.length > 0 ? courses : [demoCourseDetail]}
+        courses={courses.length > 0 ? courses : [activeCourse]}
         activeCourse={activeCourse}
         previewLecture={previewLecture}
         draft={draft}

--- a/frontend/src/features/lms/pages/useLectureStudioPageFlow.ts
+++ b/frontend/src/features/lms/pages/useLectureStudioPageFlow.ts
@@ -1,0 +1,205 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CourseDetail, Lecture, LectureDetail, LectureStudioDraftSummary } from '@myway/shared';
+import {
+  createAudioExtractionDetailed,
+  loadLectureStudioDraft,
+  loadLectureStudioDrafts,
+  publishLectureStudioDraft,
+  saveLectureStudioDraft,
+  updateLectureStudioDraft,
+} from '../../../lib/api';
+import { queryKeys } from '../../../lib/query-keys';
+import {
+  buildLectureStudioDraft,
+  buildLectureStudioDraftFromRecord,
+  toLectureStudioDraftInput,
+  type LectureStudioDraft,
+} from '../components/lecture-studio/types';
+import { demoCourseDetail, demoLectureDetail } from '../data/demo';
+
+type LectureStudioPageFlowArgs = {
+  selectedCourse: CourseDetail | null;
+  highlightedLecture: LectureDetail | Lecture | null;
+};
+
+export function useLectureStudioPageFlow({ selectedCourse, highlightedLecture }: LectureStudioPageFlowArgs) {
+  const queryClient = useQueryClient();
+  const activeCourse = selectedCourse ?? demoCourseDetail;
+  const activeLecture = highlightedLecture ?? demoLectureDetail;
+  const demoMode = !selectedCourse;
+  const [draft, setDraft] = useState<LectureStudioDraft>(() => buildLectureStudioDraft(activeCourse, activeLecture));
+  const [statusNote, setStatusNote] = useState('수강 인원, 강의실, 평가 방식, AI 보조 옵션을 단계적으로 채워보세요.');
+  const [draftId, setDraftId] = useState<string | null>(null);
+  const [draftSummaries, setDraftSummaries] = useState<LectureStudioDraftSummary[]>([]);
+
+  const previewLecture = useMemo(() => activeLecture ?? activeCourse.lectures[0] ?? null, [activeCourse, activeLecture]);
+  const outlineCount = draft.outlineText.split(/\r?\n/).filter(Boolean).length;
+  const materialCount = draft.materialsText.split(/\r?\n/).filter(Boolean).length;
+  const selectedCourseId = selectedCourse?.id ?? '';
+
+  const draftsQuery = useQuery({
+    queryKey: queryKeys.learning.drafts(selectedCourseId),
+    queryFn: () => loadLectureStudioDrafts(selectedCourseId),
+    enabled: !demoMode && !!selectedCourseId,
+  });
+
+  const matchedSummary = useMemo(() => {
+    if (demoMode || !selectedCourse) {
+      return null;
+    }
+    const lectureId = previewLecture?.id ?? selectedCourse.lectures[0]?.id ?? null;
+    if (!lectureId || !draftsQuery.data) {
+      return null;
+    }
+    return draftsQuery.data.find((item) => item.lecture_id === lectureId) ?? null;
+  }, [demoMode, draftsQuery.data, previewLecture?.id, selectedCourse]);
+
+  const draftDetailQuery = useQuery({
+    queryKey: queryKeys.learning.draftDetail(selectedCourseId, matchedSummary?.id ?? ''),
+    queryFn: () => loadLectureStudioDraft(selectedCourseId, matchedSummary!.id),
+    enabled: !demoMode && !!selectedCourseId && !!matchedSummary?.id,
+  });
+
+  useEffect(() => {
+    if (demoMode) {
+      setDraft(buildLectureStudioDraft(activeCourse, activeLecture));
+      setDraftId(null);
+      setDraftSummaries([]);
+      setStatusNote('데모 데이터로 강의 제작 스튜디오를 미리 보여주고 있습니다. 실제 저장은 강의 선택 후 가능합니다.');
+      return;
+    }
+
+    if (!selectedCourse) {
+      return;
+    }
+
+    setDraft(buildLectureStudioDraft(selectedCourse, highlightedLecture));
+    setDraftId(null);
+    setStatusNote(`${selectedCourse.title} 기준 강의 제작 초안을 불러오는 중입니다.`);
+  }, [activeCourse, activeLecture, demoMode, highlightedLecture, selectedCourse]);
+
+  useEffect(() => {
+    if (demoMode || !selectedCourse || draftsQuery.isLoading) {
+      return;
+    }
+
+    const summaries = draftsQuery.data ?? [];
+    setDraftSummaries(summaries);
+
+    if (!matchedSummary) {
+      setStatusNote(
+        summaries.length > 0
+          ? `${selectedCourse.title}에 초안 ${summaries.length}개가 있습니다. 새 초안을 바로 시작할 수 있습니다.`
+          : `${selectedCourse.title} 기준 새 초안을 시작합니다.`,
+      );
+    }
+  }, [demoMode, draftsQuery.data, draftsQuery.isLoading, matchedSummary, selectedCourse]);
+
+  useEffect(() => {
+    if (demoMode || !draftDetailQuery.data) {
+      return;
+    }
+    const record = draftDetailQuery.data;
+    setDraft(buildLectureStudioDraftFromRecord(record));
+    setDraftId(record.id);
+    setStatusNote(`${record.lecture_title} 초안을 불러왔습니다. 저장이나 발행 준비를 이어갈 수 있습니다.`);
+  }, [demoMode, draftDetailQuery.data]);
+
+  async function persistDraft() {
+    if (demoMode || !selectedCourse || !previewLecture) {
+      setStatusNote('저장할 강의와 차시를 먼저 선택해 주세요.');
+      return null;
+    }
+
+    const input = toLectureStudioDraftInput(draft, previewLecture.id);
+    const record = draftId
+      ? await updateLectureStudioDraft(selectedCourse, draftId, previewLecture, input)
+      : await saveLectureStudioDraft(selectedCourse, previewLecture, input);
+
+    if (!record) {
+      setStatusNote('초안 저장에 실패했습니다. 다시 시도해 주세요.');
+      return null;
+    }
+
+    setDraftId(record.id);
+    setDraft(buildLectureStudioDraftFromRecord(record));
+    return record;
+  }
+
+  async function startMediaPipelineAfterPublish(publishedTitle: string, lecture: LectureDetail | Lecture | null) {
+    if (!lecture || !('video_url' in lecture) || !lecture.video_url) {
+      setStatusNote(`${publishedTitle}은 발행 준비까지 완료했습니다. 영상 소스가 없어 미디어 파이프라인 자동 시작은 건너뜁니다.`);
+      return;
+    }
+
+    setStatusNote(`${publishedTitle} 발행 후 영상 기반 미디어 파이프라인을 자동 시작합니다.`);
+
+    const extraction = await createAudioExtractionDetailed({
+      lecture_id: lecture.id,
+      video_url: lecture.video_url,
+      source_file_name: `${lecture.title}.mp4`,
+      source_content_type: 'video/mp4',
+      language: 'ko',
+    });
+
+    if (!extraction?.success) {
+      setStatusNote(`${publishedTitle} 발행은 완료했지만 미디어 파이프라인 자동 시작은 실패했습니다. 제작 스튜디오에서 다시 시도할 수 있습니다.`);
+      return;
+    }
+
+    setStatusNote(`${publishedTitle} 발행 후 미디어 파이프라인을 자동 시작했습니다.`);
+  }
+
+  const handleSaveDraft = () => {
+    void (async () => {
+      const record = await persistDraft();
+      if (!record) {
+        return;
+      }
+
+      setDraft((current) => ({ ...current, reviewState: 'review' }));
+      setStatusNote(`${record.title} 초안을 저장하고 검토 상태로 전환했습니다.`);
+    })();
+  };
+
+  const publishDraftMutation = useMutation({
+    mutationFn: ({ courseId, targetDraftId }: { courseId: string; targetDraftId: string }) =>
+      publishLectureStudioDraft(courseId, targetDraftId),
+  });
+
+  const handleMarkReady = () => {
+    void (async () => {
+      const record = await persistDraft();
+      if (!record) {
+        return;
+      }
+
+      const published = await publishDraftMutation.mutateAsync({ courseId: record.course_id, targetDraftId: record.id });
+      if (!published) {
+        setStatusNote('발행 준비 상태로 전환하지 못했습니다. 다시 시도해 주세요.');
+        return;
+      }
+
+      setDraftId(published.id);
+      setDraft(buildLectureStudioDraftFromRecord(published));
+      await queryClient.invalidateQueries({ queryKey: queryKeys.learning.drafts(record.course_id) });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.learning.draftDetail(record.course_id, published.id) });
+      setStatusNote(`${published.title} 초안을 발행 준비 상태로 전환했습니다.`);
+      void startMediaPipelineAfterPublish(published.title, previewLecture);
+    })();
+  };
+
+  return {
+    activeCourse,
+    draft,
+    setDraft,
+    statusNote,
+    draftSummaries,
+    previewLecture,
+    outlineCount,
+    materialCount,
+    handleSaveDraft,
+    handleMarkReady,
+  };
+}


### PR DESCRIPTION
## 변경 요약
프론트 공통 UI와 대형 섹션 컴포넌트를 추가로 분리해 원본 파일을 조립기 수준으로 더 얇게 정리했습니다.

## 변경 내용
- AssignmentCheckPage, AdminUsersPage, LectureStudioPage를 상태/렌더 분리
- ShortformWizardStep3를 preview/meta/actions/utils 단위로 분리
- MediaPipelineBoard 상세 패널을 별도 파일로 분리하고 reexport 정리
- dev log 추가

## 검증
- 
pm run verify 통과
- build:frontend / test:backend 통과
