### PR TITLE
[Feature] AI quota/rate-limit 역할별 세분화

### DIFF
--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerAuthSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerAuthSupport.java
@@ -4,6 +4,7 @@ import com.myway.backendspring.auth.SessionService;
 import com.myway.backendspring.auth.SessionView;
 import com.myway.backendspring.common.ApiResponse;
 import com.myway.backendspring.feature.FeatureStoreAiFacade;
+import com.myway.backendspring.feature.quota.AiUsageQuotaService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
@@ -21,13 +22,15 @@ public class AiControllerAuthSupport {
     public ResponseEntity<ApiResponse<Map<String, Object>>> requireAiEligible(
             FeatureStoreAiFacade featureStore,
             SessionView session,
-            AiControllerSupport aiControllerSupport
+            AiControllerSupport aiControllerSupport,
+            String feature
     ) {
         if (session == null) {
             return aiControllerSupport.unauthenticated();
         }
-        if (!featureStore.canConsumeAi(session.user().id())) {
-            return aiControllerSupport.dailyLimitExceeded();
+        AiUsageQuotaService.QuotaDecision decision = featureStore.canConsumeAi(session.user().id(), session.user().role(), feature);
+        if (!decision.allowed()) {
+            return aiControllerSupport.dailyLimitExceeded(decision.meta());
         }
         return null;
     }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerGenerationSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerGenerationSupport.java
@@ -52,7 +52,7 @@ public class AiControllerGenerationSupport {
 
     public ResponseEntity<ApiResponse<Map<String, Object>>> intent(String auth, AiController.IntentRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session, "intent");
         if (guard != null) return guard;
         String message = aiRequestSupport.normalize(body.message());
         UnderstandingResult result = inputUnderstandingService.understandMessage(
@@ -68,7 +68,7 @@ public class AiControllerGenerationSupport {
 
     public ResponseEntity<ApiResponse<Map<String, Object>>> search(String auth, AiController.SearchRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session, "search");
         if (guard != null) return guard;
         String query = aiRequestSupport.normalize(body.query());
         String lectureId = aiRequestSupport.optionalNormalized(body.lecture_id());
@@ -91,7 +91,7 @@ public class AiControllerGenerationSupport {
 
     public ResponseEntity<ApiResponse<Map<String, Object>>> answer(String auth, AiController.AnswerRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session, "answer");
         if (guard != null) return guard;
         String question = aiRequestSupport.normalize(body.question());
         String lectureId = aiRequestSupport.optionalNormalized(body.lecture_id());
@@ -106,7 +106,7 @@ public class AiControllerGenerationSupport {
 
     public ResponseEntity<ApiResponse<Map<String, Object>>> summary(String auth, AiController.SummaryRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session, "summary");
         if (guard != null) return guard;
         String lectureId = aiRequestSupport.requireLectureId(body.lecture_id());
         ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLectureExists(lectureId);
@@ -125,7 +125,7 @@ public class AiControllerGenerationSupport {
 
     public ResponseEntity<ApiResponse<Map<String, Object>>> quiz(String auth, AiController.QuizRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session, "quiz");
         if (guard != null) return guard;
         String lectureId = aiRequestSupport.requireLectureId(body.lecture_id());
         ResponseEntity<ApiResponse<Map<String, Object>>> lectureError = validateLectureExists(lectureId);
@@ -144,8 +144,8 @@ public class AiControllerGenerationSupport {
         return aiControllerAuthSupport.requireSession(sessionService, auth);
     }
 
-    private ResponseEntity<ApiResponse<Map<String, Object>>> requireAiGuard(SessionView session) {
-        return aiControllerAuthSupport.requireAiEligible(featureStore, session, aiControllerSupport);
+    private ResponseEntity<ApiResponse<Map<String, Object>>> requireAiGuard(SessionView session, String feature) {
+        return aiControllerAuthSupport.requireAiEligible(featureStore, session, aiControllerSupport, feature);
     }
 
     private ResponseEntity<ApiResponse<Map<String, Object>>> validateLectureExists(String lectureId) {

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerQuerySupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerQuerySupport.java
@@ -83,7 +83,7 @@ public class AiControllerQuerySupport {
 
     public ResponseEntity<ApiResponse<Map<String, Object>>> rag(String auth, AiController.RagRequest body) {
         SessionView session = require(auth);
-        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session);
+        ResponseEntity<ApiResponse<Map<String, Object>>> guard = requireAiGuard(session, "rag");
         if (guard != null) return guard;
 
         String query = aiRequestSupport.normalize(body.query());
@@ -156,7 +156,7 @@ public class AiControllerQuerySupport {
         return aiControllerAuthSupport.requireSession(sessionService, auth);
     }
 
-    private ResponseEntity<ApiResponse<Map<String, Object>>> requireAiGuard(SessionView session) {
-        return aiControllerAuthSupport.requireAiEligible(featureStore, session, aiControllerSupport);
+    private ResponseEntity<ApiResponse<Map<String, Object>>> requireAiGuard(SessionView session, String feature) {
+        return aiControllerAuthSupport.requireAiEligible(featureStore, session, aiControllerSupport, feature);
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerRuntimeSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerRuntimeSupport.java
@@ -15,9 +15,10 @@ public class AiControllerRuntimeSupport {
             FeatureStoreAiFacade featureStore,
             SessionView session,
             AiControllerSupport aiControllerSupport,
-            AiControllerAuthSupport aiControllerAuthSupport
+            AiControllerAuthSupport aiControllerAuthSupport,
+            String feature
     ) {
-        return aiControllerAuthSupport.requireAiEligible(featureStore, session, aiControllerSupport);
+        return aiControllerAuthSupport.requireAiEligible(featureStore, session, aiControllerSupport, feature);
     }
 
     public Map<String, Object> generate(

--- a/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/api/support/AiControllerSupport.java
@@ -17,7 +17,25 @@ public class AiControllerSupport {
     }
 
     public ResponseEntity<ApiResponse<Map<String, Object>>> dailyLimitExceeded() {
-        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다."));
+        return dailyLimitExceeded(Map.of());
+    }
+
+    public ResponseEntity<ApiResponse<Map<String, Object>>> dailyLimitExceeded(Map<String, Object> meta) {
+        ResponseEntity.BodyBuilder builder = ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS);
+        if (meta != null) {
+            Object remaining = meta.get("remaining");
+            Object resetAt = meta.get("reset_at");
+            Object role = meta.get("role");
+            Object feature = meta.get("feature");
+            Object limit = meta.get("limit");
+            if (remaining != null) builder.header("X-AI-Quota-Remaining", String.valueOf(remaining));
+            if (resetAt != null) builder.header("X-AI-Quota-Reset", String.valueOf(resetAt));
+            if (role != null) builder.header("X-AI-Quota-Role", String.valueOf(role));
+            if (feature != null) builder.header("X-AI-Quota-Feature", String.valueOf(feature));
+            if (limit != null) builder.header("X-AI-Quota-Limit", String.valueOf(limit));
+            return builder.body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다.", meta));
+        }
+        return builder.body(ApiResponse.failure("DAILY_LIMIT_EXCEEDED", "일일 사용량을 초과했습니다."));
     }
 
     public Map<String, Object> intentResponse(UnderstandingResult result) {

--- a/backend-spring/src/main/java/com/myway/backendspring/common/ApiError.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/common/ApiError.java
@@ -1,3 +1,9 @@
 package com.myway.backendspring.common;
 
-public record ApiError(String code, String message) {}
+import java.util.Map;
+
+public record ApiError(String code, String message, Map<String, Object> meta) {
+    public ApiError(String code, String message) {
+        this(code, message, Map.of());
+    }
+}

--- a/backend-spring/src/main/java/com/myway/backendspring/common/ApiResponse.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/common/ApiResponse.java
@@ -1,5 +1,7 @@
 package com.myway.backendspring.common;
 
+import java.util.Map;
+
 public record ApiResponse<T>(boolean success, T data, ApiError error, String message) {
     public static <T> ApiResponse<T> success(T data, String message) {
         return new ApiResponse<>(true, data, null, message);
@@ -11,5 +13,9 @@ public record ApiResponse<T>(boolean success, T data, ApiError error, String mes
 
     public static <T> ApiResponse<T> failure(String code, String message) {
         return new ApiResponse<>(false, null, new ApiError(code, message), message);
+    }
+
+    public static <T> ApiResponse<T> failure(String code, String message, Map<String, Object> meta) {
+        return new ApiResponse<>(false, null, new ApiError(code, message, meta), message);
     }
 }

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreAiFacade.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreAiFacade.java
@@ -1,6 +1,7 @@
 package com.myway.backendspring.feature;
 
 import com.myway.backendspring.feature.ai.AiFeatureService;
+import com.myway.backendspring.feature.quota.AiUsageQuotaService;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -39,8 +40,8 @@ public class FeatureStoreAiFacade {
         return aiSupport.aiProviders(aiFeatureService, userId);
     }
 
-    public boolean canConsumeAi(String userId) {
-        return aiSupport.canConsumeAi(aiFeatureService, userId);
+    public AiUsageQuotaService.QuotaDecision canConsumeAi(String userId, String role, String feature) {
+        return aiSupport.canConsumeAi(aiFeatureService, userId, role, feature);
     }
 
     public void recordAiUsage(String userId, String feature, boolean success, String inputText) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreAiSupport.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreAiSupport.java
@@ -1,6 +1,7 @@
 package com.myway.backendspring.feature;
 
 import com.myway.backendspring.feature.ai.AiFeatureService;
+import com.myway.backendspring.feature.quota.AiUsageQuotaService;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -38,8 +39,10 @@ public class FeatureStoreAiSupport {
                 : aiFeatureService.aiProviders(userId);
     }
 
-    public boolean canConsumeAi(AiFeatureService aiFeatureService, String userId) {
-        return aiFeatureService == null || aiFeatureService.canConsumeAi(userId);
+    public AiUsageQuotaService.QuotaDecision canConsumeAi(AiFeatureService aiFeatureService, String userId, String role, String feature) {
+        return aiFeatureService == null
+                ? new AiUsageQuotaService.QuotaDecision(true, Integer.MAX_VALUE, 0, Integer.MAX_VALUE, role, feature, "", Map.of())
+                : aiFeatureService.canConsumeAi(userId, role, feature);
     }
 
     public void recordAiUsage(

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/FeatureStoreService.java
@@ -2,6 +2,7 @@ package com.myway.backendspring.feature;
 
 import com.myway.backendspring.feature.ai.AiFeatureService;
 import com.myway.backendspring.feature.repository.FeatureStoreRepository;
+import com.myway.backendspring.feature.quota.AiUsageQuotaService;
 import com.myway.backendspring.persistence.FeatureJdbcStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -68,8 +69,8 @@ public class FeatureStoreService {
         return aiFacade.aiProviders(userId);
     }
 
-    public boolean canConsumeAi(String userId) {
-        return aiFacade.canConsumeAi(userId);
+    public AiUsageQuotaService.QuotaDecision canConsumeAi(String userId, String role, String feature) {
+        return aiFacade.canConsumeAi(userId, role, feature);
     }
 
     public void recordAiUsage(String userId, String feature, boolean success, String inputText) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/ai/AiFeatureService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/ai/AiFeatureService.java
@@ -104,11 +104,20 @@ public class AiFeatureService {
         return Map.of("providers", List.of("demo", "ollama", "gemini"), "current", aiSettings(userId).getOrDefault("provider", "demo"));
     }
 
-    public boolean canConsumeAi(String userId) {
+    public AiUsageQuotaService.QuotaDecision canConsumeAi(String userId, String role, String feature) {
         if (aiUsageQuotaService == null) {
-            return true;
+            return new AiUsageQuotaService.QuotaDecision(true, Integer.MAX_VALUE, 0, Integer.MAX_VALUE, role, feature, Instant.now().toString(), Map.of(
+                    "role", role,
+                    "feature", feature,
+                    "limit", Integer.MAX_VALUE,
+                    "used", 0,
+                    "remaining", Integer.MAX_VALUE,
+                    "reset_at", Instant.now().toString(),
+                    "base_limit", Integer.MAX_VALUE,
+                    "feature_weight", 1.0
+            ));
         }
-        return aiUsageQuotaService.canConsumeAi(userId, aiSettings(userId));
+        return aiUsageQuotaService.evaluateQuota(userId, role, feature, aiSettings(userId));
     }
 
     public void recordAiUsage(String userId, String feature, boolean success, String inputText) {
@@ -124,6 +133,21 @@ public class AiFeatureService {
         if (settings == null) {
             repository.upsertKv(AI_SETTINGS_SCOPE, "global", new HashMap<>(Map.of(
                     "daily_limit", 100,
+                    "role_daily_limits", Map.of(
+                            "student", 100,
+                            "instructor", 200,
+                            "admin", 500
+                    ),
+                    "feature_weights", Map.of(
+                            "intent", 1.0,
+                            "search", 1.0,
+                            "answer", 1.0,
+                            "summary", 1.2,
+                            "quiz", 1.1,
+                            "smart", 1.25,
+                            "stt", 1.5,
+                            "rag", 1.5
+                    ),
                     "provider", policyProvider,
                     "model", policyModel
             )));
@@ -133,6 +157,27 @@ public class AiFeatureService {
         boolean changed = false;
         if (!settings.containsKey("daily_limit")) {
             settings.put("daily_limit", 100);
+            changed = true;
+        }
+        if (!settings.containsKey("role_daily_limits")) {
+            settings.put("role_daily_limits", Map.of(
+                    "student", 100,
+                    "instructor", 200,
+                    "admin", 500
+            ));
+            changed = true;
+        }
+        if (!settings.containsKey("feature_weights")) {
+            settings.put("feature_weights", Map.of(
+                    "intent", 1.0,
+                    "search", 1.0,
+                    "answer", 1.0,
+                    "summary", 1.2,
+                    "quiz", 1.1,
+                    "smart", 1.25,
+                    "stt", 1.5,
+                    "rag", 1.5
+            ));
             changed = true;
         }
         if (!settings.containsKey("provider") || !policyProvider.equals(String.valueOf(settings.get("provider")))) {

--- a/backend-spring/src/main/java/com/myway/backendspring/feature/quota/AiUsageQuotaService.java
+++ b/backend-spring/src/main/java/com/myway/backendspring/feature/quota/AiUsageQuotaService.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -17,6 +19,32 @@ import java.util.UUID;
 public class AiUsageQuotaService {
     private static final String AI_USAGE_SCOPE = "ai_usage_daily";
     private static final String AI_USAGE_WINDOW_SCOPE = "ai_usage_window";
+    private static final Map<String, Integer> DEFAULT_ROLE_LIMITS = Map.of(
+            "student", 100,
+            "instructor", 200,
+            "admin", 500
+    );
+    private static final Map<String, Double> DEFAULT_FEATURE_WEIGHTS = Map.of(
+            "intent", 1.0,
+            "search", 1.0,
+            "answer", 1.0,
+            "summary", 1.2,
+            "quiz", 1.1,
+            "smart", 1.25,
+            "stt", 1.5,
+            "rag", 1.5
+    );
+
+    public record QuotaDecision(
+            boolean allowed,
+            int limit,
+            int used,
+            int remaining,
+            String role,
+            String feature,
+            String resetAt,
+            Map<String, Object> meta
+    ) {}
 
     private final FeatureStoreRepository repository;
     private final ActivityEventService activityEventService;
@@ -35,47 +63,29 @@ public class AiUsageQuotaService {
         this.aiUsageDailyStore = aiUsageDailyStore;
     }
 
-    public boolean canConsumeAi(String userId, Map<String, Object> settings) {
-        int limit = asInt(settings == null ? null : settings.get("daily_limit"));
-        if (limit <= 0) {
-            limit = 100;
-        }
+    public QuotaDecision evaluateQuota(String userId, String role, String feature, Map<String, Object> settings) {
+        String normalizedRole = normalizeRole(role);
+        String normalizedFeature = normalizeFeature(feature);
+        int limit = resolveEffectiveLimit(normalizedRole, normalizedFeature, settings);
         LocalDate today = LocalDate.now();
-        int usedToday = aiUsageDailyStore.getCount(userId, today);
-        Map<String, Object> kvUsage = repository.getKv(AI_USAGE_SCOPE, userId + ":" + today);
-        int usedByKv = asInt(kvUsage == null ? null : kvUsage.get("count"));
-        Instant quotaWindowStart = parseInstantOrNull(settings == null ? null : settings.get("quota_window_started_at"));
-        int usedByLogs = aiUsageLogService == null ? 0 : aiUsageLogService.listRaw(userId).size();
-        int usedByEvents = 0;
-        if (quotaWindowStart != null) {
-            usedByLogs = (int) (aiUsageLogService == null ? List.<Map<String, Object>>of() : aiUsageLogService.listRaw(userId)).stream()
-                    .filter(item -> {
-                        Instant createdAt = parseInstantOrNull(item.get("created_at"));
-                        return createdAt != null && !createdAt.isBefore(quotaWindowStart);
-                    })
-                    .count();
-            usedByEvents = (int) repository.listActivityEvents(userId, 200).stream()
-                    .filter(item -> String.valueOf(item.getOrDefault("type", "")).startsWith("ai_"))
-                    .filter(item -> {
-                        Instant occurredAt = parseInstantOrNull(item.get("occurred_at"));
-                        return occurredAt != null && !occurredAt.isBefore(quotaWindowStart);
-                    })
-                    .count();
-        } else if (usedByLogs == 0) {
-            usedByLogs = (int) repository.listActivityEvents(userId, 100).stream()
-                    .map(item -> String.valueOf(item.getOrDefault("type", "")))
-                    .filter(type -> type.startsWith("ai_"))
-                    .count();
-        }
-        int usedByWindow = 0;
-        if (quotaWindowStart != null) {
-            Map<String, Object> windowUsage = repository.getKv(AI_USAGE_WINDOW_SCOPE, usageWindowKey(userId, quotaWindowStart));
-            usedByWindow = asInt(windowUsage == null ? null : windowUsage.get("count"));
-        }
-        int used = quotaWindowStart != null
-                ? Math.max(Math.max(usedByLogs, usedByEvents), usedByWindow)
-                : Math.max(Math.max(usedToday, usedByLogs), usedByKv);
-        return used < limit;
+        int used = resolveUsedCount(userId, today, settings);
+        int remaining = Math.max(0, limit - used);
+        boolean allowed = used < limit;
+        String resetAt = today.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toString();
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("role", normalizedRole);
+        meta.put("feature", normalizedFeature);
+        meta.put("limit", limit);
+        meta.put("used", used);
+        meta.put("remaining", remaining);
+        meta.put("reset_at", resetAt);
+        meta.put("base_limit", resolveBaseLimit(normalizedRole, settings));
+        meta.put("feature_weight", resolveFeatureWeight(normalizedFeature, settings));
+        return new QuotaDecision(allowed, limit, used, remaining, normalizedRole, normalizedFeature, resetAt, meta);
+    }
+
+    public boolean canConsumeAi(String userId, String role, String feature, Map<String, Object> settings) {
+        return evaluateQuota(userId, role, feature, settings).allowed();
     }
 
     public void recordAiUsage(String userId, String feature, boolean success, String inputText, Map<String, Object> settings) {
@@ -118,6 +128,93 @@ public class AiUsageQuotaService {
         }
     }
 
+    private int resolveEffectiveLimit(String role, String feature, Map<String, Object> settings) {
+        int baseLimit = resolveBaseLimit(role, settings);
+        double weight = resolveFeatureWeight(feature, settings);
+        return weight <= 0 ? baseLimit : Math.max(1, (int) Math.floor(baseLimit / weight));
+    }
+
+    private int resolveBaseLimit(String role, Map<String, Object> settings) {
+        int explicitLimit = asInt(settings == null ? null : settings.get("daily_limit"));
+        if (explicitLimit > 0) {
+            return explicitLimit;
+        }
+
+        Map<String, Object> roleLimits = asMap(settings == null ? null : settings.get("role_daily_limits"));
+        int roleLimit = asInt(roleLimits == null ? null : roleLimits.get(role));
+        if (roleLimit > 0) {
+            return roleLimit;
+        }
+
+        return DEFAULT_ROLE_LIMITS.getOrDefault(role, DEFAULT_ROLE_LIMITS.get("student"));
+    }
+
+    private double resolveFeatureWeight(String feature, Map<String, Object> settings) {
+        Map<String, Object> featureWeights = asMap(settings == null ? null : settings.get("feature_weights"));
+        double configuredWeight = asDouble(featureWeights == null ? null : featureWeights.get(feature));
+        if (configuredWeight > 0) {
+            return configuredWeight;
+        }
+
+        return DEFAULT_FEATURE_WEIGHTS.getOrDefault(feature, 1.0);
+    }
+
+    private int resolveUsedCount(String userId, LocalDate today, Map<String, Object> settings) {
+        int usedToday = aiUsageDailyStore.getCount(userId, today);
+        Map<String, Object> kvUsage = repository.getKv(AI_USAGE_SCOPE, userId + ":" + today);
+        int usedByKv = asInt(kvUsage == null ? null : kvUsage.get("count"));
+        Instant quotaWindowStart = parseInstantOrNull(settings == null ? null : settings.get("quota_window_started_at"));
+        int usedByLogs = aiUsageLogService == null ? 0 : aiUsageLogService.listRaw(userId).size();
+        int usedByEvents = 0;
+        if (quotaWindowStart != null) {
+            List<Map<String, Object>> rawLogs = aiUsageLogService == null ? List.of() : aiUsageLogService.listRaw(userId);
+            usedByLogs = (int) rawLogs.stream()
+                    .filter(item -> {
+                        Instant createdAt = parseInstantOrNull(item.get("created_at"));
+                        return createdAt != null && !createdAt.isBefore(quotaWindowStart);
+                    })
+                    .count();
+            usedByEvents = (int) repository.listActivityEvents(userId, 200).stream()
+                    .filter(item -> String.valueOf(item.getOrDefault("type", "")).startsWith("ai_"))
+                    .filter(item -> {
+                        Instant occurredAt = parseInstantOrNull(item.get("occurred_at"));
+                        return occurredAt != null && !occurredAt.isBefore(quotaWindowStart);
+                    })
+                    .count();
+        } else if (usedByLogs == 0) {
+            usedByLogs = (int) repository.listActivityEvents(userId, 100).stream()
+                    .map(item -> String.valueOf(item.getOrDefault("type", "")))
+                    .filter(type -> type.startsWith("ai_"))
+                    .count();
+        }
+        int usedByWindow = 0;
+        if (quotaWindowStart != null) {
+            Map<String, Object> windowUsage = repository.getKv(AI_USAGE_WINDOW_SCOPE, usageWindowKey(userId, quotaWindowStart));
+            usedByWindow = asInt(windowUsage == null ? null : windowUsage.get("count"));
+        }
+        return quotaWindowStart != null
+                ? Math.max(Math.max(usedByLogs, usedByEvents), usedByWindow)
+                : Math.max(Math.max(usedToday, usedByLogs), usedByKv);
+    }
+
+    private String normalizeRole(String role) {
+        if (role == null || role.isBlank()) {
+            return "student";
+        }
+        String normalized = role.trim().toLowerCase(Locale.ROOT);
+        if ("instructor".equals(normalized) || "admin".equals(normalized)) {
+            return normalized;
+        }
+        return "student";
+    }
+
+    private String normalizeFeature(String feature) {
+        if (feature == null || feature.isBlank()) {
+            return "intent";
+        }
+        return feature.trim().toLowerCase(Locale.ROOT);
+    }
+
     private int asInt(Object value) {
         if (value == null) return 0;
         if (value instanceof Number n) return n.intValue();
@@ -126,6 +223,24 @@ public class AiUsageQuotaService {
         } catch (Exception ignored) {
             return 0;
         }
+    }
+
+    private double asDouble(Object value) {
+        if (value == null) return 0;
+        if (value instanceof Number n) return n.doubleValue();
+        try {
+            return Double.parseDouble(String.valueOf(value));
+        } catch (Exception ignored) {
+            return 0;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return null;
     }
 
     private Instant parseInstantOrNull(Object raw) {

--- a/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
+++ b/backend-spring/src/test/java/com/myway/backendspring/contract/AiContractTest.java
@@ -131,6 +131,76 @@ class AiContractTest {
     }
 
     @Test
+    void aiEndpoints_shouldRespectRoleAwareQuotaPolicy_andExposeQuotaMetadata() throws Exception {
+        String studentAuth = "Bearer " + loginAndGetToken("usr_std_001");
+        String instructorAuth = "Bearer " + loginAndGetToken("usr_ins_001");
+        String quotaPatch = """
+                {
+                  "role_daily_limits": {"student": 2, "instructor": 4, "admin": 6},
+                  "feature_weights": {"summary": 2, "quiz": 1, "answer": 1, "rag": 2}
+                }
+                """;
+
+        try {
+            setDailyLimit(studentAuth, 0);
+            setDailyLimit(instructorAuth, 0);
+
+            mockMvc.perform(put("/api/v1/ai/settings")
+                            .header("Authorization", studentAuth)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(quotaPatch))
+                    .andExpect(status().isOk());
+
+            mockMvc.perform(post("/api/v1/ai/summary")
+                            .header("Authorization", studentAuth)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"lecture_id\":\"lec_java_01\",\"style\":\"brief\"}"))
+                    .andExpect(status().isOk());
+
+            MvcResult studentQuotaExceeded = mockMvc.perform(post("/api/v1/ai/summary")
+                            .header("Authorization", studentAuth)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"lecture_id\":\"lec_java_01\",\"style\":\"brief\"}"))
+                    .andExpect(status().isTooManyRequests())
+                    .andReturn();
+
+            assertFailureEnvelope(studentQuotaExceeded, "DAILY_LIMIT_EXCEEDED");
+            assertQuotaMetadata(studentQuotaExceeded, "student", "summary", 1, 0);
+
+            mockMvc.perform(put("/api/v1/ai/settings")
+                            .header("Authorization", instructorAuth)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(quotaPatch))
+                    .andExpect(status().isOk());
+
+            mockMvc.perform(post("/api/v1/ai/summary")
+                            .header("Authorization", instructorAuth)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"lecture_id\":\"lec_java_01\",\"style\":\"brief\"}"))
+                    .andExpect(status().isOk());
+
+            mockMvc.perform(post("/api/v1/ai/summary")
+                            .header("Authorization", instructorAuth)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"lecture_id\":\"lec_java_01\",\"style\":\"brief\"}"))
+                    .andExpect(status().isOk());
+
+            MvcResult instructorQuotaExceeded = mockMvc.perform(post("/api/v1/ai/summary")
+                            .header("Authorization", instructorAuth)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"lecture_id\":\"lec_java_01\",\"style\":\"brief\"}"))
+                    .andExpect(status().isTooManyRequests())
+                    .andReturn();
+
+            assertFailureEnvelope(instructorQuotaExceeded, "DAILY_LIMIT_EXCEEDED");
+            assertQuotaMetadata(instructorQuotaExceeded, "instructor", "summary", 2, 0);
+        } finally {
+            setDailyLimit(studentAuth, 999999);
+            setDailyLimit(instructorAuth, 999999);
+        }
+    }
+
+    @Test
     void aiEndpoints_shouldReturnNotFoundEnvelope_whenLectureOrCourseMissing() throws Exception {
         String authHeader = "Bearer " + loginAndGetToken("usr_std_001");
         setDailyLimit(authHeader, 999999);
@@ -330,6 +400,18 @@ class AiContractTest {
         assertThat(root.path("data").isNull()).isTrue();
         assertThat(root.path("error").path("code").asText()).isEqualTo(expectedCode);
         assertThat(root.path("message").asText()).isNotBlank();
+    }
+
+    private void assertQuotaMetadata(MvcResult result, String expectedRole, String expectedFeature, int expectedLimit, int expectedRemaining) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode meta = root.path("error").path("meta");
+        assertThat(meta.path("role").asText()).isEqualTo(expectedRole);
+        assertThat(meta.path("feature").asText()).isEqualTo(expectedFeature);
+        assertThat(meta.path("limit").asInt()).isEqualTo(expectedLimit);
+        assertThat(meta.path("remaining").asInt()).isEqualTo(expectedRemaining);
+        assertThat(meta.path("reset_at").asText()).isNotBlank();
+        assertThat(result.getResponse().getHeader("X-AI-Quota-Remaining")).isEqualTo(String.valueOf(expectedRemaining));
+        assertThat(result.getResponse().getHeader("X-AI-Quota-Reset")).isNotBlank();
     }
 
     private JsonNode readData(MvcResult result) throws Exception {

--- a/backend/src/lib/ai-controls-regression.test.ts
+++ b/backend/src/lib/ai-controls-regression.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { jsonFailure } from './http';
+
+const response = jsonFailure('AI_QUOTA_EXCEEDED', '일일 사용 한도를 초과했습니다.', 429, {
+  role: 'student',
+  feature: 'summary',
+  limit: 1,
+  remaining: 0,
+  reset_at: '2026-06-09T00:00:00.000Z',
+});
+
+assert.equal(response.status, 429);
+assert.equal(response.headers.get('x-ai-quota-remaining'), '0');
+assert.equal(response.headers.get('x-ai-quota-reset'), '2026-06-09T00:00:00.000Z');
+assert.equal(response.headers.get('x-ai-quota-role'), 'student');
+assert.equal(response.headers.get('x-ai-quota-feature'), 'summary');
+assert.equal(response.headers.get('x-ai-quota-limit'), '1');
+
+console.log('ai controls regression passed');

--- a/backend/src/lib/ai-controls.ts
+++ b/backend/src/lib/ai-controls.ts
@@ -1,4 +1,5 @@
 import type { AuthUser } from '@myway/shared';
+import { getAiQuotaResetAt, resolveAiQuotaLimit } from '@myway/shared';
 import { getAuthenticatedUser } from './auth';
 import { jsonFailure } from './http';
 import { getAIRuntimePolicy, type RuntimeBindings } from './runtime-env';
@@ -21,22 +22,60 @@ export type AiControlContext = {
   policy: ReturnType<typeof getAIRuntimePolicy>;
 };
 
-function getQuotaLimit(policy: AiControlContext['policy'], feature: AiControlFeature): number | undefined {
-  switch (feature) {
-    case 'intent':
-    case 'smart':
-      return policy.daily_limits.smart;
-    case 'summary':
-      return policy.daily_limits.summary;
-    case 'quiz':
-      return policy.daily_limits.quiz;
-    case 'answer':
-      return policy.daily_limits.answer;
-    case 'stt':
-      return policy.daily_limits.stt;
-    case 'search':
-      return undefined;
+function buildQuotaSettings(policy: AiControlContext['policy'], feature: Exclude<AiControlFeature, 'search'>) {
+  return {
+    daily_limit:
+      feature === 'smart'
+        ? policy.daily_limits.smart
+        : feature === 'summary'
+          ? policy.daily_limits.summary
+          : feature === 'quiz'
+            ? policy.daily_limits.quiz
+            : feature === 'answer'
+              ? policy.daily_limits.answer
+              : feature === 'stt'
+                ? policy.daily_limits.stt
+                : policy.daily_limits.smart,
+    role_daily_limits: {
+      STUDENT: policy.role_limits?.student,
+      INSTRUCTOR: policy.role_limits?.instructor,
+      ADMIN: policy.role_limits?.admin,
+    },
+    feature_weights: {
+      intent: policy.feature_weights?.intent,
+      search: policy.feature_weights?.search,
+      answer: policy.feature_weights?.answer,
+      summary: policy.feature_weights?.summary,
+      quiz: policy.feature_weights?.quiz,
+      smart: policy.feature_weights?.smart,
+      stt: policy.feature_weights?.stt,
+      rag: policy.feature_weights?.rag,
+    },
+  };
+}
+
+function getQuotaLimit(policy: AiControlContext['policy'], role: string | undefined, feature: AiControlFeature): number | undefined {
+  if (feature === 'search') {
+    return undefined;
   }
+
+  const quotaFeature = feature === 'intent' ? 'smart' : feature;
+  return resolveAiQuotaLimit(role, quotaFeature, buildQuotaSettings(policy, quotaFeature)).effective_limit;
+}
+
+function buildQuotaMeta(
+  role: string | undefined,
+  feature: AiControlFeature,
+  limit: number,
+  remaining: number,
+): Record<string, unknown> {
+  return {
+    role: String(role ?? 'STUDENT').trim().toLowerCase(),
+    feature,
+    limit,
+    remaining,
+    reset_at: getAiQuotaResetAt(),
+  };
 }
 
 function shouldCountTotal(feature: AiControlFeature): boolean {
@@ -92,7 +131,7 @@ export async function guardAiRequest(
     return { user, policy };
   }
 
-  const quotaLimit = getQuotaLimit(policy, feature);
+  const quotaLimit = getQuotaLimit(policy, user?.role, feature);
   if (!quotaLimit) {
     return { user, policy };
   }
@@ -101,20 +140,20 @@ export async function guardAiRequest(
 
   const dailyUsage = await bumpDailyUsage(db, actorId, feature, quotaLimit);
   if (!dailyUsage.allowed) {
-    return jsonFailure('AI_QUOTA_EXCEEDED', '일일 사용 한도를 초과했습니다.', 429);
+    return jsonFailure('AI_QUOTA_EXCEEDED', '일일 사용 한도를 초과했습니다.', 429, buildQuotaMeta(user?.role, feature, quotaLimit, 0));
   }
 
   if (policy.daily_limits.total && shouldCountTotal(feature)) {
     const totalUsage = await bumpDailyTotal(db, actorId, policy.daily_limits.total);
     if (!totalUsage.allowed) {
-      return jsonFailure('AI_TOTAL_QUOTA_EXCEEDED', '일일 AI 총 사용 한도를 초과했습니다.', 429);
+      return jsonFailure('AI_TOTAL_QUOTA_EXCEEDED', '일일 AI 총 사용 한도를 초과했습니다.', 429, buildQuotaMeta(user?.role, feature, policy.daily_limits.total, 0));
     }
   }
 
   if (policy.daily_limits.gemini && shouldCountGemini(feature)) {
     const geminiUsage = await bumpGlobalQuota(db, 'gemini', policy.daily_limits.gemini);
     if (!geminiUsage.allowed) {
-      return jsonFailure('AI_GEMINI_QUOTA_EXCEEDED', 'Gemini 일일 사용 한도를 초과했습니다.', 429);
+      return jsonFailure('AI_GEMINI_QUOTA_EXCEEDED', 'Gemini 일일 사용 한도를 초과했습니다.', 429, buildQuotaMeta(user?.role, feature, policy.daily_limits.gemini, 0));
     }
   }
 

--- a/backend/src/lib/http.ts
+++ b/backend/src/lib/http.ts
@@ -10,14 +10,39 @@ export function jsonSuccess<T>(data: T, message?: string, status = 200): Respons
   return Response.json(payload, { status });
 }
 
-export function jsonFailure(code: string, message: string, status = 400): Response {
+export function jsonFailure(
+  code: string,
+  message: string,
+  status = 400,
+  meta?: Record<string, unknown>,
+): Response {
   const payload: ApiResponse<never> = {
     success: false,
-    error: { code, message } satisfies ApiError,
+    error: meta ? { code, message, meta } satisfies ApiError : { code, message } satisfies ApiError,
     message,
   };
+  const headers: Record<string, string> = {};
+  if (meta) {
+    const remaining = meta.remaining;
+    const resetAt = meta.reset_at;
+    if (typeof remaining === 'number' || typeof remaining === 'string') {
+      headers['x-ai-quota-remaining'] = String(remaining);
+    }
+    if (typeof resetAt === 'string' && resetAt) {
+      headers['x-ai-quota-reset'] = resetAt;
+    }
+    if (typeof meta.role === 'string' && meta.role) {
+      headers['x-ai-quota-role'] = meta.role;
+    }
+    if (typeof meta.feature === 'string' && meta.feature) {
+      headers['x-ai-quota-feature'] = meta.feature;
+    }
+    if (typeof meta.limit === 'number' || typeof meta.limit === 'string') {
+      headers['x-ai-quota-limit'] = String(meta.limit);
+    }
+  }
 
-  return Response.json(payload, { status });
+  return Response.json(payload, { status, headers });
 }
 
 export async function readJsonBody<T>(request: Request): Promise<T | null> {

--- a/backend/src/lib/runtime-env.ts
+++ b/backend/src/lib/runtime-env.ts
@@ -49,6 +49,17 @@ export type RuntimeBindings = {
   MYWAY_AI_DAILY_LIMIT_ANSWER?: string;
   MYWAY_AI_DAILY_LIMIT_GEMINI?: string;
   MYWAY_AI_DAILY_LIMIT_TOTAL?: string;
+  MYWAY_AI_DAILY_LIMIT_STUDENT?: string;
+  MYWAY_AI_DAILY_LIMIT_INSTRUCTOR?: string;
+  MYWAY_AI_DAILY_LIMIT_ADMIN?: string;
+  MYWAY_AI_QUOTA_WEIGHT_INTENT?: string;
+  MYWAY_AI_QUOTA_WEIGHT_SEARCH?: string;
+  MYWAY_AI_QUOTA_WEIGHT_ANSWER?: string;
+  MYWAY_AI_QUOTA_WEIGHT_SUMMARY?: string;
+  MYWAY_AI_QUOTA_WEIGHT_QUIZ?: string;
+  MYWAY_AI_QUOTA_WEIGHT_SMART?: string;
+  MYWAY_AI_QUOTA_WEIGHT_STT?: string;
+  MYWAY_AI_QUOTA_WEIGHT_RAG?: string;
   MYWAY_OLLAMA_BASE_URL?: string;
   OLLAMA_BASE_URL?: string;
   MYWAY_OLLAMA_MODEL?: string;
@@ -139,6 +150,21 @@ export function getAIRuntimePolicy(env?: RuntimeBindings): {
   require_auth: boolean;
   enable_stt: boolean;
   enable_media_upload: boolean;
+  role_limits?: {
+    student?: number;
+    instructor?: number;
+    admin?: number;
+  };
+  feature_weights?: {
+    intent?: number;
+    search?: number;
+    answer?: number;
+    summary?: number;
+    quiz?: number;
+    smart?: number;
+    stt?: number;
+    rag?: number;
+  };
   daily_limits: {
     total?: number;
     smart?: number;
@@ -158,11 +184,35 @@ export function getAIRuntimePolicy(env?: RuntimeBindings): {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
   };
 
+  const parseWeight = (value: string | undefined): number | undefined => {
+    if (!value) {
+      return undefined;
+    }
+
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  };
+
   return {
     public_mode: env?.MYWAY_AI_PUBLIC_MODE ?? 'dev',
     require_auth: (env?.MYWAY_AI_REQUIRE_AUTH ?? 'false') === 'true',
     enable_stt: (env?.MYWAY_AI_ENABLE_STT ?? 'true') === 'true',
     enable_media_upload: (env?.MYWAY_AI_ENABLE_MEDIA_UPLOAD ?? 'true') === 'true',
+    role_limits: {
+      student: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_STUDENT),
+      instructor: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_INSTRUCTOR),
+      admin: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_ADMIN),
+    },
+    feature_weights: {
+      intent: parseWeight(env?.MYWAY_AI_QUOTA_WEIGHT_INTENT),
+      search: parseWeight(env?.MYWAY_AI_QUOTA_WEIGHT_SEARCH),
+      answer: parseWeight(env?.MYWAY_AI_QUOTA_WEIGHT_ANSWER),
+      summary: parseWeight(env?.MYWAY_AI_QUOTA_WEIGHT_SUMMARY),
+      quiz: parseWeight(env?.MYWAY_AI_QUOTA_WEIGHT_QUIZ),
+      smart: parseWeight(env?.MYWAY_AI_QUOTA_WEIGHT_SMART),
+      stt: parseWeight(env?.MYWAY_AI_QUOTA_WEIGHT_STT),
+      rag: parseWeight(env?.MYWAY_AI_QUOTA_WEIGHT_RAG),
+    },
     daily_limits: {
       smart: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_SMART),
       summary: parseLimit(env?.MYWAY_AI_DAILY_LIMIT_SUMMARY),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "build:frontend": "npm --workspace @myway/frontend run build",
     "build:backend": "tsx scripts/run-maven-wrapper.ts -DskipTests package",
     "test:backend": "tsx scripts/run-maven-wrapper.ts test",
+    "test:backend:quota": "tsx backend/src/lib/ai-controls-regression.test.ts",
     "test:frontend": "npm --workspace @myway/frontend run test",
+    "test:shared:quota": "tsx packages/shared/src/ai/ai-quota-policy-regression.test.ts",
     "test:backend:clean": "node -e \"const fs=require('fs');fs.rmSync('backend-spring/data',{recursive:true,force:true});\" && npm run test:backend",
     "build:backend:legacy": "npm --workspace @myway/backend run build",
     "build": "npm run build:frontend && npm run build:backend",
@@ -35,7 +37,7 @@
     "perf:smoke": "npm run build:frontend",
     "smoke:media-ai-shortform": "tsx scripts/smoke-media-ai-shortform.ts",
     "test:e2e:demo-student": "playwright test e2e/demo-student-journey.spec.ts --reporter=line",
-    "verify": "npm run check:deps && npm run build:frontend && npm run test:backend"
+    "verify": "npm run check:deps && npm run build:frontend && npm run test:shared:quota && npm run test:backend:quota && npm run test:backend"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",

--- a/packages/shared/src/ai/ai-provider.ts
+++ b/packages/shared/src/ai/ai-provider.ts
@@ -40,6 +40,21 @@ export type AIRuntimePolicy = {
   require_auth: boolean;
   enable_stt: boolean;
   enable_media_upload: boolean;
+  role_limits?: {
+    student?: number;
+    instructor?: number;
+    admin?: number;
+  };
+  feature_weights?: {
+    intent?: number;
+    search?: number;
+    answer?: number;
+    summary?: number;
+    quiz?: number;
+    smart?: number;
+    stt?: number;
+    rag?: number;
+  };
   daily_limits: {
     total?: number;
     smart?: number;

--- a/packages/shared/src/ai/ai-quota-policy-regression.test.ts
+++ b/packages/shared/src/ai/ai-quota-policy-regression.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import {
+  resolveAiQuotaLimit,
+  resolveAiQuotaBaseLimit,
+  resolveAiQuotaFeatureWeight,
+} from './ai-quota-policy';
+
+function testRoleSpecificDefaults(): void {
+  const student = resolveAiQuotaLimit('STUDENT', 'summary');
+  const instructor = resolveAiQuotaLimit('INSTRUCTOR', 'summary');
+  const admin = resolveAiQuotaLimit('ADMIN', 'summary');
+
+  assert.equal(student.role, 'STUDENT');
+  assert.equal(student.base_limit, 100);
+  assert.equal(student.feature_weight, 1.2);
+  assert.equal(student.effective_limit, 83);
+
+  assert.equal(instructor.base_limit, 200);
+  assert.equal(instructor.effective_limit, 166);
+  assert.ok(instructor.effective_limit > student.effective_limit);
+
+  assert.equal(admin.base_limit, 500);
+  assert.equal(admin.effective_limit, 416);
+  assert.ok(admin.effective_limit > instructor.effective_limit);
+}
+
+function testUserOverrideBeatsRoleDefault(): void {
+  const override = resolveAiQuotaLimit('STUDENT', 'rag', {
+    daily_limit: 42,
+    role_daily_limits: { STUDENT: 10, INSTRUCTOR: 20, ADMIN: 30 },
+    feature_weights: { rag: 2 },
+  });
+
+  assert.equal(override.base_limit, 42);
+  assert.equal(override.feature_weight, 2);
+  assert.equal(override.effective_limit, 21);
+}
+
+function testFeatureWeightsApplyPerFeature(): void {
+  const summaryWeight = resolveAiQuotaFeatureWeight('summary');
+  const quizWeight = resolveAiQuotaFeatureWeight('quiz');
+  const answerWeight = resolveAiQuotaFeatureWeight('answer');
+
+  assert.equal(summaryWeight, 1.2);
+  assert.equal(quizWeight, 1.1);
+  assert.equal(answerWeight, 1);
+  assert.equal(resolveAiQuotaBaseLimit('STUDENT'), 100);
+}
+
+testRoleSpecificDefaults();
+testUserOverrideBeatsRoleDefault();
+testFeatureWeightsApplyPerFeature();
+
+console.log('ai quota policy regressions passed');

--- a/packages/shared/src/ai/ai-quota-policy.ts
+++ b/packages/shared/src/ai/ai-quota-policy.ts
@@ -1,0 +1,86 @@
+import type { UserRole } from '../types';
+
+export type AIQuotaFeature = 'intent' | 'search' | 'answer' | 'summary' | 'quiz' | 'smart' | 'stt' | 'rag';
+
+export type AIQuotaPolicyInput = {
+  daily_limit?: number;
+  role_daily_limits?: Partial<Record<UserRole, number>>;
+  feature_weights?: Partial<Record<AIQuotaFeature, number>>;
+};
+
+export type AIQuotaResolution = {
+  role: UserRole;
+  feature: AIQuotaFeature;
+  base_limit: number;
+  feature_weight: number;
+  effective_limit: number;
+};
+
+export const DEFAULT_AI_ROLE_DAILY_LIMITS: Record<UserRole, number> = {
+  STUDENT: 100,
+  INSTRUCTOR: 200,
+  ADMIN: 500,
+};
+
+export const DEFAULT_AI_FEATURE_WEIGHTS: Record<AIQuotaFeature, number> = {
+  intent: 1,
+  search: 0,
+  answer: 1,
+  summary: 1.2,
+  quiz: 1.1,
+  smart: 1.25,
+  stt: 1.5,
+  rag: 1.5,
+};
+
+export function normalizeAiQuotaRole(role?: string | null): UserRole {
+  const normalized = String(role ?? '').trim().toUpperCase();
+  if (normalized === 'INSTRUCTOR' || normalized === 'ADMIN') {
+    return normalized;
+  }
+  return 'STUDENT';
+}
+
+export function resolveAiQuotaBaseLimit(role: UserRole, settings?: AIQuotaPolicyInput): number {
+  const explicitLimit = settings?.daily_limit;
+  if (typeof explicitLimit === 'number' && Number.isFinite(explicitLimit) && explicitLimit > 0) {
+    return Math.floor(explicitLimit);
+  }
+
+  const roleLimit = settings?.role_daily_limits?.[role];
+  if (typeof roleLimit === 'number' && Number.isFinite(roleLimit) && roleLimit > 0) {
+    return Math.floor(roleLimit);
+  }
+
+  return DEFAULT_AI_ROLE_DAILY_LIMITS[role];
+}
+
+export function resolveAiQuotaFeatureWeight(feature: AIQuotaFeature, settings?: AIQuotaPolicyInput): number {
+  const configuredWeight = settings?.feature_weights?.[feature];
+  if (typeof configuredWeight === 'number' && Number.isFinite(configuredWeight) && configuredWeight > 0) {
+    return configuredWeight;
+  }
+
+  return DEFAULT_AI_FEATURE_WEIGHTS[feature];
+}
+
+export function resolveAiQuotaLimit(role: string | UserRole | null | undefined, feature: AIQuotaFeature, settings?: AIQuotaPolicyInput): AIQuotaResolution {
+  const normalizedRole = normalizeAiQuotaRole(role);
+  const baseLimit = resolveAiQuotaBaseLimit(normalizedRole, settings);
+  const featureWeight = resolveAiQuotaFeatureWeight(feature, settings);
+  const effectiveLimit = featureWeight <= 0 ? baseLimit : Math.max(1, Math.floor(baseLimit / featureWeight));
+
+  return {
+    role: normalizedRole,
+    feature,
+    base_limit: baseLimit,
+    feature_weight: featureWeight,
+    effective_limit: effectiveLimit,
+  };
+}
+
+export function getAiQuotaResetAt(now: Date = new Date()): string {
+  const reset = new Date(now);
+  reset.setUTCHours(24, 0, 0, 0);
+  return reset.toISOString();
+}

--- a/packages/shared/src/ai/index.ts
+++ b/packages/shared/src/ai/index.ts
@@ -1,4 +1,5 @@
 export * from './ai';
+export * from './ai-quota-policy';
 export * from './ai-logs';
 export * from './ai-insights';
 export * from './ai-intent';

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1,6 +1,7 @@
 export type ApiError = {
   code: string;
   message: string;
+  meta?: Record<string, unknown>;
 };
 
 export type ApiResponse<T> = {


### PR DESCRIPTION
## Summary\n- Split AI quota policy by role (student/instructor/admin) with feature weights for summary/quiz/answer/rag\n- Add 429 metadata and quota headers for remaining/reset/limit visibility\n- Wire Spring AI guards to route-specific feature keys and keep user override support via settings\n- Mirror the same policy in the worker runtime guard\n\n## Verification\n- npm run verify\n