### PR TITLE
fix: restore db auth and playback flow

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/LegacyShortformBridgeController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/LegacyShortformBridgeController.java
@@ -81,7 +81,8 @@ public class LegacyShortformBridgeController {
         Map<String, Object> payload = payloadOf(body);
         return shortformController.generate(auth, new ShortformController.GenerateRequest(
                 text(payload, "course_id"),
-                text(payload, "mode")
+                text(payload, "mode"),
+                transcriptSegmentsByLecture(payload)
         ));
     }
 
@@ -114,7 +115,10 @@ public class LegacyShortformBridgeController {
         return shortformController.compose(auth, new ShortformController.ComposeRequest(
                 text(payload, "title"),
                 text(payload, "description"),
-                text(payload, "course_id")
+                text(payload, "course_id"),
+                text(payload, "extraction_id"),
+                listOfString(payload, "candidate_ids"),
+                List.of()
         ));
     }
 
@@ -194,5 +198,30 @@ public class LegacyShortformBridgeController {
         Object raw = body.get(key);
         if (!(raw instanceof List<?> items)) return List.of();
         return items.stream().map(String::valueOf).toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, List<Map<String, Object>>> transcriptSegmentsByLecture(Map<String, Object> body) {
+        if (body == null) return Map.of();
+        Object raw = body.get("transcript_segments_by_lecture");
+        if (!(raw instanceof Map<?, ?> rawMap)) return Map.of();
+        Map<String, List<Map<String, Object>>> result = new HashMap<>();
+        for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+            String lectureId = String.valueOf(entry.getKey()).trim();
+            if (lectureId.isBlank()) continue;
+            Object rawSegments = entry.getValue();
+            if (!(rawSegments instanceof List<?> items)) continue;
+            List<Map<String, Object>> segments = new java.util.ArrayList<>();
+            for (Object item : items) {
+                if (!(item instanceof Map<?, ?> segmentMap)) continue;
+                Map<String, Object> row = new HashMap<>();
+                for (Map.Entry<?, ?> segmentEntry : segmentMap.entrySet()) {
+                    row.put(String.valueOf(segmentEntry.getKey()), segmentEntry.getValue());
+                }
+                segments.add(row);
+            }
+            result.put(lectureId, segments);
+        }
+        return result;
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -22,16 +22,16 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/shortform")
 public class ShortformController {
-    public record GenerateRequest(String course_id, String mode) {}
+    public record GenerateRequest(String course_id, String mode, Map<String, List<Map<String, Object>>> transcript_segments_by_lecture) {}
     public record SelectCandidatesRequest(@NotBlank String extraction_id, @NotEmpty List<@NotBlank String> candidate_ids) {}
     public record ComposeClipRequest(
             @NotBlank String lecture_id,
             @NotNull @PositiveOrZero Long start_ms,
             @NotNull @PositiveOrZero Long end_ms
     ) {}
-    public record ComposeRequest(String title, String description, String course_id, String extraction_id, List<@Valid ComposeClipRequest> clips) {
+    public record ComposeRequest(String title, String description, String course_id, String extraction_id, List<String> candidate_ids, List<@Valid ComposeClipRequest> clips) {
         public ComposeRequest(String title, String description, String course_id) {
-            this(title, description, course_id, null, List.of());
+            this(title, description, course_id, null, List.of(), List.of());
         }
     }
     public record ShareRequest(@NotBlank String video_id, String course_id, String visibility, String message) {}
@@ -83,7 +83,8 @@ public class ShortformController {
         if (s == null) return support.unauthenticated();
         Map<String, Object> payload = Map.of(
                 "course_id", support.orEmpty(body.course_id()),
-                "mode", support.orEmpty(body.mode())
+                "mode", support.orEmpty(body.mode()),
+                "transcript_segments_by_lecture", body.transcript_segments_by_lecture() == null ? Map.of() : body.transcript_segments_by_lecture()
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.createShortformExtraction(s.user().id(), payload), "숏폼 후보가 생성되었습니다."));
     }
@@ -111,6 +112,19 @@ public class ShortformController {
         SessionView s = require(auth);
         if (s == null) return support.unauthenticated();
         List<ComposeClipRequest> sourceClips = body.clips() == null ? List.of() : body.clips();
+        if (sourceClips.isEmpty()) {
+            List<String> candidateIds = body.candidate_ids() == null ? List.of() : body.candidate_ids().stream().map(value -> value == null ? "" : value.trim()).filter(value -> !value.isBlank()).toList();
+            if (!candidateIds.isEmpty() && body.extraction_id() != null && !body.extraction_id().isBlank()) {
+                List<Map<String, Object>> resolvedClips = shortformService.resolveCandidateClips(body.extraction_id().trim(), candidateIds);
+                sourceClips = resolvedClips.stream()
+                        .map(clip -> new ComposeClipRequest(
+                                String.valueOf(clip.getOrDefault("lecture_id", "")).trim(),
+                                Long.valueOf(Long.parseLong(String.valueOf(clip.getOrDefault("start_ms", 0L)))),
+                                Long.valueOf(Long.parseLong(String.valueOf(clip.getOrDefault("end_ms", 0L))))
+                        ))
+                        .toList();
+            }
+        }
         List<ShortformComposeValidationSupport.ComposeClipInput> clipInputs = sourceClips.stream()
                 .map(clip -> new ShortformComposeValidationSupport.ComposeClipInput(clip.lecture_id(), clip.start_ms(), clip.end_ms()))
                 .toList();

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
@@ -1,6 +1,8 @@
 package com.myway.backendspring.feature.shortform;
 
 import com.myway.backendspring.domain.ActivityEventService;
+import com.myway.backendspring.domain.DemoLearningService;
+import com.myway.backendspring.domain.LectureItem;
 import com.myway.backendspring.feature.repository.FeatureStoreRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -10,6 +12,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -21,6 +25,7 @@ public class ShortformService {
     private static final String SHORTFORM_LIKE_SCOPE = "shortform_like";
     private final FeatureStoreRepository repository;
     private final ActivityEventService activityEventService;
+    private final DemoLearningService learningService;
     private final int shortformMaxRetry;
     private final long staleProcessingThresholdMs;
     private final ShortformRetrySupport retrySupport;
@@ -30,6 +35,7 @@ public class ShortformService {
     public ShortformService(
             FeatureStoreRepository repository,
             ActivityEventService activityEventService,
+            DemoLearningService learningService,
             @Value("${myway.shortform.retry.max-attempts:3}") int shortformMaxRetry,
             @Value("${myway.shortform.monitoring.stale-processing-ms:1800000}") long staleProcessingThresholdMs,
             ShortformRetrySupport retrySupport,
@@ -38,6 +44,7 @@ public class ShortformService {
     ) {
         this.repository = repository;
         this.activityEventService = activityEventService;
+        this.learningService = learningService;
         this.shortformMaxRetry = Math.max(1, shortformMaxRetry);
         this.staleProcessingThresholdMs = Math.max(60000L, staleProcessingThresholdMs);
         this.retrySupport = retrySupport;
@@ -55,14 +62,64 @@ public class ShortformService {
 
     public Map<String, Object> createShortformExtraction(String userId, Map<String, Object> payload) {
         String id = UUID.randomUUID().toString();
+        String courseId = String.valueOf(payload.getOrDefault("course_id", "crs_java_01")).trim();
+        String mode = String.valueOf(payload.getOrDefault("mode", "cross")).trim();
+        List<Map<String, Object>> candidates = buildCandidates(id, courseId, payload.get("transcript_segments_by_lecture"));
         Map<String, Object> data = new HashMap<>();
         data.put("id", id);
         data.put("user_id", userId);
-        data.put("course_id", payload.getOrDefault("course_id", "crs_java_01"));
-        data.put("mode", payload.getOrDefault("mode", "cross"));
-        data.put("candidates", List.of(Map.of("id", "cand-1", "selected", true), Map.of("id", "cand-2", "selected", false)));
+        data.put("course_id", courseId);
+        data.put("mode", mode);
+        data.put("candidates", candidates);
         repository.upsertKv(SHORTFORM_EXTRACTION_SCOPE, id, data);
         return data;
+    }
+
+    public List<Map<String, Object>> resolveCandidateClips(String extractionId, List<String> candidateIds) {
+        Map<String, Object> extraction = repository.getKv(SHORTFORM_EXTRACTION_SCOPE, extractionId);
+        if (extraction == null) {
+            return List.of();
+        }
+        Object rawCandidates = extraction.get("candidates");
+        if (!(rawCandidates instanceof List<?> list) || list.isEmpty()) {
+            return List.of();
+        }
+
+        Set<String> selectedIds = candidateIds == null || candidateIds.isEmpty()
+                ? null
+                : new LinkedHashSet<>(candidateIds.stream().map(value -> value == null ? "" : value.trim()).filter(value -> !value.isBlank()).toList());
+        List<Map<String, Object>> clips = new ArrayList<>();
+        for (Object item : list) {
+            if (!(item instanceof Map<?, ?> candidateMap)) {
+                continue;
+            }
+            Map<String, Object> candidate = new HashMap<>();
+            for (Map.Entry<?, ?> entry : candidateMap.entrySet()) {
+                candidate.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+            String candidateId = String.valueOf(candidate.getOrDefault("id", "")).trim();
+            if (candidateId.isBlank()) {
+                continue;
+            }
+            boolean include = selectedIds == null
+                    ? Boolean.TRUE.equals(candidate.get("is_selected")) || Boolean.TRUE.equals(candidate.get("selected"))
+                    : selectedIds.contains(candidateId);
+            if (!include) {
+                continue;
+            }
+            long startMs = asLong(candidate.get("start_time_ms"), asLong(candidate.get("start_ms"), -1L));
+            long endMs = asLong(candidate.get("end_time_ms"), asLong(candidate.get("end_ms"), -1L));
+            String lectureId = String.valueOf(candidate.getOrDefault("lecture_id", "")).trim();
+            if (lectureId.isBlank() || startMs < 0 || endMs <= startMs) {
+                continue;
+            }
+            clips.add(Map.of(
+                    "lecture_id", lectureId,
+                    "start_ms", startMs,
+                    "end_ms", endMs
+            ));
+        }
+        return clips;
     }
 
     public Map<String, Object> selectShortformCandidates(String extractionId, List<String> candidateIds) {
@@ -266,5 +323,132 @@ public class ShortformService {
         }
         composeSupport.dispatchShortformExportJob(video);
         return video;
+    }
+
+    private List<Map<String, Object>> buildCandidates(String extractionId, String courseId, Object rawTranscriptSegmentsByLecture) {
+        if (!(rawTranscriptSegmentsByLecture instanceof Map<?, ?> transcriptMap) || transcriptMap.isEmpty()) {
+            return fallbackCandidates(extractionId, courseId);
+        }
+
+        List<Map<String, Object>> candidates = new ArrayList<>();
+        int candidateIndex = 0;
+        for (Map.Entry<?, ?> lectureEntry : transcriptMap.entrySet()) {
+            String lectureId = String.valueOf(lectureEntry.getKey()).trim();
+            if (lectureId.isBlank()) {
+                continue;
+            }
+            LectureItem lecture = learningService.getLecture(lectureId);
+            String lectureTitle = lecture != null && lecture.title() != null && !lecture.title().isBlank()
+                    ? lecture.title()
+                    : lectureId;
+            String lectureCourseId = lecture != null && lecture.course_id() != null && !lecture.course_id().isBlank()
+                    ? lecture.course_id()
+                    : courseId;
+            Object rawSegments = lectureEntry.getValue();
+            if (!(rawSegments instanceof List<?> segments) || segments.isEmpty()) {
+                continue;
+            }
+            for (Object rawSegment : segments) {
+                if (!(rawSegment instanceof Map<?, ?> segmentMap)) {
+                    continue;
+                }
+                long startMs = asLong(segmentMap.get("start_ms"), -1L);
+                long endMs = asLong(segmentMap.get("end_ms"), -1L);
+                Object rawText = segmentMap.containsKey("text") ? segmentMap.get("text") : "";
+                String text = String.valueOf(rawText).trim();
+                if (startMs < 0 || endMs <= startMs) {
+                    continue;
+                }
+                candidateIndex += 1;
+                candidates.add(buildCandidate(
+                        extractionId,
+                        lectureCourseId,
+                        lectureId,
+                        lectureTitle,
+                        candidateIndex,
+                        startMs,
+                        endMs,
+                        text,
+                        candidateIndex == 1
+                ));
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return fallbackCandidates(extractionId, courseId);
+        }
+        return candidates;
+    }
+
+    private List<Map<String, Object>> fallbackCandidates(String extractionId, String courseId) {
+        List<LectureItem> lectures = learningService.getCourseLectures(courseId);
+        if (lectures.isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, Object>> candidates = new ArrayList<>();
+        int candidateIndex = 0;
+        for (LectureItem lecture : lectures) {
+            candidateIndex += 1;
+            long startMs = 0L;
+            long endMs = Math.max(60000L, (long) lecture.duration_minutes() * 1000L);
+            candidates.add(buildCandidate(
+                    extractionId,
+                    courseId,
+                    lecture.id(),
+                    lecture.title(),
+                    candidateIndex,
+                    startMs,
+                    endMs,
+                    lecture.title(),
+                    candidateIndex == 1
+            ));
+        }
+        return candidates;
+    }
+
+    private Map<String, Object> buildCandidate(
+            String extractionId,
+            String courseId,
+            String lectureId,
+            String lectureTitle,
+            int candidateIndex,
+            long startMs,
+            long endMs,
+            String text,
+            boolean selected
+    ) {
+        String normalizedText = text == null ? "" : text.trim();
+        String description = normalizedText.isBlank()
+                ? "핵심 구간"
+                : (normalizedText.length() <= 80 ? normalizedText : normalizedText.substring(0, 77) + "...");
+        Map<String, Object> candidate = new HashMap<>();
+        candidate.put("id", "cand-" + candidateIndex);
+        candidate.put("extraction_id", extractionId);
+        candidate.put("lecture_id", lectureId);
+        candidate.put("lecture_title", lectureTitle);
+        candidate.put("course_id", courseId);
+        candidate.put("start_time_ms", startMs);
+        candidate.put("end_time_ms", endMs);
+        candidate.put("label", lectureTitle + " 핵심 구간 " + candidateIndex);
+        candidate.put("description", description);
+        candidate.put("importance", Math.max(10, 100 - (candidateIndex - 1) * 10));
+        candidate.put("order_index", candidateIndex - 1);
+        candidate.put("is_selected", selected);
+        candidate.put("selected", selected);
+        return candidate;
+    }
+
+    private long asLong(Object value, long fallback) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value == null) {
+            return fallback;
+        }
+        try {
+            return Long.parseLong(String.valueOf(value).trim());
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
     }
 }

--- a/backend-spring/src/main/resources/application-dev.properties
+++ b/backend-spring/src/main/resources/application-dev.properties
@@ -1,0 +1,11 @@
+spring.datasource.url=jdbc:h2:file:./data/myway-feature-store;MODE=PostgreSQL;DATABASE_TO_UPPER=false;AUTO_SERVER=TRUE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.sql.init.mode=always
+spring.h2.console.enabled=true
+
+myway.app.env=development
+myway.runtime.env=dev
+
+myway.media.public-base-url=http://127.0.0.1:8787
+myway.media.asset-proxy.base-url=http://127.0.0.1:8788/assets

--- a/backend-spring/src/main/resources/application-production.properties
+++ b/backend-spring/src/main/resources/application-production.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=${MYWAY_DB_URL}
+spring.datasource.username=${MYWAY_DB_USERNAME}
+spring.datasource.password=${MYWAY_DB_PASSWORD}
+spring.sql.init.mode=always
+
+myway.app.env=production
+myway.runtime.env=production

--- a/backend-spring/src/main/resources/application.properties
+++ b/backend-spring/src/main/resources/application.properties
@@ -1,7 +1,5 @@
 server.port=8787
-spring.datasource.url=${MYWAY_DB_URL:jdbc:h2:file:./data/myway-feature-store;MODE=PostgreSQL;DATABASE_TO_UPPER=false;AUTO_SERVER=TRUE}
-spring.datasource.username=${MYWAY_DB_USERNAME:sa}
-spring.datasource.password=${MYWAY_DB_PASSWORD:}
+spring.profiles.default=dev
 spring.sql.init.mode=always
 spring.h2.console.enabled=true
 myway.shortform.retry.max-attempts=3
@@ -23,7 +21,6 @@ myway.media.batch.auto.mode=failed-only
 myway.auth.jwt.secret=${MYWAY_AUTH_JWT_SECRET:myway-class-dev-secret-key-change-me-32bytes}
 myway.auth.jwt.ttl-hours=${MYWAY_AUTH_JWT_TTL_HOURS:12}
 myway.cors.allowed-origins=${MYWAY_CORS_ALLOWED_ORIGINS:http://127.0.0.1:5173,http://localhost:5173}
-myway.app.env=development
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui
 myway.ai.ollama.base-url=http://127.0.0.1:11434

--- a/backend/src/routes/media-route-guards.ts
+++ b/backend/src/routes/media-route-guards.ts
@@ -1,4 +1,4 @@
-import { canManageCourses, getCourseDetail, getLectureDetail, type MediaRepository } from '@myway/shared';
+import { canManageCourses, demoLectures, getCourseDetail, getLectureDetail, type MediaRepository } from '@myway/shared';
 import { getAuthenticatedUser } from '../lib/auth';
 import { jsonFailure } from '../lib/http';
 import { verifyMediaProcessorToken } from '../lib/media-processor';
@@ -30,6 +30,55 @@ export function canAccessLectureContent(user: ReturnType<typeof getAuthenticated
   }
   const course = getCourseDetail(lecture.course_id, user.id);
   return Boolean(course?.enrolled);
+}
+
+function normalizeAssetKey(assetKey: string): string {
+  return assetKey
+    .trim()
+    .split('/')
+    .filter((segment) => segment.trim().length > 0)
+    .map((segment) => segment.trim())
+    .join('/');
+}
+
+function matchesLectureAssetKey(lecture: { video_asset_key?: string | null; video_url?: string | null }, assetKey: string): boolean {
+  const normalizedAssetKey = normalizeAssetKey(assetKey);
+  const encodedAssetKey = normalizedAssetKey
+    .split('/')
+    .filter((segment) => segment.trim().length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
+  if (lecture.video_asset_key) {
+    const lectureAssetKey = normalizeAssetKey(lecture.video_asset_key);
+    if (lectureAssetKey === normalizedAssetKey || lectureAssetKey === encodedAssetKey) {
+      return true;
+    }
+  }
+
+  if (lecture.video_url) {
+    const marker = '/api/v1/media/assets/';
+    const markerIndex = lecture.video_url.indexOf(marker);
+    if (markerIndex >= 0) {
+      const rawAssetKey = lecture.video_url.slice(markerIndex + marker.length);
+      const decodedAssetKey = decodeURIComponent(rawAssetKey);
+      if (
+        rawAssetKey === normalizedAssetKey ||
+        rawAssetKey === encodedAssetKey ||
+        decodedAssetKey === normalizedAssetKey ||
+        decodedAssetKey === encodedAssetKey
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function findLectureIdByAssetKey(assetKey: string): string | null {
+  const matchedLecture = demoLectures.find((lecture) => matchesLectureAssetKey(lecture, assetKey));
+  return matchedLecture?.id ?? null;
 }
 
 export function getMediaRepository(env: RuntimeBindings | undefined): MediaRepository | undefined {
@@ -65,8 +114,8 @@ export function requireAssetAccess(
     return jsonFailure('UNAUTHENTICATED', '로그인이 필요합니다.', 401);
   }
 
-  const lectureId = assetKey.split('/').pop()?.replace(/\.[^.]+$/, '') ?? '';
-  if (!canAccessLectureContent(user, lectureId)) {
+  const lectureId = findLectureIdByAssetKey(assetKey);
+  if (!lectureId || !canAccessLectureContent(user, lectureId)) {
     return jsonFailure('FORBIDDEN', '수강 신청 후에 영상을 시청할 수 있습니다.', 403);
   }
 

--- a/frontend/src/AppCore.tsx
+++ b/frontend/src/AppCore.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 import {
   canEnroll,
   canManageCourses,
-  demoUsers as defaultDemoUsers,
   type AuthUser,
   type AILogOverview,
   type AIInsights,
@@ -46,7 +45,7 @@ export default function App() {
   const [busy, setBusy] = useState(false);
   const [apiStatus, setApiStatus] = useState<'checking' | 'online' | 'offline'>('checking');
   const [notice, setNotice] = useState('로그인 후 내 정보와 진도가 활성화됩니다.');
-  const [loginUsers, setLoginUsers] = useState<AuthUser[]>(defaultDemoUsers);
+  const [loginUsers, setLoginUsers] = useState<AuthUser[]>([]);
 
   const enrolledCourses = useMemo(() => {
     if (!session) {

--- a/frontend/src/features/lms/components/LoginScreen.tsx
+++ b/frontend/src/features/lms/components/LoginScreen.tsx
@@ -64,7 +64,11 @@ export function LoginScreen({ demoUsers, busy, onLogin, onBackToHome }: LoginScr
             <p className="mt-1 text-[13px] leading-6 text-slate-500">이메일과 비밀번호로 로그인하세요.</p>
 
             <div className="mt-6 flex flex-col gap-2.5">
-              {demoUsers.map((user) => {
+              {demoUsers.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-sm leading-6 text-slate-500">
+                  사용자 목록을 불러오지 못했습니다. 백엔드 연결과 DB 시드를 확인한 뒤 다시 시도하세요.
+                </div>
+              ) : demoUsers.map((user) => {
                 const tone = toRoleTone(user.role);
                 return (
                   <button

--- a/frontend/src/lib/api-session.ts
+++ b/frontend/src/lib/api-session.ts
@@ -1,4 +1,4 @@
-import { demoUsers, type AuthUser, type LoginResponse } from '@myway/shared';
+import { type AuthUser, type LoginResponse } from '@myway/shared';
 import { clearStoredAuth, getFallbackUserId, getStoredAuth, request, storeAuth } from './api-core';
 
 type BackendHealth = {
@@ -6,6 +6,28 @@ type BackendHealth = {
   service: string;
   timestamp: string;
 };
+
+function normalizeRole(role: string): AuthUser['role'] {
+  const normalized = role.trim().toUpperCase();
+  if (normalized === 'ADMIN' || normalized === 'INSTRUCTOR' || normalized === 'STUDENT') {
+    return normalized;
+  }
+  return 'STUDENT';
+}
+
+function normalizeAuthUser(user: AuthUser): AuthUser {
+  return {
+    ...user,
+    role: normalizeRole(user.role),
+  };
+}
+
+function normalizeLoginResponse(response: LoginResponse): LoginResponse {
+  return {
+    ...response,
+    user: normalizeAuthUser(response.user),
+  };
+}
 
 export async function loadCurrentSession(): Promise<LoginResponse | null> {
   const storedAuth = getStoredAuth();
@@ -17,8 +39,9 @@ export async function loadCurrentSession(): Promise<LoginResponse | null> {
   const response = await request<LoginResponse>('/api/v1/auth/me', undefined, storedAuth.session_token);
 
   if (response?.success && response.data) {
-    storeAuth(response.data);
-    return response.data;
+    const normalized = normalizeLoginResponse(response.data);
+    storeAuth(normalized);
+    return normalized;
   }
 
   clearStoredAuth();
@@ -32,8 +55,9 @@ export async function loginWithUser(userId: string): Promise<LoginResponse | nul
   });
 
   if (response?.success && response.data) {
-    storeAuth(response.data);
-    return response.data;
+    const normalized = normalizeLoginResponse(response.data);
+    storeAuth(normalized);
+    return normalized;
   }
   return null;
 }
@@ -56,9 +80,9 @@ export async function loadBackendHealth(): Promise<boolean> {
 export async function loadLoginUsers(): Promise<AuthUser[]> {
   const response = await request<AuthUser[]>('/api/v1/auth/users');
   if (response?.success && Array.isArray(response.data) && response.data.length > 0) {
-    return response.data;
+    return response.data.map(normalizeAuthUser);
   }
-  return demoUsers;
+  return [];
 }
 
 export { getStoredAuth, getFallbackUserId };

--- a/frontend/src/lib/video-url.test.ts
+++ b/frontend/src/lib/video-url.test.ts
@@ -13,10 +13,10 @@ describe("video URL utilities", () => {
     expect(output).toBe("https://app.example.com/api/v1/media/assets/asset/demo/video.mp4?token=session-token-1");
   });
 
-  it("normalizes encoded slash asset URLs to canonical asset paths", () => {
+  it("preserves encoded slash asset URLs and keeps tokenized asset URLs stable", () => {
     const input = "http://127.0.0.1:8787/api/v1/media/assets/media%2Fcrs_ai_seed_001%2Flec_ai_seed_001.mp4";
     const output = resolvePlayableVideoUrl(input);
-    expect(output).toBe("http://127.0.0.1:8787/api/v1/media/assets/media/crs_ai_seed_001/lec_ai_seed_001.mp4");
+    expect(output).toBe(input);
   });
 
   it("keeps non-API absolute URLs unchanged even with session token", () => {

--- a/frontend/src/lib/video-url.ts
+++ b/frontend/src/lib/video-url.ts
@@ -6,28 +6,7 @@ function canonicalizeMediaAssetPath(videoUrl: string): string {
   if (markerIndex < 0) {
     return videoUrl;
   }
-
-  const before = videoUrl.slice(0, markerIndex + marker.length);
-  const after = videoUrl.slice(markerIndex + marker.length);
-  const [rawAssetKey, queryString = ''] = after.split('?', 2);
-  if (!rawAssetKey) {
-    return videoUrl;
-  }
-
-  let decodedKey = rawAssetKey;
-  try {
-    decodedKey = decodeURIComponent(rawAssetKey);
-  } catch {
-    decodedKey = rawAssetKey;
-  }
-
-  const encodedKey = decodedKey
-    .split('/')
-    .filter((segment) => segment.trim().length > 0)
-    .map((segment) => encodeURIComponent(segment))
-    .join('/');
-  const querySuffix = queryString ? `?${queryString}` : '';
-  return `${before}${encodedKey}${querySuffix}`;
+  return videoUrl;
 }
 
 function resolveMediaUrl(videoUrl: string): string {


### PR DESCRIPTION
﻿## 변경 요약
- Spring dev 프로필을 DB 기반 auth/asset 구동으로 정리했습니다.
- 프론트 로그인은 demoUsers 폴백 없이 DB 사용자만 사용하도록 수정했습니다.
- 강의 영상 재생과 숏폼 생성/합성 흐름을 실제 데이터 기준으로 복구했습니다.

## 배경
- 실제 DB 계정으로 로그인되어야 했고, 강의 영상/챗봇/숏폼이 실제 학습 데이터와 연결되어야 했습니다.
- 기존 dev 경로는 demo fallback과 경로 추론에 의존해 동작이 불안정했습니다.

## 변경 내용
- `backend-spring/src/main/resources/application.properties` 에서 dev 기본 프로필을 정리하고, `application-dev.properties` / `application-production.properties` 를 분리했습니다.
- `frontend/src/lib/api-session.ts` 에서 로그인 사용자 로드와 세션 로딩 시 역할을 정규화하고 demoUsers fallback을 제거했습니다.
- `backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java` 와 관련 컨트롤러에서 transcript 기반 후보 생성/합성을 복구했습니다.
- `backend-spring/src/main/java/com/myway/backendspring/api/LegacyShortformBridgeController.java` 에서 legacy 경로도 새 payload를 전달하도록 맞췄습니다.
- `frontend/src/AppCore.tsx` 와 `frontend/src/features/lms/components/LoginScreen.tsx` 에서 DB 사용자 로드를 전제로 화면을 정리했습니다.

## 연결 이슈
- 없음

## 검증
- `npm run build:frontend`
- `npm run test:backend`
- 브라우저에서 DB 사용자 로그인 확인
- 브라우저에서 강의 영상 `<video>` 로드 확인
- API에서 shortform generate / compose 흐름 확인

## 코드리뷰
- 필요 시 검토 바랍니다.

## 체크 사항
- [x] 타입/빌드 검증
- [x] 백엔드 테스트
- [x] 로그인 경로 확인
- [x] 강의 영상 재생 확인
- [x] 숏폼 생성/합성 확인

## QA Gates
- `build:frontend` pass
- `test:backend` pass
- 브라우저 수동 점검 pass

## 검증 로그 요약
- Spring dev backend started successfully on `8787`
- `auth/users` returned DB-backed users
- `lecture-video/{lectureId}` returned asset mapping
- shortform generate returned real candidates
- shortform compose resolved `candidate_ids` to clips

## ADR 링크
- 없음
