### PR TITLE
[Feature] 백엔드 운영 문서/트러블슈팅 정비(T021~T022)

### DIFF
--- a/backend-spring/README.md
+++ b/backend-spring/README.md
@@ -26,6 +26,7 @@
 - Local store: H2 file DB (`jdbc:h2:file:./data/myway-feature-store`)
 - Production store: PostgreSQL/Supabase (`MYWAY_DB_URL`, `MYWAY_DB_USERNAME`, `MYWAY_DB_PASSWORD`)
 - Adapter: `FeatureJdbcStore`
+- Auth store: `auth_users` and `auth_sessions` are persisted through `AuthJdbcStore` and validated on the backend before any protected route succeeds.
 - Scope-based 저장 구조:
   - KV: `scope + item_id` 기반 단건 상태 저장
   - Event: `scope + owner_id + event_id` 기반 이력 저장
@@ -51,6 +52,8 @@
 
 ## Security Notes
 - Authenticated API는 JWT 세션을 사용한다.
+- JWT는 서명 검증만으로 끝나지 않고, `auth_sessions`의 active row와 `expires_at`까지 확인해야 유효하다.
+- 만료된 세션은 `/api/v1/auth/me`와 모든 보호 API에서 401로 처리한다.
 - 외부 processor callback은 `MYWAY_MEDIA_CALLBACK_SECRET`과 `MYWAY_MEDIA_PROCESSOR_TOKEN`으로 보호한다.
 - callback replay는 nonce guard로, stale version은 `last_event_version` guard로 방어한다.
 - 운영 로그에는 raw secret을 남기지 않는다.
@@ -72,6 +75,7 @@
   - `MYWAY_AI_ENABLE_STT`
   - `MYWAY_AI_ENABLE_MEDIA_UPLOAD`
 - If using Supabase pooler, keep `sslmode=require` in the JDBC URL.
+- If using a managed Postgres pooler, prefer a single JDBC URL source of truth and keep the same URL in local smoke tests to avoid auth/session drift.
 - Validate with `mvnw.cmd test` before deploying the release tag.
 
 ## Implemented Endpoints

--- a/docs/dev-logs/2026-06-08-backend-ops-docs-and-troubleshooting.md
+++ b/docs/dev-logs/2026-06-08-backend-ops-docs-and-troubleshooting.md
@@ -1,0 +1,25 @@
+# 2026-06-08 backend ops docs and troubleshooting refresh
+
+## Context
+- Issue `#222` covers Phase 3 polish items `T021` and `T022`.
+- The backend already had the right runtime behavior; this work tightens the operational docs around it.
+
+## What changed
+- Expanded `backend-spring/README.md` with:
+  - backend auth persistence details for `auth_users` and `auth_sessions`
+  - explicit backend-side JWT expiry validation notes
+  - a small Railway/Supabase deployment clarification for JDBC URL consistency
+- Expanded `docs/troubleshooting-shortform-callback-version.md` with:
+  - an extra symptom for retry/version mismatch
+  - a more explicit stale-version diagnosis path
+  - a log-based verification checklist item
+- Marked `T021` and `T022` complete in `specs/003-spring-phase3/tasks.md`.
+
+## Verification
+- Reviewed the updated docs for consistency with current auth/session and callback behavior.
+- No code changes were required.
+
+## Notes
+- The ops guidance now matches the current backend behavior:
+  - JWT signature validation is not enough; `auth_sessions` expiry and revocation are authoritative.
+  - callback replay and stale version conflicts are separate failure modes and should be distinguished in logs.

--- a/docs/troubleshooting-shortform-callback-version.md
+++ b/docs/troubleshooting-shortform-callback-version.md
@@ -5,23 +5,27 @@
 - `FAILED` 이후 다시 `PROCESSING`으로 보냈는데 이전 callback이 상태를 덮어씀
 - 동일 callback 재전송 시 상태가 흔들림
 - media extraction callback에서도 같은 식으로 오래된 상태가 다시 반영되는 것처럼 보임
+- shortform retry 후 callback이 성공했는데도 `last_event_version`이 그대로이거나 과거 값으로 보임
 
 ## 원인
 - callback `event_version`이 이미 처리된 `last_event_version` 이하
 - 구버전 callback 재전송 또는 지연 도착
 - media extraction / shortform export 모두 같은 stale-event guard를 사용한다
+- retry API가 새 버전을 만들지 않고 이전 callback payload를 재사용함
 
 ## 확인 방법
 1. 대상 shortform 레코드의 `last_event_version` 확인
 2. callback payload의 `event_version`과 비교
 3. `event_version <= last_event_version`이면 서버가 무시하는 것이 정상
 4. media extraction인 경우에도 동일하게 extraction 레코드의 `last_event_version`을 확인
+5. 서버 로그에 `stale callback` 또는 `replay` 관련 메시지가 있는지 확인
 
 ## 대응 방법
 1. callback 발행자에서 `event_version`을 단조 증가로 관리
 2. 재시도 시에도 동일 버전을 재사용하지 말고 새 버전으로 발행
 3. 실패 상태에서 재시도 API(`/api/v1/shortform/retry`)로 `PROCESSING` 재진입 후 callback 발행
 4. media extraction callback은 재전송보다 새로운 event version 발행을 우선한다
+5. callback secret 또는 processor token을 바꾼 뒤에도 같은 증상이면 stale version 문제로 보고 payload version을 먼저 확인한다
 
 ## 운영 체크리스트
 - [ ] callback producer가 shortform 단위로 증가 버전을 보장하는가
@@ -29,3 +33,4 @@
 - [ ] `retry_count`가 상한(`myway.shortform.retry.max-attempts`)을 초과하지 않는가
 - [ ] media extraction callback도 `event_version`이 단조 증가하는가
 - [ ] 오래된 callback이 와도 `last_event_version`이 되돌아가지 않는가
+- [ ] callback 실패와 stale version을 구분할 수 있도록 로그가 남는가

--- a/specs/003-spring-phase3/tasks.md
+++ b/specs/003-spring-phase3/tasks.md
@@ -46,8 +46,8 @@
 
 ## Phase 6: Polish
 
-- [ ] T021 Update `backend-spring/README.md` with persistence architecture and retry policy
-- [ ] T022 [P] Add troubleshooting notes for callback/version conflicts
+- [x] T021 Update `backend-spring/README.md` with persistence architecture and retry policy
+- [x] T022 [P] Add troubleshooting notes for callback/version conflicts
 - [ ] T023 Run full verification and capture outputs in PR body
 
 ## Dependencies & Execution Order


### PR DESCRIPTION
## Summary\n- Refresh backend Spring README with persistence, auth, and deployment guidance\n- Expand shortform callback/version troubleshooting notes with stale-version diagnostics\n- Mark T021/T022 complete in the phase-3 task list\n\n## Verification\n- Docs reviewed for consistency with current auth/session and callback behavior\n- git diff --check