### PR TITLE
fix: harden ai request and dispatch parsing

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/AiRequestSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/AiRequestSupport.java
@@ -110,7 +110,6 @@ public class AiRequestSupport {
         ));
     }
 
-    @SuppressWarnings("unchecked")
     private List<Map<String, Object>> extractChunkList(Map<String, Object> ragPayload) {
         if (ragPayload == null || ragPayload.isEmpty()) {
             return List.of();
@@ -118,8 +117,8 @@ public class AiRequestSupport {
         Object chunks = ragPayload.get("chunks");
         if (chunks instanceof List<?> list) {
             return list.stream()
-                    .filter(Map.class::isInstance)
-                    .map(item -> (Map<String, Object>) item)
+                .filter(Map.class::isInstance)
+                    .map(this::copyMap)
                     .toList();
         }
         Object search = ragPayload.get("search");
@@ -128,11 +127,24 @@ public class AiRequestSupport {
             if (hits instanceof List<?> list) {
                 return list.stream()
                         .filter(Map.class::isInstance)
-                        .map(item -> (Map<String, Object>) item)
+                        .map(this::copyMap)
                         .toList();
             }
         }
         return List.of();
+    }
+
+    private Map<String, Object> copyMap(Object value) {
+        if (!(value instanceof Map<?, ?> raw)) {
+            return Map.of();
+        }
+        Map<String, Object> copy = new HashMap<>();
+        for (Map.Entry<?, ?> entry : raw.entrySet()) {
+            if (entry.getKey() != null) {
+                copy.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+        }
+        return copy;
     }
 
     private int asInt(Object value) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaProcessingDispatchSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/media/MediaProcessingDispatchSupport.java
@@ -9,6 +9,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 public class MediaProcessingDispatchSupport {
@@ -54,16 +55,31 @@ public class MediaProcessingDispatchSupport {
     }
 
     DispatchResponse parseDispatchResponse(ObjectMapper objectMapper, String responseBody) throws Exception {
-        Map<String, Object> payload = objectMapper.readValue(responseBody, Map.class);
+        Map<String, Object> payload = objectMapper.readValue(
+                responseBody,
+                objectMapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class)
+        );
         String jobId = payload.get("job_id") == null ? null : String.valueOf(payload.get("job_id"));
         String status = payload.get("status") == null ? null : String.valueOf(payload.get("status"));
         return new DispatchResponse(jobId, status);
     }
 
     RemoteHealth parseRemoteHealth(ObjectMapper objectMapper, String responseBody) throws Exception {
-        Map<String, Object> payload = objectMapper.readValue(responseBody, Map.class);
+        Map<String, Object> payload = objectMapper.readValue(
+                responseBody,
+                objectMapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class)
+        );
         boolean ok = Boolean.TRUE.equals(payload.getOrDefault("ok", false));
-        Map<String, Object> ffmpeg = payload.get("ffmpeg") instanceof Map<?, ?> map ? (Map<String, Object>) map : Map.of("available", false, "path", "unknown");
+        Map<String, Object> ffmpeg = payload.get("ffmpeg") instanceof Map<?, ?> map
+                ? map.entrySet().stream()
+                .filter(entry -> entry.getKey() != null)
+                .collect(Collectors.toMap(
+                        entry -> String.valueOf(entry.getKey()),
+                        Map.Entry::getValue,
+                        (left, right) -> right,
+                        HashMap::new
+                ))
+                : Map.of("available", false, "path", "unknown");
         return new RemoteHealth(ok, ffmpeg);
     }
 


### PR DESCRIPTION
# 변경 요약
AI request/dispatch payload parsing을 null-safe하게 고쳤습니다.

## 배경
RAG 및 원격 health/dispatch 응답에서 느슨한 `Map` 경계가 있어, 예외적인 payload가 들어오면 런타임 캐스팅 또는 NPE가 발생할 수 있었습니다.

## 변경 내용
- `AiRequestSupport.extractChunkList()`에서 chunk/hits를 안전하게 복사하도록 변경했습니다.
- `MediaProcessingDispatchSupport`에서 JSON payload를 타입 있는 `Map<String, Object>`로 읽고, `ffmpeg` 서브맵을 안전하게 복사하도록 바꿨습니다.

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [ ] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [ ] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [ ] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [x] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [ ] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [ ] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [ ] 관련 문서가 함께 갱신됐다
- [ ] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [ ] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [ ] 이벤트 메타/멱등 규칙 준수
- [ ] Query key 중앙화 및 invalidate 대상 명시
- [ ] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `mvnw.cmd -q -DskipTests compile` 통과
- layer tests: `mvnw.cmd -q -Dtest=MediaContractTest,AdminEndpointMigrationIntegrationTest test` 통과
- risk/rollback: `AiRequestSupport`와 `MediaProcessingDispatchSupport`의 변경만 되돌리면 복구 가능

## ADR 링크
- ADR: `docs/decisions/ADR-xxxx-*.md`
- 상태 변경: `Proposed -> Accepted` 또는 `Accepted -> Superseded` (해당 시 기입)
