### PR TITLE
[Feature] 백엔드 운영 문서/트러블슈팅 정비(T021~T022)

### DIFF
--- a/backend-spring/README.md
+++ b/backend-spring/README.md
@@ -23,7 +23,8 @@
 - timeout: job 기준 15분(`timeout-minutes: 15`)
 
 ## Persistence Architecture
-- Store: H2 file DB (`jdbc:h2:file:./data/myway-feature-store`)
+- Local store: H2 file DB (`jdbc:h2:file:./data/myway-feature-store`)
+- Production store: PostgreSQL/Supabase (`MYWAY_DB_URL`, `MYWAY_DB_USERNAME`, `MYWAY_DB_PASSWORD`)
 - Adapter: `FeatureJdbcStore`
 - Scope-based 저장 구조:
   - KV: `scope + item_id` 기반 단건 상태 저장
@@ -33,6 +34,10 @@
   - Media: `media_transcript`, `media_extraction`, `media_pipeline`, `media_note`, `media_asset`
   - Shortform: `shortform_extraction`, `shortform_video`, `shortform_save`, `shortform_share`, `shortform_like`
   - Custom: `custom_course`
+- 운영 참고:
+  - `FeatureJdbcStore`는 H2와 PostgreSQL을 모두 지원한다.
+  - callback/version 충돌은 `last_event_version` 기준으로 차단한다.
+  - signed callback은 `nonce + ttl + secret` 검증을 통과해야 한다.
 
 ## Shortform Retry / Callback Policy
 - 재시도 상한: `myway.shortform.retry.max-attempts` (기본값 3, 최소 1)
@@ -43,6 +48,31 @@
 - Callback 멱등/순서 보장:
   - `event_version`이 현재 `last_event_version`보다 작거나 같으면 무시
   - 최신 버전 이벤트만 상태를 갱신
+
+## Security Notes
+- Authenticated API는 JWT 세션을 사용한다.
+- 외부 processor callback은 `MYWAY_MEDIA_CALLBACK_SECRET`과 `MYWAY_MEDIA_PROCESSOR_TOKEN`으로 보호한다.
+- callback replay는 nonce guard로, stale version은 `last_event_version` guard로 방어한다.
+- 운영 로그에는 raw secret을 남기지 않는다.
+
+## Railway Deployment Checklist
+- Java 21 런타임을 사용한다.
+- Build command: `./mvnw -DskipTests package`
+- Start command: `java -jar target/backend-spring-0.1.0.jar`
+- Required env vars:
+  - `MYWAY_DB_URL`
+  - `MYWAY_DB_USERNAME`
+  - `MYWAY_DB_PASSWORD`
+  - `MYWAY_MEDIA_PROCESSOR_URL`
+  - `MYWAY_MEDIA_PROCESSOR_TOKEN`
+  - `MYWAY_MEDIA_CALLBACK_SECRET`
+- Optional env vars:
+  - `MYWAY_AI_PUBLIC_MODE`
+  - `MYWAY_AI_REQUIRE_AUTH`
+  - `MYWAY_AI_ENABLE_STT`
+  - `MYWAY_AI_ENABLE_MEDIA_UPLOAD`
+- If using Supabase pooler, keep `sslmode=require` in the JDBC URL.
+- Validate with `mvnw.cmd test` before deploying the release tag.
 
 ## Implemented Endpoints
 - GET `/`

--- a/docs/troubleshooting-shortform-callback-version.md
+++ b/docs/troubleshooting-shortform-callback-version.md
@@ -4,22 +4,28 @@
 - export callback이 왔는데 상태가 갱신되지 않음
 - `FAILED` 이후 다시 `PROCESSING`으로 보냈는데 이전 callback이 상태를 덮어씀
 - 동일 callback 재전송 시 상태가 흔들림
+- media extraction callback에서도 같은 식으로 오래된 상태가 다시 반영되는 것처럼 보임
 
 ## 원인
 - callback `event_version`이 이미 처리된 `last_event_version` 이하
 - 구버전 callback 재전송 또는 지연 도착
+- media extraction / shortform export 모두 같은 stale-event guard를 사용한다
 
 ## 확인 방법
 1. 대상 shortform 레코드의 `last_event_version` 확인
 2. callback payload의 `event_version`과 비교
 3. `event_version <= last_event_version`이면 서버가 무시하는 것이 정상
+4. media extraction인 경우에도 동일하게 extraction 레코드의 `last_event_version`을 확인
 
 ## 대응 방법
 1. callback 발행자에서 `event_version`을 단조 증가로 관리
 2. 재시도 시에도 동일 버전을 재사용하지 말고 새 버전으로 발행
 3. 실패 상태에서 재시도 API(`/api/v1/shortform/retry`)로 `PROCESSING` 재진입 후 callback 발행
+4. media extraction callback은 재전송보다 새로운 event version 발행을 우선한다
 
 ## 운영 체크리스트
 - [ ] callback producer가 shortform 단위로 증가 버전을 보장하는가
 - [ ] callback 재전송 로직이 과거 버전을 재사용하지 않는가
 - [ ] `retry_count`가 상한(`myway.shortform.retry.max-attempts`)을 초과하지 않는가
+- [ ] media extraction callback도 `event_version`이 단조 증가하는가
+- [ ] 오래된 callback이 와도 `last_event_version`이 되돌아가지 않는가


### PR DESCRIPTION
## Summary
- Updated `backend-spring/README.md` with current persistence, security, and Railway deployment guidance.
- Expanded the shortform callback/version troubleshooting doc to include the media extraction callback case and the shared stale-event guard pattern.

## Validation
- `git diff --check`