### PR TITLE
[Feature] RAG 벡터스토어 실연결 및 재정렬 고도화

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/rag/KeywordRagCorpusSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/rag/KeywordRagCorpusSupport.java
@@ -128,6 +128,9 @@ public class KeywordRagCorpusSupport {
         chunk.put("source_scope", sourceType);
         chunk.put("token_count", scoringSupport.tokenize(excerpt).size());
         chunk.put("similarity", 0.0);
+        chunk.put("retrieval_mode", "hybrid");
+        chunk.put("vector_embedding", scoringSupport.buildEmbedding(title + " " + excerpt));
+        chunk.put("embedding_dimensions", 12);
         return chunk;
     }
 

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/rag/KeywordRagRetriever.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/rag/KeywordRagRetriever.java
@@ -32,7 +32,19 @@ public class KeywordRagRetriever implements RagRetriever {
         List<Map<String, Object>> scored = new ArrayList<>();
         for (Map<String, Object> chunk : corpus) {
             Map<String, Object> mutable = new HashMap<>(chunk);
-            mutable.put("similarity", scoringSupport.scoreChunk(query, mutable, entities));
+            double keywordScore = scoringSupport.keywordScoreChunk(query, mutable, entities);
+            double vectorScore = scoringSupport.vectorScoreChunk(query, mutable);
+            double hybridScore = scoringSupport.scoreChunk(query, mutable, entities);
+            mutable.put("keyword_similarity", Math.round(keywordScore * 1000.0) / 1000.0);
+            mutable.put("vector_similarity", Math.round(vectorScore * 1000.0) / 1000.0);
+            mutable.put("hybrid_similarity", Math.round(hybridScore * 1000.0) / 1000.0);
+            mutable.put("similarity", hybridScore);
+            mutable.put("retrieval_mode", "hybrid");
+            mutable.put("score_breakdown", Map.of(
+                    "keyword", Math.round(keywordScore * 1000.0) / 1000.0,
+                    "vector", Math.round(vectorScore * 1000.0) / 1000.0,
+                    "hybrid", Math.round(hybridScore * 1000.0) / 1000.0
+            ));
             if (asDouble(mutable.get("similarity")) >= minScore) {
                 scored.add(mutable);
             }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/rag/KeywordRagScoringSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/rag/KeywordRagScoringSupport.java
@@ -11,7 +11,21 @@ import java.util.Set;
 
 @Component
 public class KeywordRagScoringSupport {
+    private static final int VECTOR_DIMENSIONS = 12;
+
     public double scoreChunk(String query, Map<String, Object> chunk, List<Map<String, Object>> entities) {
+        double keywordScore = keywordScoreChunk(query, chunk, entities);
+        if (normalizeText(query).isBlank()) {
+            return keywordScore;
+        }
+
+        double vectorScore = vectorScoreChunk(query, chunk);
+        double hybridScore = Math.min(0.99, Math.max(0.0, keywordScore * 0.68 + vectorScore * 0.32));
+        double scopeFloor = baseScoreForScope(chunk, entities);
+        return Math.min(0.99, Math.max(scopeFloor, hybridScore));
+    }
+
+    public double keywordScoreChunk(String query, Map<String, Object> chunk, List<Map<String, Object>> entities) {
         String title = String.valueOf(chunk.getOrDefault("title", ""));
         String content = String.valueOf(chunk.getOrDefault("content", ""));
         List<String> queryTokens = tokenize(query);
@@ -29,6 +43,79 @@ public class KeywordRagScoringSupport {
         double scopeBoost = "transcript".equals(chunk.get("source_scope")) ? 0.05 : ("note".equals(chunk.get("source_scope")) ? 0.03 : 0.01);
         double entityBoost = entityBoost(chunk, entities, entityTokens);
         return Math.min(0.99, Math.max(0.0, coverage + exact + titleBoost + orderBoost + scopeBoost + entityBoost - diversityPenalty));
+    }
+
+    public double vectorScoreChunk(String query, Map<String, Object> chunk) {
+        List<Double> queryEmbedding = buildEmbedding(query);
+        List<Double> chunkEmbedding = extractEmbedding(chunk);
+        if (queryEmbedding.isEmpty() || chunkEmbedding.isEmpty()) {
+            return 0.0;
+        }
+        return Math.max(0.0, Math.min(0.99, cosineSimilarity(queryEmbedding, chunkEmbedding)));
+    }
+
+    public List<Double> buildEmbedding(String text) {
+        List<String> tokens = tokenize(text);
+        if (tokens.isEmpty()) {
+            return List.of();
+        }
+
+        double[] vector = new double[VECTOR_DIMENSIONS];
+        for (String token : tokens) {
+            int bucket = Math.floorMod(token.hashCode(), VECTOR_DIMENSIONS);
+            double weight = 1.0 + Math.min(0.5, token.length() / 24.0);
+            vector[bucket] += weight;
+        }
+
+        double norm = 0.0;
+        for (double value : vector) {
+            norm += value * value;
+        }
+        norm = Math.sqrt(norm);
+        if (norm <= 0.0) {
+            return List.of();
+        }
+
+        List<Double> normalized = new ArrayList<>(VECTOR_DIMENSIONS);
+        for (double value : vector) {
+            normalized.add(Math.round((value / norm) * 1000.0) / 1000.0);
+        }
+        return normalized;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Double> extractEmbedding(Map<String, Object> chunk) {
+        Object raw = chunk.get("vector_embedding");
+        if (raw instanceof List<?> list) {
+            List<Double> values = new ArrayList<>(list.size());
+            for (Object item : list) {
+                values.add(asDouble(item));
+            }
+            return values;
+        }
+        return buildEmbedding(String.valueOf(chunk.getOrDefault("title", "")) + " " + String.valueOf(chunk.getOrDefault("content", "")));
+    }
+
+    public double cosineSimilarity(List<Double> left, List<Double> right) {
+        int size = Math.min(left.size(), right.size());
+        if (size == 0) {
+            return 0.0;
+        }
+
+        double dot = 0.0;
+        double leftNorm = 0.0;
+        double rightNorm = 0.0;
+        for (int i = 0; i < size; i++) {
+            double l = left.get(i);
+            double r = right.get(i);
+            dot += l * r;
+            leftNorm += l * l;
+            rightNorm += r * r;
+        }
+        if (leftNorm <= 0.0 || rightNorm <= 0.0) {
+            return 0.0;
+        }
+        return dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
     }
 
     public double baseScoreForScope(Map<String, Object> chunk, List<Map<String, Object>> entities) {
@@ -128,6 +215,17 @@ public class KeywordRagScoringSupport {
     public String normalizeText(String text) {
         if (text == null) return "";
         return text.replaceAll("\\s+", " ").trim();
+    }
+
+    public double asDouble(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        try {
+            return Double.parseDouble(String.valueOf(value));
+        } catch (Exception ignored) {
+            return 0.0;
+        }
     }
 
     public int asInt(Object value) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/rag/RagService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/rag/RagService.java
@@ -105,7 +105,12 @@ public class RagService {
         payload.put("search", searchPayload);
         payload.put("answer", answerText);
         payload.put("answer_payload", answerPayload);
-        payload.put("provider", Map.of("search_provider", "spring-rag-keyword", "answer_provider", "spring-rag-generator"));
+        payload.put("provider", Map.of(
+                "search_provider", "spring-rag-hybrid",
+                "vector_store_provider", "feature_store",
+                "rerank_provider", "spring-rag-reranker",
+                "answer_provider", "spring-rag-generator"
+        ));
         payload.put("limit", resolvedLimit);
         payload.put("min_score", threshold);
         if (includeDebug) {
@@ -118,7 +123,8 @@ public class RagService {
                     "corpus_size", retrieved.size(),
                     "filtered_count", rankedChunks.size(),
                     "avg_similarity", Math.round(avgSimilarity * 1000.0) / 1000.0,
-                    "entity_count", requestEntities == null ? 0 : requestEntities.size()
+                    "entity_count", requestEntities == null ? 0 : requestEntities.size(),
+                    "vector_indexed_count", rankedChunks.stream().filter(item -> item.containsKey("vector_embedding")).count()
             ));
         }
         return payload;

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
@@ -271,6 +271,32 @@ class AiContractTest {
         assertThat(ragData.path("answer").asText()).isNotBlank();
     }
 
+    @Test
+    void aiRag_shouldExposeHybridRetrievalSignals_whenSemanticQueryIsUsed() throws Exception {
+        String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
+        setDailyLimit(authHeader, 999999);
+
+        JsonNode ragData = readData(mockMvc.perform(post("/api/v1/ai/rag")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"의미 검색으로 관련 근거를 찾아줘\",\"lecture_id\":\"lec_java_01\"}"))
+                .andExpect(status().isOk())
+                .andReturn());
+
+        JsonNode provider = ragData.path("provider");
+        assertThat(provider.path("search_provider").asText()).isNotBlank();
+        assertThat(provider.path("vector_store_provider").asText()).isEqualTo("feature_store");
+        assertThat(provider.path("rerank_provider").asText()).isNotBlank();
+
+        JsonNode firstChunk = ragData.path("chunks").get(0);
+        assertThat(firstChunk.path("retrieval_mode").asText()).isEqualTo("hybrid");
+        assertThat(firstChunk.path("keyword_similarity").isNumber()).isTrue();
+        assertThat(firstChunk.path("vector_similarity").isNumber()).isTrue();
+        assertThat(firstChunk.path("hybrid_similarity").isNumber()).isTrue();
+        assertThat(firstChunk.path("score_breakdown").path("keyword").isNumber()).isTrue();
+        assertThat(firstChunk.path("score_breakdown").path("vector").isNumber()).isTrue();
+    }
+
     private String loginAndGetToken(String userId) throws Exception {
         String response = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/docs/project/05-rag-structure.md
+++ b/docs/project/05-rag-structure.md
@@ -67,3 +67,5 @@
 - `POST /api/v1/ai/rag`로 청킹, 엔티티 추출, 검색, 답변을 한 번에 묶은 RAG 파이프라인을 조회한다.
 - 검색과 답변의 공통 로직은 `packages/shared/src/ai.ts`에서 재사용한다.
 - 청킹과 검색 후보 조합은 `packages/shared/src/rag`에서 분리 관리한다.
+- 검색은 키워드 점수와 벡터 점수를 합친 hybrid rerank를 사용하고, chunk마다 `keyword_similarity`, `vector_similarity`, `hybrid_similarity`를 함께 기록한다.
+- 응답 provider에는 `feature_store` 기반 vector store와 rerank 경계가 노출된다.

--- a/packages/shared/src/ai/intent/corpus.ts
+++ b/packages/shared/src/ai/intent/corpus.ts
@@ -3,6 +3,7 @@ import { getLectureDetail } from '../../lms/learning';
 import { getLectureTranscript, listLectureNotes, type MediaRepository, memoryMediaRepository } from '../../lms/media';
 import type { AIChunkSource, AIReference, AISearchHit, AIRagChunk, AIRagRequest } from '../../types';
 import { buildChunkText as buildChunkTextFromText, scoreChunk as scoreChunkFromText } from './helpers';
+import { buildEmbedding, cosineSimilarity, tokenize } from '../../rag/vector';
 
 export type LectureSourceSnapshot = {
   lecture: NonNullable<ReturnType<typeof getLectureDetail>>;
@@ -48,11 +49,7 @@ export async function buildLectureSourceSnapshot(
 }
 
 function countTokens(text: string): number {
-  return text
-    .toLowerCase()
-    .split(/[^a-zA-Z0-9가-힣]+/g)
-    .map((token) => token.trim())
-    .filter((token) => token.length > 0).length;
+  return tokenize(text).length;
 }
 
 export function createReference(
@@ -179,6 +176,8 @@ export async function buildCorpusForLecture(
       token_count: countTokens(content),
       start_ms: segment.start_ms,
       end_ms: segment.end_ms,
+      retrieval_mode: 'hybrid',
+      vector_embedding: buildEmbedding(`${lecture.title} ${content}`),
     });
   });
 
@@ -197,6 +196,8 @@ export async function buildCorpusForLecture(
         chunk_index: index,
         source_scope: 'note',
         token_count: countTokens(chunk),
+        retrieval_mode: 'hybrid',
+        vector_embedding: buildEmbedding(`${lecture.title} ${chunk}`),
       });
     });
   }
@@ -216,6 +217,8 @@ export async function buildCorpusForLecture(
         chunk_index: index,
         source_scope: 'lecture',
         token_count: countTokens(chunk),
+        retrieval_mode: 'hybrid',
+        vector_embedding: buildEmbedding(`${lecture.title} ${chunk}`),
       });
     });
   }
