### PR TITLE
refactor: split ai chat and public home state

### DIFF
--- a/docs/dev-logs/2026-06-06-frontend-ai-chat-public-home-split-bundle-v8.md
+++ b/docs/dev-logs/2026-06-06-frontend-ai-chat-public-home-split-bundle-v8.md
@@ -1,0 +1,18 @@
+# Frontend AI Chat / Public Home Split Bundle v8
+
+## 범위
+- `AIChatPage` 상태/전송 로직을 `useAIChatPageState`로 분리
+- `PublicHomePage` 검색/필터/집계 로직을 `usePublicHomePageState`로 분리
+
+## 결과
+- `frontend/src/features/lms/pages/AIChatPage.tsx` 63줄
+- `frontend/src/features/lms/pages/PublicHomePage.tsx` 126줄
+- `frontend/src/features/lms/pages/useAIChatPageState.ts` 163줄
+- `frontend/src/features/lms/pages/usePublicHomePageState.ts` 85줄
+
+## 검증
+- `npm run build:frontend`
+- `npm run verify`
+
+## 비고
+- UI 조립 파일은 얇게 유지하고, 데이터 가공과 비동기 요청은 훅으로 이동해 다음 분리의 기준을 낮췄다.

--- a/frontend/src/features/lms/pages/AIChatPage.tsx
+++ b/frontend/src/features/lms/pages/AIChatPage.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
-import type { AIRagResult, AIInsights, LectureDetail, SmartChatResult } from '@myway/shared';
-import { loadAIRAGOverview } from '../../../lib/ai-rag';
-import { sendSmartChatDetailed } from '../../../lib/api';
-import { getAiErrorMessage, getPublicTestPolicyText, getQuotaStatusText } from '../../../lib/ai-access';
-import { type AIChatMessage } from '../components/AIChatThread';
+import type { AIInsights, LectureDetail } from '@myway/shared';
 import { AIChatPageConversation, AIChatPageHero } from './AIChatPageSections';
