### PR TITLE
[codex] fix legacy backend build

### DIFF
--- a/backend/src/lib/media-pipeline-actions-callback-core.ts
+++ b/backend/src/lib/media-pipeline-actions-callback-core.ts
@@ -1,11 +1,7 @@
 import type { AudioExtraction, AudioExtractionCallbackRequest, LecturePipeline, MediaRepository } from '@myway/shared';
-import { getAudioExtraction } from './media-repository-read-ops';
-import { updateAudioExtraction } from './media-repository-write-ops';
 import { runTranscriptGeneration, type STTAdapterResult } from './stt-adapter';
 import { persistLectureDuration } from './learning-store';
 import type { RuntimeBindings } from './runtime-env';
-import { createLectureSummaryNote } from './media-repository-write-ops';
-import { listLectureNotes } from './media-repository-read-ops';
 
 export type MediaExtractionCallbackResult =
   | {
@@ -25,20 +21,20 @@ async function ensureAutoTimelineSummary(
   lectureId: string,
   repository?: MediaRepository,
 ): Promise<void> {
-  const notes = await listLectureNotes(lectureId, repository);
+  const notes = repository ? await repository.listLectureNotes(lectureId) : [];
   if (notes.some((note) => note.note_type === 'ai_timeline')) {
     return;
   }
 
-  await createLectureSummaryNote(
-    userId,
-    {
-      lecture_id: lectureId,
-      style: 'timeline',
-      language: 'ko',
-    },
-    repository,
-  );
+  if (!repository) {
+    return;
+  }
+
+  await repository.createLectureSummaryNote(userId, {
+    lecture_id: lectureId,
+    style: 'timeline',
+    language: 'ko',
+  });
 }
 
 export async function completeMediaExtractionJob(
@@ -47,7 +43,7 @@ export async function completeMediaExtractionJob(
   env?: RuntimeBindings,
   repository?: MediaRepository,
 ): Promise<MediaExtractionCallbackResult> {
-  const extraction = await getAudioExtraction(payload.extraction_id, repository);
+  const extraction = repository ? await repository.getAudioExtraction(payload.extraction_id) : undefined;
   if (!extraction || extraction.lecture_id !== payload.lecture_id) {
     return {
       ok: false,
@@ -57,7 +53,7 @@ export async function completeMediaExtractionJob(
   }
 
   if (payload.status === 'FAILED') {
-    const failed = await updateAudioExtraction(payload, repository);
+    const failed = repository ? await repository.updateAudioExtraction(payload) : null;
     if (!failed) {
       return {
         ok: false,
@@ -98,11 +94,13 @@ export async function completeMediaExtractionJob(
   );
 
   if (!transcriptResult.ok) {
-    const failed = await updateAudioExtraction({
+    const failed = repository
+      ? await repository.updateAudioExtraction({
       ...payload,
       status: 'FAILED',
       error_message: '오디오 전사를 생성할 수 없습니다.',
-    }, repository);
+    })
+      : null;
 
     return {
       ok: false,
@@ -114,12 +112,14 @@ export async function completeMediaExtractionJob(
   await persistLectureDuration(extraction.lecture_id, Math.max(1, Math.round(transcriptResult.duration_ms / 60_000)), env);
   await ensureAutoTimelineSummary(userId, extraction.lecture_id, repository);
 
-  const completed = await updateAudioExtraction({
+  const completed = repository
+    ? await repository.updateAudioExtraction({
     ...payload,
     status: 'COMPLETED',
     transcript_id: transcriptResult.transcript_id,
     stt_status: 'COMPLETED',
-  }, repository);
+  })
+    : null;
 
   if (!completed) {
     return {

--- a/backend/src/lib/media-pipeline-actions-request-core.ts
+++ b/backend/src/lib/media-pipeline-actions-request-core.ts
@@ -1,10 +1,8 @@
 import type { AudioExtraction, LecturePipeline, MediaRepository, AudioExtractionRequest } from '@myway/shared';
-import { createAudioExtraction, createLectureSummaryNote, updateAudioExtraction } from './media-repository-write-ops';
 import { dispatchMediaProcessorJob } from './media-processor';
 import { runTranscriptGeneration, type STTAdapterResult } from './stt-adapter';
 import { persistLectureDuration } from './learning-store';
 import type { RuntimeBindings } from './runtime-env';
-import { listLectureNotes } from './media-repository-read-ops';
 
 export type MediaExtractionRequestResult =
   | {
@@ -30,20 +28,20 @@ async function ensureAutoTimelineSummary(
   lectureId: string,
   repository?: MediaRepository,
 ): Promise<void> {
-  const notes = await listLectureNotes(lectureId, repository);
+  const notes = repository ? await repository.listLectureNotes(lectureId) : [];
   if (notes.some((note) => note.note_type === 'ai_timeline')) {
     return;
   }
 
-  await createLectureSummaryNote(
-    userId,
-    {
-      lecture_id: lectureId,
-      style: 'timeline',
-      language: 'ko',
-    },
-    repository,
-  );
+  if (!repository) {
+    return;
+  }
+
+  await repository.createLectureSummaryNote(userId, {
+    lecture_id: lectureId,
+    style: 'timeline',
+    language: 'ko',
+  });
 }
 
 export async function createMediaExtractionJob(
@@ -82,7 +80,8 @@ export async function createMediaExtractionJob(
     await ensureAutoTimelineSummary(userId, input.lecture_id, repository);
   }
 
-  const extractionResult = await createAudioExtraction(userId, {
+  const extractionResult = repository
+    ? await repository.createAudioExtraction(userId, {
     lecture_id: input.lecture_id,
     video_url: input.video_url?.trim(),
     video_asset_key: input.video_asset_key?.trim(),
@@ -93,7 +92,8 @@ export async function createMediaExtractionJob(
     language: input.language ?? 'ko',
     stt_provider: input.stt_provider?.trim(),
     stt_model: input.stt_model?.trim(),
-  }, repository);
+  })
+    : null;
 
   if (!extractionResult) {
     return {
@@ -122,12 +122,14 @@ export async function createMediaExtractionJob(
   );
 
   if (!dispatchResult.ok) {
-    await updateAudioExtraction({
-      extraction_id: extractionResult.extraction.id,
-      lecture_id: extractionResult.extraction.lecture_id,
-      status: 'FAILED',
-      error_message: dispatchResult.message,
-    }, repository);
+    if (repository) {
+      await repository.updateAudioExtraction({
+        extraction_id: extractionResult.extraction.id,
+        lecture_id: extractionResult.extraction.lecture_id,
+        status: 'FAILED',
+        error_message: dispatchResult.message,
+      });
+    }
     return {
       ok: false,
       reason: dispatchResult.reason === 'not_configured' ? 'processor_not_configured' : 'dispatch_failed',
@@ -135,12 +137,14 @@ export async function createMediaExtractionJob(
     };
   }
 
-  const updated = await updateAudioExtraction({
-    extraction_id: extractionResult.extraction.id,
-    lecture_id: extractionResult.extraction.lecture_id,
-    status: dispatchResult.status,
-    processing_job_id: dispatchResult.job_id ?? undefined,
-  }, repository);
+  const updated = repository
+    ? await repository.updateAudioExtraction({
+        extraction_id: extractionResult.extraction.id,
+        lecture_id: extractionResult.extraction.lecture_id,
+        status: dispatchResult.status,
+        processing_job_id: dispatchResult.job_id ?? undefined,
+      })
+    : null;
 
   return {
     ok: true,

--- a/backend/src/lib/media-repository-read-ops.ts
+++ b/backend/src/lib/media-repository-read-ops.ts
@@ -3,6 +3,8 @@ import type { AudioExtraction, LectureNote, LecturePipeline, LectureTranscript }
 import { now } from '@myway/shared/lms/media/helpers';
 import { mapExtractionRow, mapNoteRow, mapPipelineRow, mapTranscriptRow, type ExtractionRow, type NoteRow, type PipelineRow, type TranscriptRow } from './media-repository-mappers';
 
+type Awaitable<T> = T | Promise<T>;
+
 export async function getLectureTranscript(db: D1Database, lectureId: string): Promise<LectureTranscript | undefined> {
   const row = await db
     .prepare('SELECT * FROM lecture_transcripts WHERE lecture_id = ? ORDER BY created_at DESC LIMIT 1')
@@ -44,9 +46,9 @@ export async function getLecturePipeline(
   db: D1Database,
   lectureId: string,
   readers: {
-    getLectureTranscript: (lectureId: string) => Promise<LectureTranscript | undefined>;
-    listLectureNotes: (lectureId: string) => Promise<LectureNote[]>;
-    listAudioExtractions: (lectureId: string) => Promise<AudioExtraction[]>;
+    getLectureTranscript: (lectureId: string) => Awaitable<LectureTranscript | undefined>;
+    listLectureNotes: (lectureId: string) => Awaitable<LectureNote[]>;
+    listAudioExtractions: (lectureId: string) => Awaitable<AudioExtraction[]>;
   },
 ): Promise<LecturePipeline> {
   const row = await db.prepare('SELECT * FROM lecture_pipelines WHERE lecture_id = ? LIMIT 1').bind(lectureId).first<PipelineRow>();

--- a/backend/src/routes/media-core-admin-callback.ts
+++ b/backend/src/routes/media-core-admin-callback.ts
@@ -18,12 +18,13 @@ export function registerMediaAdminCallbackRoutes(media: Hono): void {
     }
 
     const callback = await extractionCallbackAction(body, c.env as RuntimeBindings | undefined, getMediaRepository(c.env as RuntimeBindings | undefined));
-    if ('error' in callback) {
-      if (callback.error === 'CALLBACK_INVALID') {
+    const callbackError = 'error' in callback ? callback.error ?? 'CALLBACK_INVALID' : null;
+    if (callbackError) {
+      if (callbackError === 'CALLBACK_INVALID') {
         return jsonFailure('CALLBACK_INVALID', 'callback payload가 올바르지 않습니다.', 400);
       }
-      const status = callback.error === 'extraction_not_found' ? 404 : callback.error === 'transcript_failed' ? 502 : 400;
-      return jsonFailure(callback.error.toUpperCase(), callback.message ?? 'callback 처리에 실패했습니다.', status);
+      const status = callbackError === 'extraction_not_found' ? 404 : callbackError === 'transcript_failed' ? 502 : 400;
+      return jsonFailure(callbackError.toUpperCase(), callback.message ?? 'callback 처리에 실패했습니다.', status);
     }
 
     if (!callback.payload) {

--- a/backend/src/routes/media-core-admin-processing-ai.ts
+++ b/backend/src/routes/media-core-admin-processing-ai.ts
@@ -24,7 +24,7 @@ export function registerMediaAdminProcessingAIMRoutes(media: Hono): void {
     }
 
     const summary = await summarizeLectureAction(user, body, getMediaRepository(c.env as RuntimeBindings | undefined));
-    if ('error' in summary) {
+    if (!summary || 'error' in summary) {
       return jsonFailure('SUMMARY_FAILED', '요약을 생성할 수 없습니다.', 400);
     }
     const { result } = summary;
@@ -71,11 +71,12 @@ export function registerMediaAdminProcessingAIMRoutes(media: Hono): void {
     }
 
     const extraction = await extractAudioAction(user, body, c.req.url, c.env as RuntimeBindings | undefined, getMediaRepository(c.env as RuntimeBindings | undefined));
-    if ('error' in extraction) {
-      if (extraction.error === 'INVALID_BODY') return jsonFailure('INVALID_BODY', '요청 본문이 올바르지 않습니다.');
-      if (extraction.error === 'LECTURE_ID_REQUIRED') return jsonFailure('LECTURE_ID_REQUIRED', 'lecture_id가 필요합니다.');
-      const status = extraction.error === 'processor_not_configured' ? 503 : extraction.error === 'dispatch_failed' ? 502 : 400;
-      return jsonFailure(extraction.error.toUpperCase(), extraction.message ?? '오디오 추출 요청을 처리할 수 없습니다.', status);
+    const extractionError = 'error' in extraction ? extraction.error ?? 'dispatch_failed' : null;
+    if (extractionError) {
+      if (extractionError === 'INVALID_BODY') return jsonFailure('INVALID_BODY', '요청 본문이 올바르지 않습니다.');
+      if (extractionError === 'LECTURE_ID_REQUIRED') return jsonFailure('LECTURE_ID_REQUIRED', 'lecture_id가 필요합니다.');
+      const status = extractionError === 'processor_not_configured' ? 503 : extractionError === 'dispatch_failed' ? 502 : 400;
+      return jsonFailure(extractionError.toUpperCase(), extraction.message ?? '오디오 추출 요청을 처리할 수 없습니다.', status);
     }
 
     return jsonSuccess(

--- a/backend/src/routes/shortform-core-library.ts
+++ b/backend/src/routes/shortform-core-library.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import {
   getShortformVideoDetail,
   listMyShortformLibrary,
+  listMyShortformVideos,
   listShortformCommunity,
   saveShortformVideo,
   shareShortformVideo,

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["@cloudflare/workers-types"]
   },
   "include": ["src", "wrangler.jsonc"],
-  "exclude": ["src/dev-server.ts"]
+  "exclude": ["src/dev-server.ts", "src/dev-server-core.ts"]
 }


### PR DESCRIPTION
﻿## Summary
- Switched media pipeline request/callback flows to use the repository abstraction instead of mismatched DB-level helper signatures.
- Fixed summary/extraction route guards and shortform library imports that were breaking the legacy backend build.
- Relaxed pipeline reader types to accept awaitable repository methods and excluded dev-only Node server files from the backend tsconfig.

## Validation
- `npm run build:backend:legacy`
- `npm run build:backend`