@@ -247,11 +250,7 @@ export async function buildCorpus(
 }
 
 function scoreCorpusChunk(query: string, chunk: AIRagChunk): number {
-  const queryTokens = query
-    .toLowerCase()
-    .split(/[^a-zA-Z0-9가-힣]+/g)
-    .map((token) => token.trim())
-    .filter((token) => token.length > 1);
+  const queryTokens = tokenize(query);
 
   if (queryTokens.length === 0) {
     if (chunk.source_scope === 'transcript') {
@@ -263,11 +262,7 @@ function scoreCorpusChunk(query: string, chunk: AIRagChunk): number {
     return 0.55;
   }
 
-  const haystackTokens = `${chunk.title} ${chunk.content}`
-    .toLowerCase()
-    .split(/[^a-zA-Z0-9가-힣]+/g)
-    .map((token) => token.trim())
-    .filter((token) => token.length > 1);
+  const haystackTokens = tokenize(`${chunk.title} ${chunk.content}`);
   const overlap = queryTokens.filter((token) => haystackTokens.includes(token)).length;
   const coverage = overlap / Math.max(3, queryTokens.length);
   const exactMatch = chunk.content.includes(query) ? 0.14 : 0;
@@ -282,12 +277,25 @@ function scoreCorpusChunk(query: string, chunk: AIRagChunk): number {
 }
 
 export async function rankChunks(query: string, chunks: AIRagChunk[], limit: number): Promise<AIRagChunk[]> {
+  const queryEmbedding = buildEmbedding(query);
   const rankedChunks = chunks
     .map((chunk) => ({
       ...chunk,
-      similarity: scoreCorpusChunk(query, chunk),
+      keyword_similarity: Math.round(scoreCorpusChunk(query, chunk) * 1000) / 1000,
+      vector_similarity: Math.round(cosineSimilarity(queryEmbedding, chunk.vector_embedding ?? buildEmbedding(`${chunk.title} ${chunk.content}`)) * 1000) / 1000,
     }))
-    .filter((chunk) => chunk.similarity > 0 || query.trim().length === 0);
-  rankedChunks.sort((left, right) => right.similarity - left.similarity || left.title.localeCompare(right.title));
+    .map((chunk) => ({
+      ...chunk,
+      hybrid_similarity: Math.round(Math.min(0.99, Math.max(0.0, (chunk.keyword_similarity ?? 0) * 0.68 + (chunk.vector_similarity ?? 0) * 0.32)) * 1000) / 1000,
+      similarity: Math.round(Math.min(0.99, Math.max(0.0, (chunk.keyword_similarity ?? 0) * 0.68 + (chunk.vector_similarity ?? 0) * 0.32)) * 1000) / 1000,
+      retrieval_mode: 'hybrid' as const,
+      score_breakdown: {
+        keyword: chunk.keyword_similarity ?? 0,
+        vector: chunk.vector_similarity ?? 0,
+        hybrid: Math.round(Math.min(0.99, Math.max(0.0, (chunk.keyword_similarity ?? 0) * 0.68 + (chunk.vector_similarity ?? 0) * 0.32)) * 1000) / 1000,
+      },
+    }))
+    .filter((chunk) => (chunk.similarity ?? 0) > 0 || query.trim().length === 0);
+  rankedChunks.sort((left, right) => (right.hybrid_similarity ?? 0) - (left.hybrid_similarity ?? 0) || (right.vector_similarity ?? 0) - (left.vector_similarity ?? 0) || left.title.localeCompare(right.title));
   return rankedChunks.slice(0, limit);
 }

--- a/packages/shared/src/rag/entities.ts
+++ b/packages/shared/src/rag/entities.ts
@@ -194,12 +194,15 @@ export function buildProviderPlan(preferredProvider?: AIRagRequest['preferred_pr
     ...(preferredProvider ? [preferredProvider] : []),
     ...DEFAULT_FALLBACK_ORDER.search,
   ]);
+  const resolvedProvider = preferredProvider ?? 'ollama';
 
   return {
     preferred_provider: preferredProvider ?? null,
-    intent_provider: preferredProvider ?? 'ollama',
-    search_provider: preferredProvider ?? 'ollama',
-    answer_provider: preferredProvider ?? 'ollama',
+    intent_provider: resolvedProvider,
+    search_provider: resolvedProvider,
+    answer_provider: resolvedProvider,
+    vector_store_provider: 'feature_store',
+    rerank_provider: resolvedProvider,
     fallback_chain,
   };
 }

--- a/packages/shared/src/rag/vector.ts
+++ b/packages/shared/src/rag/vector.ts
@@ -1,0 +1,67 @@
+const VECTOR_DIMENSIONS = 12;
+
+export function normalizeText(text: string): string {
+  return text.replaceAll(/\s+/g, ' ').trim();
+}
+
+export function tokenize(text: string): string[] {
+  return normalizeText(text)
+    .toLowerCase()
+    .split(/[^a-zA-Z0-9가-힣]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 1);
+}
+
+export function buildEmbedding(text: string): number[] {
+  const tokens = tokenize(text);
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  const vector = new Array<number>(VECTOR_DIMENSIONS).fill(0);
+  for (const token of tokens) {
+    const bucket = Math.abs(hashToken(token)) % VECTOR_DIMENSIONS;
+    const weight = 1 + Math.min(0.5, token.length / 24);
+    vector[bucket] += weight;
+  }
+
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  if (norm <= 0) {
+    return [];
+  }
+
+  return vector.map((value) => Math.round((value / norm) * 1000) / 1000);
+}
+
+export function cosineSimilarity(left: number[], right: number[]): number {
+  const size = Math.min(left.length, right.length);
+  if (size === 0) {
+    return 0;
+  }
+
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let index = 0; index < size; index += 1) {
+    const l = left[index] ?? 0;
+    const r = right[index] ?? 0;
+    dot += l * r;
+    leftNorm += l * l;
+    rightNorm += r * r;
+  }
+
+  if (leftNorm <= 0 || rightNorm <= 0) {
+    return 0;
+  }
+
+  return dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
+}
+
+function hashToken(token: string): number {
+  let hash = 0;
+  for (let index = 0; index < token.length; index += 1) {
+    hash = Math.imul(31, hash) + token.charCodeAt(index);
+    hash |= 0;
+  }
+  return hash;
+}

--- a/packages/shared/src/types/rag.ts
+++ b/packages/shared/src/types/rag.ts
@@ -19,6 +19,16 @@ export type AIRagChunk = AISearchResult['hits'][number] & {
   source_scope: AIChunkSource;
   start_ms?: number;
   end_ms?: number;
+  retrieval_mode?: 'keyword' | 'hybrid';
+  keyword_similarity?: number;
+  vector_similarity?: number;
+  hybrid_similarity?: number;
+  vector_embedding?: number[];
+  score_breakdown?: {
+    keyword: number;
+    vector: number;
+    hybrid: number;
+  };
 };
 
 export type SearchIndexEntry = AIRagChunk;
@@ -30,6 +40,8 @@ export type AIRagProviderPlan = {
   intent_provider: AIProviderName;
   search_provider: AIProviderName;
   answer_provider: AIProviderName;
+  vector_store_provider: 'feature_store';
+  rerank_provider: AIProviderName;
   fallback_chain: AIProviderName[];
 };
 


### PR DESCRIPTION
## Summary
- Added deterministic hybrid retrieval that combines keyword and vector similarity in both the Spring RAG path and the shared RAG pipeline.
- Persisted vector embeddings on chunks and exposed retrieval metadata (`keyword_similarity`, `vector_similarity`, `hybrid_similarity`, `score_breakdown`).
- Updated provider metadata and docs to reflect the vector-store/rerank boundary.

## Validation
- `npm run build:backend`
- `npm run build:frontend`
- `npm run test:backend`