### PR TITLE
[codex] transcript chunk boundary split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ backend/tmp/
 tmp/
 frontend.zip
 temp-sample-10s.mp4
+.worktrees/
 
 .github/.tmp_*.md
 _workspace/

--- a/backend-spring/src/main/java/com/myway/backendspring/api/LegacyShortformBridgeController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/LegacyShortformBridgeController.java
@@ -82,6 +82,7 @@ public class LegacyShortformBridgeController {
         return shortformController.generate(auth, new ShortformController.GenerateRequest(
                 text(payload, "course_id"),
                 text(payload, "mode"),
+                transcriptChunksByLecture(payload),
                 transcriptSegmentsByLecture(payload)
         ));
     }
@@ -201,9 +202,17 @@ public class LegacyShortformBridgeController {
     }
 
     @SuppressWarnings("unchecked")
+    private Map<String, List<Map<String, Object>>> transcriptChunksByLecture(Map<String, Object> body) {
+        return transcriptByLecture(body, "transcript_chunks_by_lecture");
+    }
+
     private Map<String, List<Map<String, Object>>> transcriptSegmentsByLecture(Map<String, Object> body) {
+        return transcriptByLecture(body, "transcript_segments_by_lecture");
+    }
+
+    private Map<String, List<Map<String, Object>>> transcriptByLecture(Map<String, Object> body, String keyName) {
         if (body == null) return Map.of();
-        Object raw = body.get("transcript_segments_by_lecture");
+        Object raw = body.get(keyName);
         if (!(raw instanceof Map<?, ?> rawMap)) return Map.of();
         Map<String, List<Map<String, Object>>> result = new HashMap<>();
         for (Map.Entry<?, ?> entry : rawMap.entrySet()) {

--- a/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/ShortformController.java
@@ -22,7 +22,12 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/shortform")
 public class ShortformController {
-    public record GenerateRequest(String course_id, String mode, Map<String, List<Map<String, Object>>> transcript_segments_by_lecture) {}
+    public record GenerateRequest(
+            String course_id,
+            String mode,
+            Map<String, List<Map<String, Object>>> transcript_chunks_by_lecture,
+            Map<String, List<Map<String, Object>>> transcript_segments_by_lecture
+    ) {}
     public record SelectCandidatesRequest(@NotBlank String extraction_id, @NotEmpty List<@NotBlank String> candidate_ids) {}
     public record ComposeClipRequest(
             @NotBlank String lecture_id,
@@ -84,6 +89,7 @@ public class ShortformController {
         Map<String, Object> payload = Map.of(
                 "course_id", support.orEmpty(body.course_id()),
                 "mode", support.orEmpty(body.mode()),
+                "transcript_chunks_by_lecture", body.transcript_chunks_by_lecture() == null ? Map.of() : body.transcript_chunks_by_lecture(),
                 "transcript_segments_by_lecture", body.transcript_segments_by_lecture() == null ? Map.of() : body.transcript_segments_by_lecture()
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(shortformService.createShortformExtraction(s.user().id(), payload), "숏폼 후보가 생성되었습니다."));

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/shortform/ShortformService.java
@@ -64,7 +64,9 @@ public class ShortformService {
         String id = UUID.randomUUID().toString();
         String courseId = String.valueOf(payload.getOrDefault("course_id", "crs_java_01")).trim();
         String mode = String.valueOf(payload.getOrDefault("mode", "cross")).trim();
-        List<Map<String, Object>> candidates = buildCandidates(id, courseId, payload.get("transcript_segments_by_lecture"));
+        Object rawTranscriptChunks = payload.get("transcript_chunks_by_lecture");
+        Object rawTranscriptSegments = payload.get("transcript_segments_by_lecture");
+        List<Map<String, Object>> candidates = buildCandidates(id, courseId, rawTranscriptChunks, rawTranscriptSegments);
         Map<String, Object> data = new HashMap<>();
         data.put("id", id);
         data.put("user_id", userId);
@@ -325,8 +327,11 @@ public class ShortformService {
         return video;
     }
 
-    private List<Map<String, Object>> buildCandidates(String extractionId, String courseId, Object rawTranscriptSegmentsByLecture) {
-        if (!(rawTranscriptSegmentsByLecture instanceof Map<?, ?> transcriptMap) || transcriptMap.isEmpty()) {
+    private List<Map<String, Object>> buildCandidates(String extractionId, String courseId, Object rawTranscriptChunksByLecture, Object rawTranscriptSegmentsByLecture) {
+        Object preferredSource = rawTranscriptChunksByLecture instanceof Map<?, ?> chunks && !chunks.isEmpty()
+                ? chunks
+                : rawTranscriptSegmentsByLecture;
+        if (!(preferredSource instanceof Map<?, ?> transcriptMap) || transcriptMap.isEmpty()) {
             return fallbackCandidates(extractionId, courseId);
         }
 

--- a/backend/src/lib/media-repository-builders.ts
+++ b/backend/src/lib/media-repository-builders.ts
@@ -8,6 +8,7 @@ import type {
   MediaSummaryRequest,
   TranscriptCreateRequest,
 } from '@myway/shared';
+import { buildTranscriptChunks } from '@myway/shared';
 import {
   buildTimelineMarkers,
   extractKeyConcepts,
@@ -47,19 +48,38 @@ export function buildLectureTranscript(
     return null;
   }
   const fallbackDurationMs = Math.max(lecture.duration_minutes * 60_000, fullText.length * 40, 180_000);
+  const transcriptId = createId('trs');
   const segments = input.segments?.length
-    ? input.segments.map((segment, index) => ({
-        index,
-        start_ms: Math.max(0, Math.round(segment.start_ms)),
-        end_ms: Math.max(Math.round(segment.start_ms), Math.round(segment.end_ms)),
-        text: normalizeText(segment.text),
-      }))
-    : splitIntoSegments(fullText, input.duration_ms ?? fallbackDurationMs);
+    ? buildTranscriptChunks(
+        lecture.id,
+        input.segments.map((segment, index) => ({
+          ...segment,
+          text: normalizeText(segment.text),
+          chunk_index: segment.chunk_index ?? segment.index ?? index,
+          index: segment.index ?? segment.chunk_index ?? index,
+        })),
+        transcriptId,
+      )
+    : buildTranscriptChunks(
+        lecture.id,
+        splitIntoSegments(fullText, input.duration_ms ?? fallbackDurationMs).map((segment) => ({
+          lecture_id: lecture.id,
+          start_ms: segment.start_ms,
+          end_ms: segment.end_ms,
+          text: segment.text,
+          chunk_index: segment.index,
+          index: segment.index,
+          confidence: 0.9,
+          speaker: null,
+          topic_tags: [],
+        })),
+        transcriptId,
+      );
   const durationMs =
     input.duration_ms ?? (segments.length > 0 ? segments[segments.length - 1]?.end_ms ?? fallbackDurationMs : fallbackDurationMs);
   const wordCount = input.word_count ?? fullText.split(/\s+/).filter(Boolean).length;
   return {
-    id: createId('trs'),
+    id: transcriptId,
     lecture_id: lecture.id,
     user_id: userId,
     language: input.language ?? 'ko',

--- a/backend/src/routes/shortform-route-actions.ts
+++ b/backend/src/routes/shortform-route-actions.ts
@@ -2,9 +2,10 @@ import {
   getCourseDetail,
   getShortformVideoDetail,
   listLectureTranscripts,
+  type TranscriptChunk,
   type ShortformGenerateRequest,
   type ShortformComposeRequest,
-  type ShortformExportVideo,
+  type ShortformVideoDetail,
   type MediaRepository,
   generateShortformExtraction,
   composeShortformVideo,
@@ -20,6 +21,7 @@ export async function generateShortformCandidates(
   if (!courseId) return null;
 
   const transcriptSegmentsByLecture: Record<string, Array<{ start_ms: number; end_ms: number; text: string }>> = {};
+  const transcriptChunksByLecture: Record<string, TranscriptChunk[]> = {};
   const course = getCourseDetail(courseId, userId);
   const lectureIds =
     body?.mode === 'single' && body?.lecture_id?.trim()
@@ -30,6 +32,7 @@ export async function generateShortformCandidates(
     for (const lectureId of lectureIds) {
       const transcript = (await listLectureTranscripts(lectureId, repository))[0] ?? null;
       if (transcript?.segments?.length) {
+        transcriptChunksByLecture[lectureId] = transcript.segments;
         transcriptSegmentsByLecture[lectureId] = transcript.segments.map((segment) => ({
           start_ms: segment.start_ms,
           end_ms: segment.end_ms,
@@ -46,11 +49,12 @@ export async function generateShortformCandidates(
     style: body?.style ?? 'highlight',
     target_duration_sec: body?.target_duration_sec ?? 300,
     language: body?.language ?? 'ko',
+    transcript_chunks_by_lecture: transcriptChunksByLecture,
     transcript_segments_by_lecture: transcriptSegmentsByLecture,
   });
 }
 
-export function composeShortformAndMarkProcessing(userId: string, body: ShortformComposeRequest | null): ShortformExportVideo | null {
+export function composeShortformAndMarkProcessing(userId: string, body: ShortformComposeRequest | null): ShortformVideoDetail | null {
   const extractionId = body?.extraction_id?.trim();
   const title = body?.title?.trim();
   if (!extractionId || !title) return null;
@@ -71,5 +75,5 @@ export function composeShortformAndMarkProcessing(userId: string, body: Shortfor
     export_job_id: null,
     export_retry_count: 0,
   });
-  return getShortformVideoDetail(video.id);
+  return getShortformVideoDetail(video.id) ?? null;
 }

--- a/docs/architecture/rag-flow.md
+++ b/docs/architecture/rag-flow.md
@@ -1,12 +1,13 @@
 # RAG Flow
 
 ## 시스템 흐름
-1. STT: 강의 오디오를 전사하고 `segment(start_ms, end_ms, text)` 생성
-2. Chunk: 문장 경계 보정으로 검색 단위 chunk 생성
-3. Index: 키워드 인덱스 + 벡터 인덱스 저장
-4. Retrieve: 질의 기준으로 키워드/벡터 후보를 병렬 수집
-5. Rerank: 메타데이터(강의/코스/시간축)와 관련도로 재정렬
-6. Answer: 상위 근거 chunk를 사용해 grounded answer 생성
+1. STT: 강의 오디오를 전사하고 `TranscriptChunk` 생성
+2. Persist: chunk를 lecture 단위 canonical source로 저장
+3. SearchIndex: 검색용 인덱스를 chunk에서 파생
+4. Retrieve: 질의 기준으로 후보 chunk를 찾고 timestamp citation을 유지
+5. TimelineProject: 사용자가 선택한 chunk를 숏폼 편집 계획으로 조합
+6. AnswerPolicy: 애매한 발화, 낮은 신뢰도, 상담사 전환 기준을 판정
+7. Answer: 상위 근거 chunk와 policy를 바탕으로 grounded answer 생성
 
 ## 실패/폴백 시나리오
 - STT 실패: 재시도 후 demo/fallback transcript 경로 사용, 파이프라인 상태 `FAILED` 기록
@@ -14,7 +15,9 @@
 - Vector store 장애: 키워드 인덱스 단독 모드 전환
 - Rerank 실패: retrieve score 순으로 응답
 - Answer 생성 실패: 검색 결과/요약만 반환
+- Policy 미달: 답변 대신 재질문 또는 찾지 못했다는 응답으로 전환
 
 ## 운영 포인트
 - 각 단계별 상태를 `processing_stage`, `status`, `updated_at`로 기록
 - 장애 시 단계별 재처리 가능하도록 idempotent key 유지
+- 검색과 편집은 같은 chunk를 보되 서로 다른 레이어에서만 해석한다.

--- a/frontend/src/features/lms/components/shortformWizardUtils.ts
+++ b/frontend/src/features/lms/components/shortformWizardUtils.ts
@@ -5,7 +5,19 @@ export const MIN_CLIP_MS = 1_000;
 export const MAX_CLIP_MS = 300_000;
 
 export type TranscriptSnapshot = {
-  segments: Array<{ start_ms: number; end_ms: number; text: string }>;
+  chunks?: Array<{
+    lecture_id?: string;
+    transcript_id?: string | null;
+    start_ms: number;
+    end_ms: number;
+    text: string;
+    confidence?: number;
+    speaker?: string | null;
+    topic_tags?: string[];
+    chunk_index?: number;
+    index?: number;
+  }>;
+  segments?: Array<{ start_ms: number; end_ms: number; text: string }>;
   duration_ms: number;
 } | null;
 
@@ -40,7 +52,7 @@ export function clipKey(clip: ClipSuggestion): string {
 function buildTranscriptSuggestions(course: CourseDetail, lectureId: string, transcript: TranscriptSnapshot): ClipSuggestion[] {
   const lectures = Array.isArray(course.lectures) ? course.lectures : [];
   const lecture = lectures.find((item) => item.id === lectureId);
-  const segments = transcript?.segments ?? [];
+  const segments = transcript?.chunks ?? transcript?.segments ?? [];
   if (!lecture || segments.length === 0) return [];
 
   const validSegments = segments.filter((segment) => segment.text.trim().length > 0);
@@ -78,7 +90,7 @@ export function buildClipSuggestions(course: CourseDetail | null, transcriptMap:
   const lectures = Array.isArray(course.lectures) ? course.lectures : [];
   return lectures.flatMap((lecture, lectureIndex) => {
     const transcriptSnapshot = transcriptMap[lecture.id] ?? null;
-    if (transcriptSnapshot?.segments && transcriptSnapshot.segments.length > 0) {
+    if ((transcriptSnapshot?.chunks && transcriptSnapshot.chunks.length > 0) || (transcriptSnapshot?.segments && transcriptSnapshot.segments.length > 0)) {
       return buildTranscriptSuggestions(course, lecture.id, transcriptSnapshot);
     }
 

--- a/frontend/src/features/lms/components/useShortformWizardActions.ts
+++ b/frontend/src/features/lms/components/useShortformWizardActions.ts
@@ -50,6 +50,22 @@ export function useShortformWizardActions({
         title: title.trim() || `${courseDetail.title} 숏폼`,
         description,
         candidate_ids: selectedClips.map((clip) => clip.id),
+        timeline_project: {
+          id: extractionId,
+          course_id: courseDetail.id,
+          title: title.trim() || `${courseDetail.title} 숏폼`,
+          description,
+          status: 'selected',
+          clips: selectedClips.map((clip, order_index) => ({
+            lecture_id: clip.lecture_id,
+            start_ms: clip.start_time_ms,
+            end_ms: clip.end_time_ms,
+            text: clip.description,
+            order_index,
+          })),
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
       },
       sessionToken,
     );

--- a/frontend/src/features/lms/components/useShortformWizardStateCore.ts
+++ b/frontend/src/features/lms/components/useShortformWizardStateCore.ts
@@ -84,7 +84,15 @@ export function useShortformWizardState({ highlightedLecture, selectedCourse, co
     Promise.all(
       courseLectures.map(async (lecture) => {
         const transcript = await loadLectureTranscriptDetailed(lecture.id, sessionToken);
-        return [lecture.id, transcript ? { segments: transcript.segments ?? [], duration_ms: transcript.duration_ms } : null] as const;
+        return [
+          lecture.id,
+          transcript
+            ? {
+                chunks: transcript.segments ?? [],
+                duration_ms: transcript.duration_ms,
+              }
+            : null,
+        ] as const;
       }),
     ).then((entries) => {
       if (alive) setTranscriptMap(Object.fromEntries(entries));
@@ -126,13 +134,20 @@ export function useShortformWizardState({ highlightedLecture, selectedCourse, co
 
     const transcriptSegmentsByLecture = Object.fromEntries(
       Object.entries(transcriptMap)
-        .filter(([, snapshot]) => Boolean(snapshot?.segments?.length))
+        .filter(([, snapshot]) => Boolean(snapshot?.chunks?.length))
         .map(([lectureId, snapshot]) => [
           lectureId,
-          (snapshot?.segments ?? []).map((segment) => ({
+          (snapshot?.chunks ?? []).map((segment) => ({
+            lecture_id: lectureId,
+            transcript_id: segment.transcript_id ?? undefined,
             start_ms: segment.start_ms,
             end_ms: segment.end_ms,
             text: segment.text,
+            confidence: segment.confidence,
+            speaker: segment.speaker ?? null,
+            topic_tags: segment.topic_tags ?? [],
+            chunk_index: segment.chunk_index ?? segment.index,
+            index: segment.index ?? segment.chunk_index,
           })),
         ]),
     );
@@ -146,6 +161,7 @@ export function useShortformWizardState({ highlightedLecture, selectedCourse, co
       {
         course_id: courseDetail.id,
         mode: 'cross',
+        transcript_chunks_by_lecture: transcriptSegmentsByLecture,
         transcript_segments_by_lecture: transcriptSegmentsByLecture,
       },
       sessionToken,

--- a/packages/shared/src/lms/shortform/compose.ts
+++ b/packages/shared/src/lms/shortform/compose.ts
@@ -32,13 +32,23 @@ type TranscriptSegmentLike = {
   text: string;
 };
 
+type TranscriptChunkLike = TranscriptSegmentLike & {
+  lecture_id?: string;
+  transcript_id?: string | null;
+  confidence?: number;
+  speaker?: string | null;
+  topic_tags?: string[];
+  chunk_index?: number;
+  index?: number;
+};
+
 function buildTranscriptCandidates(
   extractionId: string,
   lectureId: string,
   lectureTitle: string,
   courseId: string,
   style: ShortformStyle,
-  segments: TranscriptSegmentLike[],
+  segments: TranscriptChunkLike[],
   startOrderIndex: number,
 ): ShortformCandidate[] {
   const validSegments = segments.filter((segment) => segment.text.trim().length > 0);
@@ -112,17 +122,18 @@ export function generateShortformExtraction(userId: string, input: ShortformGene
       return;
     }
 
+    const transcriptChunks = input.transcript_chunks_by_lecture?.[lecture.id];
     const transcriptSegments = input.transcript_segments_by_lecture?.[lecture.id];
     const baseOrderIndex = demoShortformCandidates.filter((item) => item.extraction_id === extraction.id).length;
     const candidates =
-      transcriptSegments && transcriptSegments.length > 0
+      (transcriptChunks && transcriptChunks.length > 0) || (transcriptSegments && transcriptSegments.length > 0)
         ? buildTranscriptCandidates(
             extraction.id,
             lecture.id,
             lecture.title,
             lecture.course_id,
             extraction.style,
-            transcriptSegments,
+            (transcriptChunks ?? transcriptSegments) as TranscriptChunkLike[],
             baseOrderIndex,
           )
         : Array.from({ length: 3 }, (_, index) =>
@@ -165,12 +176,17 @@ export function toggleShortformCandidateSelection(input: ShortformSelectRequest)
 }
 
 export function composeShortformVideo(userId: string, input: ShortformComposeRequest): ShortformVideo | null {
-  const extraction = getExtraction(input.extraction_id);
+  const extractionId = input.extraction_id?.trim();
+  if (!extractionId) {
+    return null;
+  }
+
+  const extraction = getExtraction(extractionId);
   if (!extraction) {
     return null;
   }
 
-  const candidates = getSelectedShortformCandidates(input.extraction_id, input.candidate_ids);
+  const candidates = getSelectedShortformCandidates(extractionId, input.candidate_ids);
   return createShortformVideoFromCandidates(userId, extraction, input.title, input.description ?? '', candidates);
 }
 

--- a/packages/shared/src/rag/entities.ts
+++ b/packages/shared/src/rag/entities.ts
@@ -7,6 +7,7 @@ import type {
   AIRagEntityKind,
   AIRagProviderPlan,
   AIRagRequest,
+  AnswerPolicy,
 } from '../types';
 
 function normalizeText(text: string): string {
@@ -121,17 +122,49 @@ export function buildSuggestions(intent: AIIntent, label: string): string[] {
   return [`${label}를 다른 각도에서 설명해줘.`, `같은 주제를 더 자세히 보여줘.`];
 }
 
+export function buildAnswerPolicy(intent: AIIntent, topHitSimilarity: number): AnswerPolicy {
+  const baseMinConfidence =
+    intent === 'request_summary'
+      ? 0.45
+      : intent === 'generate_quiz'
+        ? 0.5
+        : intent === 'search_content'
+          ? 0.4
+          : 0.42;
+
+  const minConfidence = Math.max(0.35, Math.min(0.7, baseMinConfidence));
+  const clarifyThreshold = Math.max(minConfidence + 0.08, 0.58);
+  const handoffThreshold = Math.max(0.18, Math.min(minConfidence - 0.12, topHitSimilarity * 0.8));
+
+  return {
+    min_confidence: minConfidence,
+    clarify_threshold: clarifyThreshold,
+    handoff_threshold: handoffThreshold,
+    max_clarify_rounds: 1,
+    citation_required: true,
+  };
+}
+
 export function buildAnswerText(
   query: string,
   intent: AIIntent,
   hits: { excerpt: string; title: string; similarity: number }[],
   label: string,
+  policy: AnswerPolicy,
 ): string {
   if (hits.length === 0) {
     return `${label}에서 "${query}"와 관련된 근거를 찾지 못했습니다. 질문을 조금 더 구체적으로 바꿔 주세요.`;
   }
 
   const topHit = hits[0];
+  if (topHit.similarity < policy.handoff_threshold) {
+    return `${label}에서 "${query}"와 관련된 근거를 찾지 못했습니다. 질문을 조금 더 구체적으로 바꿔 주세요.`;
+  }
+
+  if (topHit.similarity < policy.clarify_threshold) {
+    return `${label}에서 근거는 찾았지만 질문과의 연결이 약합니다. 질문을 조금 더 구체적으로 바꿔 주세요.`;
+  }
+
   const nextHit = hits[1];
   const opener =
     intent === 'request_summary'

--- a/packages/shared/src/rag/pipeline.ts
+++ b/packages/shared/src/rag/pipeline.ts
@@ -9,7 +9,7 @@ import type {
   AIRagResult,
   AISearchResult,
 } from '../types';
-import { buildAnswerText, buildProviderPlan, buildSuggestions, extractEntities } from './entities';
+import { buildAnswerPolicy, buildAnswerText, buildProviderPlan, buildSuggestions, extractEntities } from './entities';
 import { buildCorpus, rankChunks } from './chunking';
 
 function resolveLabel(input: AIRagRequest): string {
@@ -38,12 +38,13 @@ function buildAnswerResult(
   intent: AIIntentResult,
   chunks: Awaited<ReturnType<typeof rankChunks>>,
   label: string,
+  policy: ReturnType<typeof buildAnswerPolicy>,
 ): AIAnswerResult {
   return {
     question: query,
     lecture_id: lectureId,
     intent,
-    answer: buildAnswerText(query, intent.intent, chunks, label),
+    answer: buildAnswerText(query, intent.intent, chunks, label, policy),
     references: chunks,
     suggestions: buildSuggestions(intent.intent, label),
   };
@@ -61,6 +62,7 @@ export async function buildAIRAGOverview(
   });
   const chunks = await rankChunks(query, await buildCorpus(input, repository), Math.max(1, Math.min(6, input.limit ?? 4)));
   const label = resolveLabel(input);
+  const policy = buildAnswerPolicy(intent.intent, chunks[0]?.similarity ?? 0);
 
   return {
     query,
@@ -70,7 +72,8 @@ export async function buildAIRAGOverview(
     entities: extractEntities(input),
     chunks,
     search: buildSearchResult(query, input.lecture_id ?? null, chunks),
-    answer: buildAnswerResult(query, input.lecture_id ?? null, intent, chunks, label),
+    answer: buildAnswerResult(query, input.lecture_id ?? null, intent, chunks, label, policy),
+    policy,
     provider: buildProviderPlan(input.preferred_provider),
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,4 +1,5 @@
 export * from './types/common';
+export * from './types/transcript';
 export * from './types/lms';
 export * from './types/ai';
 export * from './types/custom-course';

--- a/packages/shared/src/types/lms.ts
+++ b/packages/shared/src/types/lms.ts
@@ -1,4 +1,5 @@
 import type { CourseDifficulty, EnrollmentStatus, LectureContentType, UserRole } from './common';
+import type { TranscriptChunk, TranscriptChunkInput } from './transcript';
 
 export type Course = {
   id: string;
@@ -144,7 +145,7 @@ export type LectureTranscript = {
   user_id: string;
   language: string;
   full_text: string;
-  segments: TranscriptSegment[];
+  segments: TranscriptChunk[];
   word_count: number;
   duration_ms: number;
   stt_provider: string;
@@ -235,7 +236,7 @@ export type TranscriptCreateRequest = {
   language?: string;
   stt_provider?: string;
   stt_model?: string;
-  segments?: TranscriptSegment[];
+  segments?: TranscriptChunkInput[];
   word_count?: number;
 };
 

--- a/packages/shared/src/types/rag.ts
+++ b/packages/shared/src/types/rag.ts
@@ -1,5 +1,6 @@
 import type { AIProviderName } from '../ai/ai-provider';
 import type { AIAnswerResult, AIChunkSource, AIIntentResult, AISearchResult } from './ai';
+import type { AnswerPolicy } from './transcript';
 
 export type AIRagEntityKind = 'lecture_title' | 'course_title' | 'keyword' | 'quoted_phrase' | 'number' | 'context';
 
@@ -19,6 +20,10 @@ export type AIRagChunk = AISearchResult['hits'][number] & {
   start_ms?: number;
   end_ms?: number;
 };
+
+export type SearchIndexEntry = AIRagChunk;
+
+export type SearchIndex = SearchIndexEntry[];
 
 export type AIRagProviderPlan = {
   preferred_provider: AIProviderName | null;
@@ -46,5 +51,6 @@ export type AIRagResult = {
   chunks: AIRagChunk[];
   search: AISearchResult;
   answer: AIAnswerResult;
+  policy: AnswerPolicy;
   provider: AIRagProviderPlan;
 };

--- a/packages/shared/src/types/shortform.ts
+++ b/packages/shared/src/types/shortform.ts
@@ -1,3 +1,5 @@
+import type { TimelineProject, TranscriptChunk } from './transcript';
+
 export type ShortformStyle = 'highlight' | 'exam_prep' | 'quick_review' | 'deep_dive' | 'custom';
 
 export type ShortformStatus = 'DRAFT' | 'GENERATED' | 'REVIEWED' | 'PUBLIC' | 'ARCHIVED';
@@ -107,6 +109,7 @@ export type ShortformGenerateRequest = {
   style?: ShortformStyle;
   target_duration_sec?: number;
   language?: string;
+  transcript_chunks_by_lecture?: Record<string, TranscriptChunk[]>;
   transcript_segments_by_lecture?: Record<string, Array<{ start_ms: number; end_ms: number; text: string }>>;
 };
 
@@ -120,6 +123,7 @@ export type ShortformComposeRequest = {
   course_id?: string;
   title: string;
   candidate_ids?: string[];
+  timeline_project?: TimelineProject;
   clips?: Array<{
     lecture_id: string;
     start_ms: number;

--- a/packages/shared/src/types/transcript.ts
+++ b/packages/shared/src/types/transcript.ts
@@ -1,0 +1,86 @@
+export type TranscriptChunk = {
+  lecture_id?: string;
+  transcript_id?: string | null;
+  start_ms: number;
+  end_ms: number;
+  text: string;
+  confidence?: number;
+  speaker?: string | null;
+  topic_tags?: string[];
+  index: number;
+  chunk_index?: number;
+};
+
+export type TranscriptChunkInput = {
+  lecture_id?: string;
+  transcript_id?: string | null;
+  start_ms: number;
+  end_ms: number;
+  text: string;
+  confidence?: number;
+  speaker?: string | null;
+  topic_tags?: string[];
+  index: number;
+  chunk_index?: number;
+};
+
+export type TimelineProjectClip = {
+  lecture_id: string;
+  start_ms: number;
+  end_ms: number;
+  text: string;
+  confidence?: number;
+  speaker?: string | null;
+  topic_tags?: string[];
+  order_index: number;
+  note?: string | null;
+};
+
+export type TimelineProjectStatus = 'draft' | 'selected' | 'rendering' | 'exported';
+
+export type TimelineProject = {
+  id: string;
+  course_id: string;
+  title: string;
+  description: string;
+  status: TimelineProjectStatus;
+  clips: TimelineProjectClip[];
+  created_at: string;
+  updated_at: string;
+};
+
+export type AnswerPolicy = {
+  min_confidence: number;
+  clarify_threshold: number;
+  handoff_threshold: number;
+  max_clarify_rounds: number;
+  citation_required: boolean;
+};
+
+export function normalizeTranscriptChunk(
+  input: TranscriptChunkInput,
+  lectureId: string,
+  chunkIndex: number,
+  transcriptId?: string | null,
+): TranscriptChunk {
+  return {
+    lecture_id: input.lecture_id ?? lectureId,
+    transcript_id: input.transcript_id ?? transcriptId ?? null,
+    start_ms: Math.max(0, Math.round(input.start_ms)),
+    end_ms: Math.max(Math.round(input.start_ms), Math.round(input.end_ms)),
+    text: String(input.text ?? '').trim(),
+    confidence: input.confidence ?? 0.92,
+    speaker: input.speaker ?? null,
+    topic_tags: Array.isArray(input.topic_tags) ? input.topic_tags.filter(Boolean).map((value) => String(value)) : [],
+    index: input.index ?? input.chunk_index ?? chunkIndex,
+    chunk_index: input.chunk_index ?? input.index ?? chunkIndex,
+  };
+}
+
+export function buildTranscriptChunks(
+  lectureId: string,
+  chunks: TranscriptChunkInput[],
+  transcriptId?: string | null,
+): TranscriptChunk[] {
+  return chunks.map((chunk, index) => normalizeTranscriptChunk(chunk, lectureId, index, transcriptId));
+}


### PR DESCRIPTION
## What changed
- Added canonical `TranscriptChunk`, `TimelineProject`, and `AnswerPolicy` shared types.
- Split shortform generation to prefer `transcript_chunks_by_lecture` while keeping legacy segment input compatible.
- Attached answer policy data to RAG results and made low-confidence responses fall back to clarify/refuse behavior.
- Updated the frontend shortform wizard to pass chunk-based transcript data and a timeline project payload.
- Documented the chunk/search/timeline/policy boundary in `docs/architecture/rag-flow.md`.

## Why
- This aligns the codebase with the B path: one transcript source, separate search and edit consumers, and explicit answer policy handling.

## Validation
- `npm run build:frontend`
- `npm run build:backend`
- `npm run build:backend:legacy` still fails on existing pre-existing TS issues in the legacy backend workspace, unrelated to this change.