+import { useAIChatPageState } from './useAIChatPageState';
 
 type AIChatPageProps = {
   highlightedLecture: LectureDetail | null;
@@ -14,139 +10,23 @@ type AIChatPageProps = {
   sessionToken?: string | null;
 };
 
-function createWelcomeMessage(highlightedLecture: LectureDetail | null): AIChatMessage {
-  return {
-    id: `welcome-${highlightedLecture?.id ?? 'general'}`,
-    role: 'assistant',
-    content: highlightedLecture
-      ? `${highlightedLecture.title} 기준으로 질문을 이어갈 수 있습니다. 핵심 개념, 요약, 퀴즈 중 하나로 시작해보세요.`
-      : '강의를 선택하면 더 정확한 질문과 답변을 받을 수 있습니다.',
-    suggestions: ['핵심 개념 요약', '시험 대비 문제', '숏폼으로 복습', '이전 강의와 연결'],
-  };
-}
-
-function mapSmartChatResult(result: SmartChatResult): AIChatMessage {
-  return {
-    id: `assistant-${Date.now()}`,
-    role: 'assistant',
-    content: result.answer,
-    references: result.references,
-    suggestions: result.suggestions,
-    intent: result.intent,
-  };
-}
-
 export function AIChatPage({ highlightedLecture, insights, selectedCourse, canManageCurrent, sessionToken }: AIChatPageProps) {
-  const [ragOverview, setRagOverview] = useState<AIRagResult | null>(null);
-  const [ragLoading, setRagLoading] = useState(false);
-  const [messages, setMessages] = useState<AIChatMessage[]>(() => [createWelcomeMessage(null)]);
-  const [input, setInput] = useState('');
-  const [sending, setSending] = useState(false);
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [bannerTitle, setBannerTitle] = useState('공개 테스트 안내');
-  const [bannerDescription, setBannerDescription] = useState(getPublicTestPolicyText('chat'));
-  const [bannerMeta, setBannerMeta] = useState<string | null>(null);
-  const isLocked = Boolean(selectedCourse && !selectedCourse.enrolled && !canManageCurrent);
-
-  useEffect(() => {
-    setMessages([createWelcomeMessage(highlightedLecture)]);
-    setSidebarOpen(false);
-  }, [highlightedLecture?.id, highlightedLecture?.title]);
-
-  useEffect(() => {
-    let alive = true;
-    setBannerTitle('공개 테스트 안내');
-    setBannerDescription(getPublicTestPolicyText('chat'));
-    setBannerMeta(null);
-
-    if (isLocked || !highlightedLecture) {
-      setRagOverview(null);
-      setRagLoading(false);
-      return undefined;
-    }
-
-    setRagLoading(true);
-    loadAIRAGOverview({
-      query: `${highlightedLecture.title}의 핵심을 근거와 함께 정리해줘`,
-      lecture_id: highlightedLecture.id,
-      limit: 4,
-    })
-      .then((result) => {
-        if (alive) {
-          setRagOverview(result);
-        }
-      })
-      .finally(() => {
-        if (alive) {
-          setRagLoading(false);
-        }
-      });
-
-    return () => {
-      alive = false;
-    };
-  }, [highlightedLecture?.id, highlightedLecture?.title, isLocked]);
-
-  const quickPrompts = useMemo(
-    () => ['핵심 개념 요약', '시험 대비 문제', '이전 강의와 연결', '숏폼으로 복습'],
-    [],
-  );
-
-  async function handleSubmit(messageText = input) {
-    const message = messageText.trim();
-    if (!message || sending) {
-      return;
-    }
-
-    setInput('');
-    setSending(true);
-    setMessages((current) => [
-      ...current,
-      {
-        id: `user-${Date.now()}`,
-        role: 'user',
-        content: message,
-      },
-    ]);
-
-    try {
-      const result = await sendSmartChatDetailed(
-        {
-          message,
-          lecture_id: highlightedLecture?.id ?? undefined,
-          course_id: undefined,
-          context: highlightedLecture ? [highlightedLecture.title] : undefined,
-        },
-        sessionToken,
-      );
-
-      if (result?.success && result.data) {
-        setBannerTitle('AI 요청 상태');
-        setBannerDescription('요청이 정상 처리되었습니다. 남은 사용량은 화면 우측 배너에서 확인할 수 있습니다.');
-        setBannerMeta(getQuotaStatusText(result) ?? '사용량 정보 없음');
-      } else {
-        setBannerTitle('요청 제한 안내');
-        setBannerDescription(getAiErrorMessage(result, 'AI 채팅을 처리할 수 없습니다.'));
-        setBannerMeta(getQuotaStatusText(result));
-      }
-
-      setMessages((current) => [
-        ...current,
-        result && result.success && result.data
-          ? mapSmartChatResult(result.data)
-          : {
-              id: `fallback-${Date.now()}`,
-              role: 'assistant',
-              content: highlightedLecture
-                ? `${highlightedLecture.title} 기준으로 정리하면 핵심 개념부터 요약해볼 수 있습니다.`
-                : '질문을 다시 입력해보세요.',
-              suggestions: quickPrompts,
-            },
-      ]);
-    } finally {
-      setSending(false);
-    }
-  }
+  const {
+    ragOverview,
+    ragLoading,
+    messages,
+    input,
+    sending,
+    sidebarOpen,
+    bannerTitle,
+    bannerDescription,
+    bannerMeta,
+    isLocked,
+    quickPrompts,
+    setInput,
+    setSidebarOpen,
+    handleSubmit,
+  } = useAIChatPageState({ highlightedLecture, insights, selectedCourse, canManageCurrent, sessionToken });
 
   return (
     <div className="space-y-5">

--- a/frontend/src/features/lms/pages/PublicHomePage.tsx
+++ b/frontend/src/features/lms/pages/PublicHomePage.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useRef, useState } from 'react';
 import type { CourseCard } from '@myway/shared';
 import { PublicHomeCourseSection, PublicHomeHeroSection } from './PublicHomePageSections';
+import { usePublicHomePageState } from './usePublicHomePageState';
 
 type PublicHomePageProps = {
   courseCards: CourseCard[];
@@ -16,64 +16,25 @@ const navItems = [
   { label: '커뮤니티', icon: 'ri-group-line' },
 ];
 
-function countUnique(values: string[]): number {
-  return new Set(values).size;
-}
-
-function scrollToElement(element: HTMLElement | null) {
-  element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-}
-
 export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePageProps) {
-  const coursesRef = useRef<HTMLElement | null>(null);
-  const roadmapRef = useRef<HTMLElement | null>(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [activeCategory, setActiveCategory] = useState('');
-  const [activeStatus, setActiveStatus] = useState<'all' | 'available' | 'enrolled'>('all');
-
-  const categories = useMemo(() => [...new Set(courseCards.map((item) => item.category))], [courseCards]);
-
-  const filteredCourses = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-
-    return courseCards.filter((course) => {
-      const tags = Array.isArray(course.tags) ? course.tags : [];
-      const queryMatch = query
-        ? [course.title, course.description, course.category, course.instructor_name, ...tags].join(' ').toLowerCase().includes(query)
-        : true;
-      const categoryMatch = activeCategory ? course.category === activeCategory : true;
-      const statusMatch =
-        activeStatus === 'all'
-          ? true
-          : activeStatus === 'available'
-            ? !course.enrolled
-            : course.enrolled;
-
-      return queryMatch && categoryMatch && statusMatch;
-    });
-  }, [activeCategory, activeStatus, courseCards, searchQuery]);
-
-  const featuredCourses = filteredCourses.slice(0, 5);
-  const featuredTags = useMemo(() => {
-    const counts = new Map<string, number>();
-
-    courseCards.forEach((course) => {
-      const tags = Array.isArray(course.tags) ? course.tags : [];
-      tags.forEach((tag) => {
-        counts.set(tag, (counts.get(tag) ?? 0) + 1);
-      });
-    });
-
-    return [...counts.entries()]
-      .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
-      .slice(0, 6)
-      .map(([tag]) => tag);
-  }, [courseCards]);
-
-  const totalProgress = Math.round(
-    courseCards.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courseCards.length, 1),
-  );
-  const tagCount = countUnique(courseCards.flatMap((course) => (Array.isArray(course.tags) ? course.tags : [])));
+  const {
+    coursesRef,
+    roadmapRef,
+    searchQuery,
+    setSearchQuery,
+    activeCategory,
+    setActiveCategory,
+    activeStatus,
+    setActiveStatus,
+    categories,
+    filteredCourses,
+    featuredCourses,
+    featuredTags,
+    totalProgress,
+    tagCount,
+    scrollToCourses,
+    scrollToRoadmap,
+  } = usePublicHomePageState({ courseCards });
 
   return (
     <div className="min-h-screen bg-[#eef2f7]">
@@ -92,12 +53,12 @@ export function PublicHomePage({ courseCards, busy, onOpenLogin }: PublicHomePag
                 key={item.label}
                 type="button"
                 onClick={() => {
-                  if (item.label === '강의 탐색') {
-                    scrollToElement(coursesRef.current);
+              if (item.label === '강의 탐색') {
+                    scrollToCourses();
                     return;
                   }
                   if (item.label === '학습 로드맵') {
-                    scrollToElement(roadmapRef.current);
+                    scrollToRoadmap();
                     return;
                   }
                   if (item.label === 'AI 도구' || item.label === '커뮤니티') {

--- a/frontend/src/features/lms/pages/useAIChatPageState.ts
+++ b/frontend/src/features/lms/pages/useAIChatPageState.ts
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { AIRagResult, AIInsights, LectureDetail, SmartChatResult } from '@myway/shared';
+import { loadAIRAGOverview } from '../../../lib/ai-rag';
+import { sendSmartChatDetailed } from '../../../lib/api';
+import { getAiErrorMessage, getPublicTestPolicyText, getQuotaStatusText } from '../../../lib/ai-access';
+import { type AIChatMessage } from '../components/AIChatThread';
+
+type AIChatPageStateArgs = {
+  highlightedLecture: LectureDetail | null;
+  insights: AIInsights | null;
+  selectedCourse?: { enrolled: boolean } | null;
+  canManageCurrent?: boolean;
+  sessionToken?: string | null;
+};
+
+function createWelcomeMessage(highlightedLecture: LectureDetail | null): AIChatMessage {
+  return {
+    id: `welcome-${highlightedLecture?.id ?? 'general'}`,
+    role: 'assistant',
+    content: highlightedLecture
+      ? `${highlightedLecture.title} 기준으로 질문을 이어갈 수 있습니다. 핵심 개념, 요약, 퀴즈 중 하나로 시작해보세요.`
+      : '강의를 선택하면 더 정확한 질문과 답변을 받을 수 있습니다.',
+    suggestions: ['핵심 개념 요약', '시험 대비 문제', '숏폼으로 복습', '이전 강의와 연결'],
+  };
+}
+
+function mapSmartChatResult(result: SmartChatResult): AIChatMessage {
+  return {
+    id: `assistant-${Date.now()}`,
+    role: 'assistant',
+    content: result.answer,
+    references: result.references,
+    suggestions: result.suggestions,
+    intent: result.intent,
+  };
+}
+
+export function useAIChatPageState({ highlightedLecture, selectedCourse, canManageCurrent, sessionToken }: AIChatPageStateArgs) {
+  const [ragOverview, setRagOverview] = useState<AIRagResult | null>(null);
+  const [ragLoading, setRagLoading] = useState(false);
+  const [messages, setMessages] = useState<AIChatMessage[]>(() => [createWelcomeMessage(null)]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [bannerTitle, setBannerTitle] = useState('공개 테스트 안내');
+  const [bannerDescription, setBannerDescription] = useState(getPublicTestPolicyText('chat'));
+  const [bannerMeta, setBannerMeta] = useState<string | null>(null);
+  const isLocked = Boolean(selectedCourse && !selectedCourse.enrolled && !canManageCurrent);
+
+  useEffect(() => {
+    setMessages([createWelcomeMessage(highlightedLecture)]);
+    setSidebarOpen(false);
+  }, [highlightedLecture?.id, highlightedLecture?.title]);
+
+  useEffect(() => {
+    let alive = true;
+    setBannerTitle('공개 테스트 안내');
+    setBannerDescription(getPublicTestPolicyText('chat'));
+    setBannerMeta(null);
+
+    if (isLocked || !highlightedLecture) {
+      setRagOverview(null);
+      setRagLoading(false);
+      return undefined;
+    }
+
+    setRagLoading(true);
+    loadAIRAGOverview({
+      query: `${highlightedLecture.title}의 핵심을 근거와 함께 정리해줘`,
+      lecture_id: highlightedLecture.id,
+      limit: 4,
+    })
+      .then((result) => {
+        if (alive) {
+          setRagOverview(result);
+        }
+      })
+      .finally(() => {
+        if (alive) {
+          setRagLoading(false);
+        }
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [highlightedLecture?.id, highlightedLecture?.title, isLocked]);
+
+  const quickPrompts = useMemo(() => ['핵심 개념 요약', '시험 대비 문제', '이전 강의와 연결', '숏폼으로 복습'], []);
+
+  async function handleSubmit(messageText = input) {
+    const message = messageText.trim();
+    if (!message || sending) {
+      return;
+    }
+
+    setInput('');
+    setSending(true);
+    setMessages((current) => [
+      ...current,
+      {
+        id: `user-${Date.now()}`,
+        role: 'user',
+        content: message,
+      },
+    ]);
+
+    try {
+      const result = await sendSmartChatDetailed(
+        {
+          message,
+          lecture_id: highlightedLecture?.id ?? undefined,
+          course_id: undefined,
+          context: highlightedLecture ? [highlightedLecture.title] : undefined,
+        },
+        sessionToken,
+      );
+
+      if (result?.success && result.data) {
+        setBannerTitle('AI 요청 상태');
+        setBannerDescription('요청이 정상 처리되었습니다. 남은 사용량은 화면 우측 배너에서 확인할 수 있습니다.');
+        setBannerMeta(getQuotaStatusText(result) ?? '사용량 정보 없음');
+      } else {
+        setBannerTitle('요청 제한 안내');
+        setBannerDescription(getAiErrorMessage(result, 'AI 채팅을 처리할 수 없습니다.'));
+        setBannerMeta(getQuotaStatusText(result));
+      }
+
+      setMessages((current) => [
+        ...current,
+        result && result.success && result.data
+          ? mapSmartChatResult(result.data)
+          : {
+              id: `fallback-${Date.now()}`,
+              role: 'assistant',
+              content: highlightedLecture
+                ? `${highlightedLecture.title} 기준으로 정리하면 핵심 개념부터 요약해볼 수 있습니다.`
+                : '질문을 다시 입력해보세요.',
+              suggestions: quickPrompts,
+            },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return {
+    ragOverview,
+    ragLoading,
+    messages,
+    input,
+    sending,
+    sidebarOpen,
+    bannerTitle,
+    bannerDescription,
+    bannerMeta,
+    isLocked,
+    quickPrompts,
+    setInput,
+    setSidebarOpen,
+    handleSubmit,
+  };
+}

--- a/frontend/src/features/lms/pages/usePublicHomePageState.ts
+++ b/frontend/src/features/lms/pages/usePublicHomePageState.ts
@@ -1,0 +1,85 @@
+import { useMemo, useRef, useState } from 'react';
+import type { CourseCard } from '@myway/shared';
+
+type PublicHomePageStateArgs = {
+  courseCards: CourseCard[];
+};
+
+function countUnique(values: string[]): number {
+  return new Set(values).size;
+}
+
+function scrollToElement(element: HTMLElement | null) {
+  element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+export function usePublicHomePageState({ courseCards }: PublicHomePageStateArgs) {
+  const coursesRef = useRef<HTMLElement | null>(null);
+  const roadmapRef = useRef<HTMLElement | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeCategory, setActiveCategory] = useState('');
+  const [activeStatus, setActiveStatus] = useState<'all' | 'available' | 'enrolled'>('all');
+
+  const categories = useMemo(() => [...new Set(courseCards.map((item) => item.category))], [courseCards]);
+
+  const filteredCourses = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    return courseCards.filter((course) => {
+      const tags = Array.isArray(course.tags) ? course.tags : [];
+      const queryMatch = query
+        ? [course.title, course.description, course.category, course.instructor_name, ...tags].join(' ').toLowerCase().includes(query)
+        : true;
+      const categoryMatch = activeCategory ? course.category === activeCategory : true;
+      const statusMatch =
+        activeStatus === 'all'
+          ? true
+          : activeStatus === 'available'
+            ? !course.enrolled
+            : course.enrolled;
+
+      return queryMatch && categoryMatch && statusMatch;
+    });
+  }, [activeCategory, activeStatus, courseCards, searchQuery]);
+
+  const featuredCourses = filteredCourses.slice(0, 5);
+  const featuredTags = useMemo(() => {
+    const counts = new Map<string, number>();
+
+    courseCards.forEach((course) => {
+      const tags = Array.isArray(course.tags) ? course.tags : [];
+      tags.forEach((tag) => {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      });
+    });
+
+    return [...counts.entries()]
+      .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+      .slice(0, 6)
+      .map(([tag]) => tag);
+  }, [courseCards]);
+
+  const totalProgress = Math.round(
+    courseCards.reduce((sum, course) => sum + course.progress_percent, 0) / Math.max(courseCards.length, 1),
+  );
+  const tagCount = countUnique(courseCards.flatMap((course) => (Array.isArray(course.tags) ? course.tags : [])));
+
+  return {
+    coursesRef,
+    roadmapRef,
+    searchQuery,
+    setSearchQuery,
+    activeCategory,
+    setActiveCategory,
+    activeStatus,
+    setActiveStatus,
+    categories,
+    filteredCourses,
+    featuredCourses,
+    featuredTags,
+    totalProgress,
+    tagCount,
+    scrollToCourses: () => scrollToElement(coursesRef.current),
+    scrollToRoadmap: () => scrollToElement(roadmapRef.current),
+  };
+}


### PR DESCRIPTION
# 변경 요약
AI 채팅과 공용 홈 화면의 상태 계산을 훅으로 분리해 페이지 조립 파일을 더 얇게 만들었습니다.

## 배경
큰 페이지 컴포넌트에서 검색, 집계, 비동기 요청 로직을 분리해 유지보수성과 재사용성을 높이기 위해서입니다.

## 변경 내용
- `AIChatPage`의 RAG 로드, 메시지 전송, 배너 상태를 `useAIChatPageState`로 분리했습니다.
- `PublicHomePage`의 검색/필터/집계/스크롤 로직을 `usePublicHomePageState`로 분리했습니다.
- 변경 요약을 dev log로 남겼습니다.

## 연결 이슈
- Closes #
- Fixes #

## 검증
- [x] 로컬 확인 완료
- [x] 문서 갱신 완료
- [x] 영향 범위 점검 완료
- [x] (설계 변경 시) ADR 상태 갱신 완료 (Proposed/Accepted/Superseded)

## 코드리뷰
- [x] CODEOWNERS 자동 리뷰 요청이 걸린다
- [x] 프론트 변경이면 `frontend/` 담당자 확인이 필요하다
- [ ] 백엔드 변경이면 `backend/` 담당자 확인이 필요하다
- [x] 문서 변경이면 `docs/` 담당자 확인이 필요하다
- [ ] 공통 타입 변경이면 `packages/shared/` 담당자 확인이 필요하다
- [x] 리뷰 시 확인해야 할 포인트를 적었다
- [x] PR 본문에 연결 이슈 번호가 들어갔다

## 체크 사항
- [x] 범위가 MoSCoW 기준에 맞는다
- [x] 관련 문서가 함께 갱신됐다
- [x] 기능 PR이면 ADR 링크를 본문에 포함했다 (없으면 PR 보류)
- [x] `docs/dev-logs/`에 변경 요약을 남겼다
- [x] 불필요한 리팩터링이 없다

## QA Gates (docs/architecture/qa-gates.md)
- [x] 의존 방향 규칙 준수 (`api -> domain`, `api -> persistence` 직접 접근 없음)
- [x] 신규 `Map<String,Object>` 경계 도입 없음
- [x] DTO 경계 규칙 준수 (Entity 직접 API 반환 없음, Mapper 경유)
- [x] 트랜잭션 규칙 준수 (`@Transactional`은 application 계층)
- [x] 이벤트 메타/멱등 규칙 준수
- [x] Query key 중앙화 및 invalidate 대상 명시
- [x] 예외 규칙 사용 시 ADR 링크 첨부
- [x] 계층별 테스트 갱신 완료 (application unit / persistence integration / api contract-e2e)

## 검증 로그 요약
- verify: `npm run verify` 통과
- layer tests: `npm run build:frontend` 통과, backend verify 포함
- risk/rollback: 훅 분리만 수행했기 때문에 롤백은 새 훅 파일 제거와 page 파일 복구로 가능

## ADR 링크
- ADR: 없음 (리팩터링 전용)
- 상태 변경: 해당 없음
