### PR TITLE
[Feature] 인텐트/NLP 도메인 튜닝 및 임계값 재조정

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/feature/understanding/RuleBasedIntentClassificationService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/understanding/RuleBasedIntentClassificationService.java
@@ -43,7 +43,7 @@ public class RuleBasedIntentClassificationService implements IntentClassificatio
         debug.put("source", context.sourceType());
         debug.put("rule_score", score.confidence);
 
-        if (score.confidence < 0.72 && aiRuntimeService != null) {
+        if (score.confidence < 0.68 && aiRuntimeService != null) {
             Map<String, Object> runtime = aiRuntimeService.generate(
                     "intent",
                     promptService.buildIntentPrompt(context, entities),
@@ -52,7 +52,7 @@ public class RuleBasedIntentClassificationService implements IntentClassificatio
             String runtimeText = String.valueOf(runtime.getOrDefault("text", ""));
             String runtimeIntent = inferIntentFromText(runtimeText);
             if (!"unknown".equals(runtimeIntent)) {
-                score = new IntentScore(runtimeIntent, Math.max(score.confidence, 0.76));
+                score = new IntentScore(runtimeIntent, Math.max(score.confidence, 0.74));
             }
             debug.put("provider", runtime.getOrDefault("provider", "demo"));
             debug.put("model", runtime.getOrDefault("model", "demo-intent-v1"));

--- a/backend-spring/src/test/java/com/myway/backendspring/feature/understanding/InputUnderstandingServiceTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/feature/understanding/InputUnderstandingServiceTest.java
@@ -51,4 +51,32 @@ class InputUnderstandingServiceTest {
         assertThat(result.entities()).isNotEmpty();
         assertThat(result.debug()).containsKey("source");
     }
+
+    @Test
+    void understandMessage_shouldPreferSummaryForShortformSummaryQuery() {
+        UnderstandingResult result = service.understandMessage(
+                "usr_std_001",
+                "숏폼으로 요약해줘",
+                "lec_java_01",
+                null
+        );
+
+        assertThat(result.intent()).isEqualTo("summary");
+        assertThat(result.route()).isEqualTo("summary");
+        assertThat(result.confidence()).isGreaterThanOrEqualTo(0.9);
+    }
+
+    @Test
+    void understandMessage_shouldKeepRecommendationForSuggestionQuery() {
+        UnderstandingResult result = service.understandMessage(
+                "usr_std_001",
+                "추천 강의 알려줘",
+                "lec_java_01",
+                null
+        );
+
+        assertThat(result.intent()).isEqualTo("recommendation");
+        assertThat(result.route()).isEqualTo("recommendation");
+        assertThat(result.confidence()).isGreaterThanOrEqualTo(0.8);
+    }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:frontend": "npm --workspace @myway/frontend run build",
     "build:backend": "tsx scripts/run-maven-wrapper.ts -DskipTests package",
     "test:backend": "tsx scripts/run-maven-wrapper.ts test",
+    "test:shared:intent": "tsx packages/shared/src/ai/intent/intent-regression.test.ts",
     "test:frontend": "npm --workspace @myway/frontend run test",
     "test:backend:clean": "node -e \"const fs=require('fs');fs.rmSync('backend-spring/data',{recursive:true,force:true});\" && npm run test:backend",
     "build:backend:legacy": "npm --workspace @myway/backend run build",
@@ -35,7 +36,7 @@
     "perf:smoke": "npm run build:frontend",
     "smoke:media-ai-shortform": "tsx scripts/smoke-media-ai-shortform.ts",
     "test:e2e:demo-student": "playwright test e2e/demo-student-journey.spec.ts --reporter=line",
-    "verify": "npm run check:deps && npm run build:frontend && npm run test:backend"
+    "verify": "npm run check:deps && npm run build:frontend && npm run test:shared:intent && npm run test:backend"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",

--- a/packages/shared/src/ai/intent/helpers.ts
+++ b/packages/shared/src/ai/intent/helpers.ts
@@ -16,18 +16,19 @@ export const INTENT_RULES: Array<{
   intent: AIIntent;
   action: AIAction;
   keywords: string[];
+  priority: number;
 }> = [
-  { intent: 'request_summary', action: 'DIRECT_ANSWER', keywords: ['요약', '정리', '핵심', 'summary'] },
-  { intent: 'generate_quiz', action: 'DECOMPOSE', keywords: ['퀴즈', '문제', '문항', '플래시카드', 'flashcard'] },
-  { intent: 'search_content', action: 'SEARCH', keywords: ['검색', '찾', '어디', '근거', '검색해', 'search'] },
-  { intent: 'ask_concept', action: 'DIRECT_ANSWER', keywords: ['무엇', '뭐', '왜', '어떻게', '설명', '알려줘'] },
-  { intent: 'ask_recommendation', action: 'SEARCH', keywords: ['추천', '무슨', '어떤 강의', '골라', 'recommend'] },
-  { intent: 'explain_deeper', action: 'DIRECT_ANSWER', keywords: ['자세히', '깊게', '더 설명', '왜 그런지'] },
-  { intent: 'translate', action: 'DIRECT_ANSWER', keywords: ['번역', 'translate'] },
-  { intent: 'compare', action: 'DECOMPOSE', keywords: ['비교', '차이', '다른 점'] },
-  { intent: 'create_shortform', action: 'DECOMPOSE', keywords: ['숏폼', 'shortform', '클립'] },
-  { intent: 'extract_audio', action: 'DIRECT_ANSWER', keywords: ['오디오', '음성 추출', 'extract audio'] },
-  { intent: 'analyze_progress', action: 'DIRECT_ANSWER', keywords: ['진도', '진행', '수강 현황', 'progress'] },
+  { intent: 'request_summary', action: 'DIRECT_ANSWER', keywords: ['요약', '정리', '핵심', 'summary'], priority: 60 },
+  { intent: 'generate_quiz', action: 'DECOMPOSE', keywords: ['퀴즈', '문제', '문항', '플래시카드', 'flashcard'], priority: 55 },
+  { intent: 'search_content', action: 'SEARCH', keywords: ['검색', '찾', '어디', '근거', '검색해', 'search'], priority: 50 },
+  { intent: 'compare', action: 'DECOMPOSE', keywords: ['비교', '차이', '다른 점'], priority: 48 },
+  { intent: 'ask_recommendation', action: 'SEARCH', keywords: ['추천', '무슨', '어떤 강의', '골라', 'recommend'], priority: 45 },
+  { intent: 'create_shortform', action: 'DECOMPOSE', keywords: ['숏폼', 'shortform', '클립'], priority: 44 },
+  { intent: 'explain_deeper', action: 'DIRECT_ANSWER', keywords: ['자세히', '깊게', '더 설명', '왜 그런지'], priority: 40 },
+  { intent: 'ask_concept', action: 'DIRECT_ANSWER', keywords: ['무엇', '뭐', '왜', '어떻게', '설명', '알려줘'], priority: 35 },
+  { intent: 'translate', action: 'DIRECT_ANSWER', keywords: ['번역', 'translate'], priority: 30 },
+  { intent: 'extract_audio', action: 'DIRECT_ANSWER', keywords: ['오디오', '음성 추출', 'extract audio'], priority: 25 },
+  { intent: 'analyze_progress', action: 'DIRECT_ANSWER', keywords: ['진도', '진행', '수강 현황', 'progress'], priority: 25 },
 ];
 
 export function normalizeText(text: string): string {
@@ -160,7 +161,7 @@ export function rankIntentRules(normalized: string): {
       score: matchedKeywords.length * 0.2 + (matchedKeywords.length > 0 ? 0.45 : 0),
     };
   });
-  rankedRules.sort((left, right) => right.score - left.score);
+  rankedRules.sort((left, right) => right.score - left.score || right.priority - left.priority || right.matchedKeywords.length - left.matchedKeywords.length);
 
   const topRule = rankedRules[0];
   const secondRule = rankedRules[1];
@@ -168,7 +169,13 @@ export function rankIntentRules(normalized: string): {
   return {
     topRule,
     secondRule,
-    hasAmbiguousMatch: Boolean(topRule && secondRule && topRule.score >= 0.5 && Math.abs(topRule.score - secondRule.score) < 0.1),
+    hasAmbiguousMatch: Boolean(
+      topRule &&
+      secondRule &&
+      topRule.score >= 0.5 &&
+      Math.abs(topRule.score - secondRule.score) < 0.1 &&
+      topRule.priority === secondRule.priority,
+    ),
   };
 }
 

--- a/packages/shared/src/ai/intent/intent-regression.test.ts
+++ b/packages/shared/src/ai/intent/intent-regression.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { buildSmartChatOverview } from '../smart';
+import { classifyAIIntent } from './pipeline';
+
+async function main() {
+  const summaryIntent = classifyAIIntent({
+    message: '숏폼으로 요약해줘',
+    lecture_id: 'lec_java_01',
+  });
+  assert.equal(summaryIntent.intent, 'request_summary');
+  assert.equal(summaryIntent.action, 'DIRECT_ANSWER');
+  assert.equal(summaryIntent.needs_clarification, false);
+
+  const compareIntent = classifyAIIntent({
+    message: '이 두 개념 차이 설명해줘',
+    lecture_id: 'lec_java_01',
+  });
+  assert.equal(compareIntent.intent, 'compare');
+  assert.equal(compareIntent.action, 'DECOMPOSE');
+  assert.equal(compareIntent.needs_clarification, false);
+
+  const smartSummary = await buildSmartChatOverview({
+    message: '숏폼으로 요약해줘',
+    lecture_id: 'lec_java_01',
+  });
+  assert.equal(smartSummary.route, 'summary');
+  assert.equal(smartSummary.intent.intent, 'request_summary');
+
+  const smartCompare = await buildSmartChatOverview({
+    message: '이 두 개념 차이 설명해줘',
+    lecture_id: 'lec_java_01',
+  });
+  assert.equal(smartCompare.route, 'compare');
+  assert.equal(smartCompare.intent.intent, 'compare');
+}
+
+await main();

--- a/packages/shared/src/ai/intent/pipeline.ts
+++ b/packages/shared/src/ai/intent/pipeline.ts
@@ -55,7 +55,7 @@ export function classifyAIIntent(input: AIIntentRequest): AIIntentResult {
   const intent = hasAmbiguousMatch ? 'clarify' : topRule?.intent ?? fallbackIntent;
   const baseScore = topRule?.score ?? (intent === 'general_chat' ? 0.42 : 0.5);
   const confidence = clampConfidence(baseScore + (input.lecture_id ? 0.05 : 0));
-  const needsClarification = intent === 'clarify' || confidence < 0.6;
+  const needsClarification = intent === 'clarify' || confidence < 0.55;
   let action: AIAction = 'DIRECT_ANSWER';
   if (hasAmbiguousMatch) {
     action = 'CLARIFY';


### PR DESCRIPTION
## Summary
- Tuned shared intent ranking so summary/search/compare routes win over ambiguous shortform blends.
- Lowered clarification threshold in the shared intent pipeline.
- Aligned the backend understanding service with the new runtime confidence threshold.
- Added regression coverage for summary, compare, and smart chat routing.

## Validation
- `npm run test:shared:intent`
- `npm run build:frontend`
- `npm run test:backend`