### PR TITLE
docs: reconcile persistence spec with implementation

### DIFF
--- a/docs/dev-logs/2026-06-08-persistence-spec-reconciliation.md
+++ b/docs/dev-logs/2026-06-08-persistence-spec-reconciliation.md
@@ -1,0 +1,17 @@
+# 2026-06-08 persistence spec reconciliation
+
+## 왜 바꿨는가
+- `specs/003-spring-phase3/tasks.md`의 초기 persistence 항목이 현재 코드의 실제 구현과 이름이 달라서, 남은 작업처럼 보이는 drift가 있었다.
+- 실제 코드는 개별 repository 클래스 대신 `FeatureJdbcStore` 중심의 shared persistence core로 이미 구현돼 있었기 때문에, 스펙을 현 구조에 맞춰 정리할 필요가 있었다.
+
+## 무엇을 바꿨는가
+- Phase 1의 `T001~T003`을 완료로 표시했다.
+- Phase 2의 `T004~T007`을 실제 구현 의미에 맞게 재서술하고 완료로 표시했다.
+- `FeatureJdbcStore`, `FeatureStoreRepository`, `JdbcAiUsageDailyStore`, `JdbcActivityEventStore`가 스펙상의 repository 책임을 담당한다는 구현 노트를 추가했다.
+
+## 어떻게 검증했는가
+- `git diff --check`
+
+## 검증 상태
+- 문서 전용 변경이다.
+- 코드/테스트 동작에는 영향을 주지 않는다.

--- a/specs/003-spring-phase3/tasks.md
+++ b/specs/003-spring-phase3/tasks.md
@@ -5,17 +5,22 @@
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-- [ ] T001 Create `backend-spring/src/main/java/com/myway/backendspring/persistence/` package skeleton
-- [ ] T002 Add persistence dependencies and test dependencies in `backend-spring/pom.xml`
-- [ ] T003 [P] Create migration/schema bootstrap files in `backend-spring/src/main/resources/`
+- [x] T001 Create `backend-spring/src/main/java/com/myway/backendspring/persistence/` package skeleton
+- [x] T002 Add persistence dependencies and test dependencies in `backend-spring/pom.xml`
+- [x] T003 [P] Create migration/schema bootstrap files in `backend-spring/src/main/resources/`
 
 ## Phase 2: Foundational (Blocking)
 
-- [ ] T004 Implement `AiRuntimeSettingRepository` and entity mappings
-- [ ] T005 [P] Implement `MediaJobRepository` and entity mappings
-- [ ] T006 [P] Implement `TranscriptRepository` and entity mappings
-- [ ] T007 [P] Implement `ShortformExportJobRepository` and entity mappings
+- [x] T004 Implement persistent AI settings store and entity mappings
+- [x] T005 [P] Implement persistent media job store and entity mappings
+- [x] T006 [P] Implement persistent transcript store and entity mappings
+- [x] T007 [P] Implement persistent shortform export job store and entity mappings
 - [x] T008 Add optimistic versioning/idempotency guard for callbacks
+
+> Implementation note: the repository responsibilities above are realized through the shared
+> `FeatureJdbcStore` persistence core plus `FeatureStoreRepository`, `JdbcAiUsageDailyStore`,
+> and `JdbcActivityEventStore`. The codebase does not need one dedicated repository class per
+> entity to satisfy the persistence contract.
 
 ## Phase 3: User Story 1 - Persistent Media and AI State (P1)
 


### PR DESCRIPTION
## Summary
- mark the already-implemented persistence setup and foundational tasks as complete
- align the phase 2 wording with the actual shared persistence core in the codebase
- add a dev log explaining the spec-to-implementation reconciliation

## Verification
- git diff --check